### PR TITLE
ci: run live ClickHouse integration tests, bump Go to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,18 @@ jobs:
       run: docker compose up -d --wait
 
     - name: Run live tests
+      # ENABLE_CLICKHOUSE is the env-var default for the -clickhouse flag
+      # in both test packages, avoiding the gotcha that custom test flags
+      # must follow the package list.
+      #
       # Skips MaterializedView/View/Dictionary subtests of
       # TestLive_Introspection_AllStatements because they depend on source
       # tables the test harness doesn't pre-create. Tracked in
       # docs/tasks/live-introspection-mv-view-dict.md.
+      env:
+        ENABLE_CLICKHOUSE: '1'
       run: |
-        go test -v -clickhouse \
+        go test -v \
           -skip 'TestLive_Introspection_AllStatements/(MaterializedView|View|Dictionary)' \
           ./test/... ./internal/loader/hcl/...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
         cache-dependency-path: go.sum
 
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
         cache-dependency-path: go.sum
 
@@ -66,7 +66,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
         cache-dependency-path: go.sum
 
@@ -85,9 +85,8 @@ jobs:
         COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
         echo "Total test coverage: ${COVERAGE}%"
 
-  build:
+  test-live:
     runs-on: ubuntu-latest
-    needs: [lint, vet, test]
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
@@ -95,7 +94,45 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Start ClickHouse stack
+      run: docker compose up -d --wait
+
+    - name: Run live tests
+      # Skips MaterializedView/View/Dictionary subtests of
+      # TestLive_Introspection_AllStatements because they depend on source
+      # tables the test harness doesn't pre-create. Tracked in
+      # docs/tasks/live-introspection-mv-view-dict.md.
+      run: |
+        go test -v -clickhouse \
+          -skip 'TestLive_Introspection_AllStatements/(MaterializedView|View|Dictionary)' \
+          ./test/... ./internal/loader/hcl/...
+
+    - name: Dump ClickHouse logs on failure
+      if: failure()
+      run: docker compose logs --no-color clickhouse keeper
+
+    - name: Tear down ClickHouse stack
+      if: always()
+      run: docker compose down -v
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, vet, test, test-live]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.26'
         cache: true
         cache-dependency-path: go.sum
 

--- a/docs/tasks/live-introspection-mv-view-dict.md
+++ b/docs/tasks/live-introspection-mv-view-dict.md
@@ -1,0 +1,88 @@
+# Live introspection: re-enable MaterializedView, View, Dictionary subtests
+
+## Status
+
+Skipped in CI as of 2026-05-16. The `test-live` job in
+`.github/workflows/ci.yml` runs `go test -v -clickhouse` with
+`-skip 'TestLive_Introspection_AllStatements/(MaterializedView|View|Dictionary)'`.
+Other live tests run normally and pass.
+
+## Symptom
+
+Against a freshly-started ClickHouse stack
+(`docker compose up -d --wait`), the affected subtests of
+`TestLive_Introspection_AllStatements` (in
+`test/introspection_live_test.go`) fail in two shapes:
+
+- For some objects the CREATE statement errors out:
+  `code: 57, message: Table default.<name> already exists` — even on a
+  clean DB. This is the surface error reported by the SQL fixture loader.
+- For the rest the CREATE succeeds but the introspector returns nil when
+  queried back: `Expected value not to be nil. Object '<name>' should be
+  found after introspection`.
+
+Every failing subtest is an object type that **references other
+objects**:
+
+- `MaterializedView/*` — every MV in `test/testdata/posthog-create-statements/MaterializedView/`
+  references a source table named in its `SELECT ... FROM <source>`. The
+  test fixture doesn't create those sources first, so the MV either
+  fails to materialize or introspection can't resolve it back through
+  the source.
+- `View/*` — same shape (views also reference base tables).
+- `Dictionary/*` — dictionaries pull from a `SOURCE(...)`, often another
+  table. Same missing-prerequisite story.
+
+The "table already exists" variant likely comes from a previous
+sub-test in the same group having half-created an MV against a
+not-yet-created destination, leaving the destination orphan. The next
+subtest tries to create the orphan again and collides.
+
+## Root cause (working theory)
+
+`TestLive_Introspection_AllStatements` walks
+`test/testdata/posthog-create-statements/` and runs each `.sql` in
+isolation against a per-test database. For self-contained engines
+(MergeTree, Replicated*, Kafka, Distributed) the CREATE is independent
+and the introspector round-trips it cleanly. For
+`MaterializedView`/`View`/`Dictionary`, the CREATE has implicit
+dependencies on tables that live in *other* fixture files and aren't
+materialized as part of this test's setup.
+
+## Fix sketch
+
+The test harness needs to set up the dependency graph before running
+each MV/View/Dictionary subtest. Options, roughly in order of effort:
+
+1. **Pre-create dependency tables in a setup step.** Inspect each
+   failing fixture, list the source tables it needs, add a `BeforeAll`
+   that creates minimal stub versions of them in the per-test database.
+   Brittle (manual mapping) but unblocks immediately.
+2. **Group fixtures by dependency.** Run all `Tables/*` fixtures first
+   to populate the test DB, then run dependents. Requires the walker to
+   topologically order groups instead of running them in
+   `filepath.Walk` order.
+3. **Parse the `SELECT`/`SOURCE` of each fixture, auto-create stubs.**
+   The HCL package already has a SELECT-source-table extractor for MV
+   validation (`internal/loader/hcl/validate.go`). Reuse it to derive
+   the required-tables set, then synthesize minimal-shape stubs at the
+   start of each subtest.
+4. **Use a single fixture corpus that's internally consistent.** Drop
+   the per-file fixture model in favour of a curated multi-statement
+   `.sql` file that the test runs end-to-end.
+
+Option 3 is the cleanest end state; option 1 is the cheapest interim.
+
+## Acceptance criteria
+
+- Remove the `-skip` flag from the `test-live` step in
+  `.github/workflows/ci.yml`.
+- `go test -v -clickhouse ./test/... ./internal/loader/hcl/...` passes
+  with no subtests skipped against a fresh `docker compose up -d --wait`.
+- No flakes when re-run consecutively (cleanup between subtests works).
+
+## References
+
+- Failing test bodies: `test/introspection_live_test.go:324–419`.
+- Fixture corpus: `test/testdata/posthog-create-statements/{MaterializedView,View,Dictionary}/`.
+- Existing dependency parser: `internal/loader/hcl/validate.go`.

--- a/internal/loader/hcl/clickhouse_create_table_test.go
+++ b/internal/loader/hcl/clickhouse_create_table_test.go
@@ -15,6 +15,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,14 @@ import (
 // clickhouseLive enables tests that execute generated DDL against a real
 // ClickHouse instance. Mirrors the flag in test/integration_test.go — both
 // are valid in their respective test binaries, neither affects the other.
-var clickhouseLive = flag.Bool("clickhouse", false, "run tests that execute against a live ClickHouse")
+// Defaults from the ENABLE_CLICKHOUSE env var so CI can opt in without
+// the flag-ordering gotcha (custom flags must follow the package list).
+var clickhouseLive = flag.Bool("clickhouse", envBoolClickhouse(), "run tests that execute against a live ClickHouse")
+
+func envBoolClickhouse() bool {
+	v, _ := strconv.ParseBool(os.Getenv("ENABLE_CLICKHOUSE"))
+	return v
+}
 
 // createTableCase is one row of the doc-derived test table. Each case maps a
 // CREATE TABLE feature from the ClickHouse docs to a piece of HCL and the

--- a/test/integration_live_test.go
+++ b/test/integration_live_test.go
@@ -224,9 +224,7 @@ func TestEnd2End(t *testing.T) {
 			require.NoError(t, err, "Failed to introspect current state")
 			require.Len(t, state.Tables, 1)
 
-			tempDir, err := os.MkdirTemp("dump", "dumper_test")
-			require.NoError(t, err, "Failed to create temp dir")
-			// defer os.RemoveAll(tempDir)
+			tempDir := t.TempDir()
 
 			require.NoError(t, dumper.WriteYAMLFile(path.Join(tempDir, tableName+".yaml"), state.Tables[0], false))
 		})

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -14,11 +15,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// clickhouse defaults from the ENABLE_CLICKHOUSE env var so CI can opt in
+// without the custom-flag-after-packages ordering trap.
 var (
 	updateSnapshots = flag.Bool("update-snapshots", false, "update SQL snapshots")
-	clickhouse      = flag.Bool("clickhouse", false, "run ClickHouse tests")
+	clickhouse      = flag.Bool("clickhouse", envBoolClickhouse(), "run ClickHouse tests")
 	emptyState      = loader.NewDesiredState()
 )
+
+func envBoolClickhouse() bool {
+	v, _ := strconv.ParseBool(os.Getenv("ENABLE_CLICKHOUSE"))
+	return v
+}
 
 // AssertSQLDiff is a generic function that tests SQL generation by comparing desired and current states
 // and validating the generated SQL against a snapshot file.


### PR DESCRIPTION
Adds a test-live job that spins up the docker-compose ClickHouse + Keeper stack with --wait (using the existing healthcheck) and runs the live test suites in ./test/... and ./internal/loader/hcl/... with -clickhouse. The build job now also waits on test-live so we don't ship a binary that fails against a real ClickHouse.

The MaterializedView/View/Dictionary subtests of
TestLive_Introspection_AllStatements are skipped: the test fixture creates each statement in isolation but those object types reference source tables that aren't pre-materialized, so they fail with either "already exists" or "Object not found after introspection". Tracked in docs/tasks/live-introspection-mv-view-dict.md.

Also bumps go-version from 1.25 to 1.26 across every setup-go step.