### PR TITLE
ci: restore depot-ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -36,7 +36,7 @@ jobs:
         fi
 
   vet:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -58,7 +58,7 @@ jobs:
       run: go vet ./...
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -86,7 +86,7 @@ jobs:
         echo "Total test coverage: ${COVERAGE}%"
 
   test-live:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -129,7 +129,7 @@ jobs:
       run: docker compose down -v
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
     needs: [lint, vet, test, test-live]
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: depot-ubuntu-22.04
+    runs-on: depot-ubuntu-24.04
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -36,7 +36,7 @@ jobs:
         fi
 
   vet:
-    runs-on: depot-ubuntu-22.04
+    runs-on: depot-ubuntu-24.04
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -58,7 +58,7 @@ jobs:
       run: go vet ./...
 
   test:
-    runs-on: depot-ubuntu-22.04
+    runs-on: depot-ubuntu-24.04
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -86,7 +86,7 @@ jobs:
         echo "Total test coverage: ${COVERAGE}%"
 
   test-live:
-    runs-on: depot-ubuntu-22.04
+    runs-on: depot-ubuntu-24.04
     steps:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -129,7 +129,7 @@ jobs:
       run: docker compose down -v
 
   build:
-    runs-on: depot-ubuntu-22.04
+    runs-on: depot-ubuntu-24.04
     needs: [lint, vet, test, test-live]
     steps:
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -383,3 +383,4 @@ functionality on top of the `proto/`, `gen/`, or `cmd/chschema/` paths.
 ## License
 
 TBD
+


### PR DESCRIPTION
## Summary

Flips all 5 CI jobs (lint, vet, test, test-live, build) from `ubuntu-latest` back to `depot-ubuntu-22.04`.

The temporary `ubuntu-latest` (introduced in 73478dc) was a "confirm the workflow itself is healthy" step. With CI now green on GitHub-hosted runners, we should be back on Depot to stop burning GitHub-hosted minutes.

## Why this is worth a separate PR

Per [Depot's runner-types docs](https://depot.dev/docs/github-actions/runner-types) the label `depot-ubuntu-22.04` is still valid. So if this PR's CI **still fails at job provisioning**, the failure is an **org-side** problem (Depot dashboard / GitHub App link / runner group / billing) rather than the workflow.

This PR exists as a concrete failing run to point an admin at if needed.

## Test Plan

- [ ] CI run kicks off and jobs land on Depot runners
- [ ] All 5 jobs reach completion and pass (same green outcome as on ubuntu-latest)
- [ ] If they don't: capture the provisioning error and escalate to whoever owns the Depot org link

🤖 Generated with [Claude Code](https://claude.com/claude-code)