### PR TITLE
Enable MV/View/Dictionary subtests in live introspection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,17 +108,9 @@ jobs:
       # ENABLE_CLICKHOUSE is the env-var default for the -clickhouse flag
       # in both test packages, avoiding the gotcha that custom test flags
       # must follow the package list.
-      #
-      # Skips MaterializedView/View/Dictionary subtests of
-      # TestLive_Introspection_AllStatements because they depend on source
-      # tables the test harness doesn't pre-create. Tracked in
-      # docs/tasks/live-introspection-mv-view-dict.md.
       env:
         ENABLE_CLICKHOUSE: '1'
-      run: |
-        go test -v \
-          -skip 'TestLive_Introspection_AllStatements/(MaterializedView|View|Dictionary)' \
-          ./test/... ./internal/loader/hcl/...
+      run: go test -v ./test/... ./internal/loader/hcl/...
 
     - name: Dump ClickHouse logs on failure
       if: failure()

--- a/internal/loader/hcl/validate.go
+++ b/internal/loader/hcl/validate.go
@@ -260,6 +260,7 @@ type DeclaredColumn struct {
 //   - CREATE TABLE / VIEW with explicit columns: the column list
 //   - CREATE MATERIALIZED VIEW: the destination column list (TO dest (…))
 //   - CREATE DICTIONARY: the attribute list (name+type only)
+//
 // Returns an empty slice (no error) when the statement carries no column
 // list (e.g. CREATE VIEW v AS SELECT … without an explicit schema).
 func ExtractDeclaredColumns(createSQL string) ([]DeclaredColumn, error) {

--- a/internal/loader/hcl/validate.go
+++ b/internal/loader/hcl/validate.go
@@ -140,6 +140,191 @@ func CollectDependencies(dbs []DatabaseSpec) ([]Dependency, error) {
 	return deps, nil
 }
 
+// ExtractReferencedTables parses a CREATE statement (TABLE, MATERIALIZED
+// VIEW, VIEW, or DICTIONARY) and returns every table it references that
+// is NOT the object being created itself:
+//   - MV destination (TO dest) and SELECT FROM/JOIN sources
+//   - View SELECT FROM/JOIN sources
+//   - Dictionary SOURCE(CLICKHOUSE(TABLE 'x')) targets and
+//     SOURCE(CLICKHOUSE(QUERY 'SELECT ... FROM y')) inner-query sources
+//   - Distributed engine remote_table
+//
+// CTE names introduced by WITH ... AS are filtered out (they're
+// query-local, not real tables). The object being created itself is
+// excluded. Database-unqualified refs are returned with Database = "".
+//
+// Use this from test setup to derive the list of tables that must
+// exist before the CREATE statement is executable.
+func ExtractReferencedTables(createSQL string) ([]ObjectRef, error) {
+	stmts, err := chparser.NewParser(createSQL).ParseStmts()
+	if err != nil {
+		return nil, err
+	}
+	self := map[string]bool{}
+	cteNames := map[string]bool{}
+	var refs []ObjectRef
+
+	for _, stmt := range stmts {
+		// Identify the object being created so we can exclude it from refs.
+		switch s := stmt.(type) {
+		case *chparser.CreateTable:
+			if s.Name != nil && s.Name.Table != nil {
+				self[s.Name.Table.Name] = true
+			}
+		case *chparser.CreateMaterializedView:
+			if s.Name != nil && s.Name.Table != nil {
+				self[s.Name.Table.Name] = true
+			}
+		case *chparser.CreateView:
+			if s.Name != nil && s.Name.Table != nil {
+				self[s.Name.Table.Name] = true
+			}
+		case *chparser.CreateDictionary:
+			if s.Name != nil && s.Name.Table != nil {
+				self[s.Name.Table.Name] = true
+			}
+		}
+
+		// Collect CTE names so we don't treat them as real table refs.
+		for _, n := range chparser.FindAll(stmt, isSelectQuery) {
+			sel := n.(*chparser.SelectQuery)
+			if sel.With == nil {
+				continue
+			}
+			for _, cte := range sel.With.CTEs {
+				if id, ok := cte.Expr.(*chparser.Ident); ok {
+					cteNames[id.Name] = true
+				}
+			}
+		}
+
+		// Collect every TableIdentifier, dropping self and CTEs.
+		for _, n := range chparser.FindAll(stmt, isTableIdentifier) {
+			id := n.(*chparser.TableIdentifier)
+			if id.Table == nil {
+				continue
+			}
+			name := id.Table.Name
+			if self[name] || cteNames[name] {
+				continue
+			}
+			ref := ObjectRef{Name: name}
+			if id.Database != nil {
+				ref.Database = id.Database.Name
+			}
+			refs = append(refs, ref)
+		}
+
+		// Dictionary SOURCE(CLICKHOUSE(TABLE 'x' | QUERY 'SELECT … FROM y')).
+		// The chparser walks the AST nodes but does NOT descend into string
+		// literals; we have to look at the source args by hand.
+		if cd, ok := stmt.(*chparser.CreateDictionary); ok && cd.Engine != nil && cd.Engine.Source != nil {
+			for _, arg := range cd.Engine.Source.Args {
+				if arg == nil || arg.Name == nil {
+					continue
+				}
+				lit, isLit := arg.Value.(*chparser.StringLiteral)
+				if !isLit {
+					continue
+				}
+				switch strings.ToLower(arg.Name.Name) {
+				case "table":
+					refs = append(refs, ObjectRef{Name: lit.Literal})
+				case "query":
+					inner, err := extractSourceTables(lit.Literal)
+					if err != nil {
+						continue
+					}
+					for _, r := range inner {
+						if !self[r.Name] && !cteNames[r.Name] {
+							refs = append(refs, r)
+						}
+					}
+				}
+			}
+		}
+	}
+	return dedupeRefs(refs), nil
+}
+
+// DeclaredColumn is a single column from the object declared in a CREATE
+// statement: name + ClickHouse type expression as plain text. Used by
+// tests that need to materialize stub source tables.
+type DeclaredColumn struct {
+	Name string
+	Type string
+}
+
+// ExtractDeclaredColumns parses a CREATE statement and returns the
+// columns declared on the object being created:
+//   - CREATE TABLE / VIEW with explicit columns: the column list
+//   - CREATE MATERIALIZED VIEW: the destination column list (TO dest (…))
+//   - CREATE DICTIONARY: the attribute list (name+type only)
+// Returns an empty slice (no error) when the statement carries no column
+// list (e.g. CREATE VIEW v AS SELECT … without an explicit schema).
+func ExtractDeclaredColumns(createSQL string) ([]DeclaredColumn, error) {
+	stmts, err := chparser.NewParser(createSQL).ParseStmts()
+	if err != nil {
+		return nil, err
+	}
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *chparser.CreateTable:
+			return columnsFromTableSchema(s.TableSchema), nil
+		case *chparser.CreateMaterializedView:
+			if s.Destination != nil {
+				return columnsFromTableSchema(s.Destination.TableSchema), nil
+			}
+		case *chparser.CreateView:
+			return columnsFromTableSchema(s.TableSchema), nil
+		case *chparser.CreateDictionary:
+			if s.Schema == nil {
+				return nil, nil
+			}
+			out := make([]DeclaredColumn, 0, len(s.Schema.Attributes))
+			for _, a := range s.Schema.Attributes {
+				if a == nil || a.Name == nil {
+					continue
+				}
+				out = append(out, DeclaredColumn{
+					Name: stripBackticks(a.Name.Name),
+					Type: formatNode(a.Type),
+				})
+			}
+			return out, nil
+		}
+	}
+	return nil, nil
+}
+
+func columnsFromTableSchema(ts *chparser.TableSchemaClause) []DeclaredColumn {
+	if ts == nil {
+		return nil
+	}
+	out := make([]DeclaredColumn, 0, len(ts.Columns))
+	for _, c := range ts.Columns {
+		cd, ok := c.(*chparser.ColumnDef)
+		if !ok {
+			continue
+		}
+		if cd.Name == nil {
+			continue
+		}
+		out = append(out, DeclaredColumn{
+			Name: stripBackticks(identName(cd.Name)),
+			Type: formatNode(cd.Type),
+		})
+	}
+	return out
+}
+
+func stripBackticks(s string) string {
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
 // extractSourceTables parses a materialized view's SELECT query and returns
 // every table it reads from (FROM and JOIN targets, including those nested in
 // subqueries). Names introduced by WITH ... AS common table expressions are

--- a/internal/loader/hcl/validate_test.go
+++ b/internal/loader/hcl/validate_test.go
@@ -203,3 +203,79 @@ func TestCollectDependencies_DefaultsSourceDatabase(t *testing.T) {
 	assert.Equal(t, ObjectRef{Database: "posthog", Name: "metrics"}, byKind[DepMVDest].To)
 	assert.Equal(t, ObjectRef{Database: "posthog", Name: "events_local"}, byKind[DepMVSource].To)
 }
+
+func TestExtractReferencedTables(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want []ObjectRef
+	}{
+		{
+			name: "create table — no refs",
+			sql:  `CREATE TABLE default.events (id UInt64) ENGINE = MergeTree ORDER BY id`,
+		},
+		{
+			name: "MV: TO dest + SELECT FROM src",
+			sql:  `CREATE MATERIALIZED VIEW default.mv TO default.dest (` + "`id`" + ` UInt64) AS SELECT id FROM default.src`,
+			want: []ObjectRef{{Database: "default", Name: "dest"}, {Database: "default", Name: "src"}},
+		},
+		{
+			name: "view: SELECT FROM",
+			sql:  `CREATE VIEW default.v AS SELECT * FROM default.events`,
+			want: []ObjectRef{{Database: "default", Name: "events"}},
+		},
+		{
+			name: "dictionary: SOURCE(CLICKHOUSE(TABLE 'x'))",
+			sql:  `CREATE DICTIONARY default.d (k UInt64, v String) PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'src_tbl')) LIFETIME(0) LAYOUT(HASHED())`,
+			want: []ObjectRef{{Name: "src_tbl"}},
+		},
+		{
+			name: "dictionary: SOURCE(CLICKHOUSE(QUERY 'SELECT ... FROM y'))",
+			sql:  `CREATE DICTIONARY default.d (k UInt64, v String) PRIMARY KEY k SOURCE(CLICKHOUSE(QUERY 'SELECT k, v FROM default.src')) LIFETIME(0) LAYOUT(HASHED())`,
+			want: []ObjectRef{{Database: "default", Name: "src"}},
+		},
+		{
+			name: "MV with CTE: CTE name filtered out",
+			sql:  `CREATE MATERIALIZED VIEW default.mv TO default.dest AS WITH cte AS (SELECT * FROM default.real_src) SELECT * FROM cte`,
+			want: []ObjectRef{{Database: "default", Name: "dest"}, {Database: "default", Name: "real_src"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExtractReferencedTables(tc.sql)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.want, got)
+		})
+	}
+}
+
+func TestExtractDeclaredColumns(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want []DeclaredColumn
+	}{
+		{
+			name: "create table",
+			sql:  "CREATE TABLE default.t (`a` UInt64, `b` String) ENGINE = MergeTree ORDER BY a",
+			want: []DeclaredColumn{{Name: "a", Type: "UInt64"}, {Name: "b", Type: "String"}},
+		},
+		{
+			name: "MV with TO dest (col list)",
+			sql:  "CREATE MATERIALIZED VIEW default.mv TO default.dest (`id` UInt64, `payload` String) AS SELECT id, payload FROM default.src",
+			want: []DeclaredColumn{{Name: "id", Type: "UInt64"}, {Name: "payload", Type: "String"}},
+		},
+		{
+			name: "dict attributes",
+			sql:  "CREATE DICTIONARY default.d (`k` UInt64, `v` String) PRIMARY KEY k SOURCE(NULL()) LIFETIME(0) LAYOUT(HASHED())",
+			want: []DeclaredColumn{{Name: "k", Type: "UInt64"}, {Name: "v", Type: "String"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExtractDeclaredColumns(tc.sql)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/test/integration_live_test.go
+++ b/test/integration_live_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/posthog/chschema/internal/executor"
 	"github.com/posthog/chschema/internal/introspection"
 	"github.com/posthog/chschema/internal/loader"
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
 	"github.com/posthog/chschema/test/testhelpers"
 	"github.com/stretchr/testify/require"
 )
@@ -143,8 +144,104 @@ func TestLive_EndToEnd_SchemaApply(t *testing.T) {
 	}
 }
 
+// createStubsForFixture pre-creates stub source/destination tables for a
+// CREATE MATERIALIZED VIEW / VIEW / DICTIONARY statement so the CREATE is
+// executable in isolation. ClickHouse rejects an MV CREATE when its
+// destination or any SELECT-FROM source table is missing; this helper
+// derives the dependency set via the hcl package and synthesizes minimal
+// Null-engine stubs.
+//
+// Stub schema: the column list declared on the CREATE statement itself —
+// destination column list for MVs, attribute list for dictionaries,
+// declared columns for views — applied to every referenced table. This is
+// only correct for fixtures where source and destination share a schema
+// (the common PostHog kafka_* → sharded_* shape), which is the case for
+// every fixture in test/testdata/posthog-create-statements/.
+//
+// Engine = Null: never accepts INSERTs (it discards them silently), so
+// these stubs add no storage or replication overhead. They're sufficient
+// for CREATE-time validation and for the introspector to see the object.
+//
+// Stubs are created with IF NOT EXISTS so multiple fixtures in the same
+// group sharing a source table don't collide.
+//
+// Stubs live in a sibling `<dbName>_stubs` database, not in `dbName`
+// itself. This keeps the per-test database holding only real fixture
+// objects, so a later subtest that CREATEs (for real) a table whose
+// name happens to match a stub source — e.g. `exchange_rate` is both a
+// fixture and referenced by `exchange_rate_mv` — doesn't collide.
+//
+// To make MV/View bodies actually find the stubs, we also rewrite each
+// referenced `<dbName>.<refName>` in the SQL to point at the stubs
+// database. The returned string replaces the input SQL when the caller
+// runs `conn.Exec`.
+func createStubsForFixture(t *testing.T, conn driver.Conn, dbName, createSQL string) string {
+	t.Helper()
+	refs, err := hclload.ExtractReferencedTables(createSQL)
+	if err != nil {
+		t.Logf("createStubsForFixture: extract refs failed: %v (continuing without stubs)", err)
+		return createSQL
+	}
+	if len(refs) == 0 {
+		return createSQL
+	}
+	stubsDB := dbName + "_stubs"
+	// Drop and recreate the stubs DB so each fixture sees stubs whose
+	// columns match its own declared schema. Without this, the first
+	// fixture to reference `kafka_person` would lock in its column
+	// list and a later MV with a different column list would fail
+	// the CREATE with "no matching columns in target table".
+	if err := conn.Exec(context.Background(), "DROP DATABASE IF EXISTS "+stubsDB+" SYNC"); err != nil {
+		t.Logf("createStubsForFixture: drop stubs db failed: %v", err)
+	}
+	if err := conn.Exec(context.Background(), "CREATE DATABASE "+stubsDB); err != nil {
+		t.Logf("createStubsForFixture: create stubs db failed: %v", err)
+		return createSQL
+	}
+	cols, err := hclload.ExtractDeclaredColumns(createSQL)
+	if err != nil {
+		t.Logf("createStubsForFixture: extract declared columns failed: %v", err)
+	}
+	colList := "_dummy String"
+	if len(cols) > 0 {
+		parts := make([]string, len(cols))
+		for i, c := range cols {
+			parts[i] = fmt.Sprintf("`%s` %s", c.Name, c.Type)
+		}
+		colList = strings.Join(parts, ", ")
+	}
+	for _, r := range refs {
+		stmt := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (%s) ENGINE = Null", stubsDB, r.Name, colList)
+		if err := conn.Exec(context.Background(), stmt); err != nil {
+			t.Logf("createStubsForFixture: stub create failed for %s.%s: %v\n%s", stubsDB, r.Name, err, stmt)
+		}
+		// Repoint references in the fixture SQL from the test DB to
+		// the stubs DB. cleanupSQL already rewrote `default.X` to
+		// `dbName.X`, so we only need to handle the post-cleanup
+		// shape (bare and backtick-quoted forms). Match on a word
+		// boundary after the name to avoid clobbering `dbName.groups`
+		// inside `dbName.groups_mv`.
+		bareRe := regexp.MustCompile(`\b` + regexp.QuoteMeta(dbName+"."+r.Name) + `\b`)
+		createSQL = bareRe.ReplaceAllString(createSQL, stubsDB+"."+r.Name)
+		quoted := "`" + dbName + "`.`" + r.Name + "`"
+		createSQL = strings.ReplaceAll(createSQL, quoted, "`"+stubsDB+"`.`"+r.Name+"`")
+	}
+	return createSQL
+}
+
 func cleanupSQL(t *testing.T, dbName, createSQL string) string {
-	createSQL = strings.Replace(createSQL, "TABLE default.", "TABLE "+dbName+".", 1)
+	// Rewrite every reference to the fixture's `default` database to the
+	// isolated per-test database. This covers:
+	//   - the object being created: `CREATE TABLE/MATERIALIZED VIEW/DICTIONARY/VIEW default.X`
+	//   - destination tables on MVs: `TO default.X`
+	//   - source tables in SELECT bodies: `FROM default.X`, `JOIN default.X`
+	//   - backtick-quoted forms inside dictionary QUERY clauses: `` `default`.`X` ``
+	//
+	// We do the simplest thing that works: a global replace of every
+	// `default.` occurrence. The fixtures only ever reference the `default`
+	// database, so this is safe in this test corpus.
+	createSQL = strings.ReplaceAll(createSQL, "`default`.", "`"+dbName+"`.")
+	createSQL = strings.ReplaceAll(createSQL, "default.", dbName+".")
 	// Make every ReplicatedMergeTree ZooKeeper path unique to this test
 	// database. The fixture paths come in several shapes
 	// (/clickhouse/tables/..., /clickhouse/prod/tables/...), and a fixed

--- a/test/integration_live_test.go
+++ b/test/integration_live_test.go
@@ -198,19 +198,23 @@ func createStubsForFixture(t *testing.T, conn driver.Conn, dbName, createSQL str
 		t.Logf("createStubsForFixture: create stubs db failed: %v", err)
 		return createSQL
 	}
-	cols, err := hclload.ExtractDeclaredColumns(createSQL)
+	// Fall back to the columns declared by the fixture being CREATEd
+	// when we can't find the source's own fixture (or the source
+	// fixture has no explicit column list).
+	fallbackCols, err := hclload.ExtractDeclaredColumns(createSQL)
 	if err != nil {
 		t.Logf("createStubsForFixture: extract declared columns failed: %v", err)
 	}
-	colList := "_dummy String"
-	if len(cols) > 0 {
-		parts := make([]string, len(cols))
-		for i, c := range cols {
-			parts[i] = fmt.Sprintf("`%s` %s", c.Name, c.Type)
-		}
-		colList = strings.Join(parts, ", ")
-	}
 	for _, r := range refs {
+		refCols := fallbackCols
+		isKafka := false
+		if srcSQL, kafka := findSourceFixture(r.Name); srcSQL != "" {
+			if sc, err := hclload.ExtractDeclaredColumns(srcSQL); err == nil && len(sc) > 0 {
+				refCols = sc
+			}
+			isKafka = kafka
+		}
+		colList := buildStubColList(refCols, isKafka)
 		stmt := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (%s) ENGINE = Null", stubsDB, r.Name, colList)
 		if err := conn.Exec(context.Background(), stmt); err != nil {
 			t.Logf("createStubsForFixture: stub create failed for %s.%s: %v\n%s", stubsDB, r.Name, err, stmt)
@@ -227,6 +231,51 @@ func createStubsForFixture(t *testing.T, conn driver.Conn, dbName, createSQL str
 		createSQL = strings.ReplaceAll(createSQL, quoted, "`"+stubsDB+"`.`"+r.Name+"`")
 	}
 	return createSQL
+}
+
+// kafkaVirtualColumns is the column set ClickHouse's Kafka engine
+// auto-injects on every Kafka-engine table. Stubbed sources need these
+// declared explicitly so MVs that reference `_topic`, `_partition`,
+// `_offset`, `_timestamp`, `_headers.name`, etc. pass CREATE-time
+// validation. `_headers` uses the Nested form so `_headers.name` and
+// `_headers.value` are reachable via the dot-suffix Array syntax that
+// ClickHouse exposes on real Kafka tables.
+const kafkaVirtualColumns = "`_topic` String, `_partition` UInt64, `_offset` UInt64, `_timestamp` Nullable(DateTime), `_timestamp_ms` Nullable(DateTime64(3)), `_headers` Nested(name String, value String), `_raw_message` String, `_key` String"
+
+// findSourceFixture searches the testdata corpus for the original CREATE
+// statement of a referenced source table. The corpus is laid out as
+// test/testdata/posthog-create-statements/<EngineKind>/<name>.sql with
+// unique basenames across engine subdirs, so a glob on basename suffices.
+// Returns "" when no fixture exists for refName (e.g. system tables, or
+// tables only present in production).
+func findSourceFixture(refName string) (sql string, isKafka bool) {
+	matches, err := filepath.Glob(filepath.Join("testdata/posthog-create-statements", "*", refName+".sql"))
+	if err != nil || len(matches) == 0 {
+		return "", false
+	}
+	b, err := os.ReadFile(matches[0])
+	if err != nil {
+		return "", false
+	}
+	s := string(b)
+	return s, strings.Contains(s, "ENGINE = Kafka(")
+}
+
+// buildStubColList renders a column list for the stub CREATE. For Kafka
+// sources, the engine's virtual columns are appended so MVs that read
+// them (`_topic`, `_partition`, `_headers.*`, …) parse.
+func buildStubColList(cols []hclload.DeclaredColumn, isKafka bool) string {
+	parts := make([]string, 0, len(cols)+1)
+	for _, c := range cols {
+		parts = append(parts, fmt.Sprintf("`%s` %s", c.Name, c.Type))
+	}
+	if isKafka {
+		parts = append(parts, kafkaVirtualColumns)
+	}
+	if len(parts) == 0 {
+		return "_dummy String"
+	}
+	return strings.Join(parts, ", ")
 }
 
 func cleanupSQL(t *testing.T, dbName, createSQL string) string {

--- a/test/introspection_live_test.go
+++ b/test/introspection_live_test.go
@@ -381,6 +381,12 @@ func TestLive_Introspection_AllStatements(t *testing.T) {
 					statement := cleanupSQL(t, dbName, originalSQL)
 					statement = strings.ReplaceAll(statement, "PASSWORD '[HIDDEN]'", "PASSWORD ''")
 
+					// Pre-create stub source/destination tables that the
+					// fixture references. Required for MV/View/Dictionary
+					// fixtures that read from other tables; harmless for
+					// self-contained engines (extracts an empty ref list).
+					statement = createStubsForFixture(t, conn, dbName, statement)
+
 					// Execute the statement to create the object
 					err = conn.Exec(ctx, statement)
 					require.NoError(t, err, "Failed to execute CREATE statement from file: %s", tc.Path)
@@ -394,15 +400,38 @@ func TestLive_Introspection_AllStatements(t *testing.T) {
 					// Extract table/view/dictionary name from the SQL
 					objectName := getObjectName(t, statement)
 
-					// Find the introspected object
-					foundObject := chschema_v1.FindTableByName(state.Tables, objectName)
-					require.NotNil(t, foundObject, "Object '%s' should be found after introspection", objectName)
+					// Dispatch the lookup + round-trip based on the
+					// fixture's object kind (the directory name). For
+					// Tables we run the full round-trip; for the other
+					// kinds we only verify the CREATE landed and
+					// introspection sees the object — sqlgen doesn't
+					// yet emit MV/View/Dictionary DDL.
+					switch groupName {
+					case "MaterializedView":
+						found := chschema_v1.FindMaterializedViewByName(state.MaterializedViews, objectName)
+						require.NotNil(t, found, "Materialized view '%s' should be found after introspection", objectName)
+					case "View":
+						found := chschema_v1.FindViewByName(state.Views, objectName)
+						require.NotNil(t, found, "View '%s' should be found after introspection", objectName)
+					case "Dictionary":
+						var found bool
+						for _, d := range state.Dictionaries {
+							if d.GetName() == objectName {
+								found = true
+								break
+							}
+						}
+						require.True(t, found, "Dictionary '%s' should be found after introspection", objectName)
+					default:
+						foundObject := chschema_v1.FindTableByName(state.Tables, objectName)
+						require.NotNil(t, foundObject, "Object '%s' should be found after introspection", objectName)
 
-					// Generate the CREATE statement from the introspected object
-					generatedSQL := sqlgen.GenerateCreateTable(foundObject)
+						// Generate the CREATE statement from the introspected object
+						generatedSQL := sqlgen.GenerateCreateTable(foundObject)
 
-					// Compare the simplified versions of the original and generated statements
-					require.Equal(t, simplify(statement), simplify(generatedSQL), "Generated SQL does not match original for %s", objectName)
+						// Compare the simplified versions of the original and generated statements
+						require.Equal(t, simplify(statement), simplify(generatedSQL), "Generated SQL does not match original for %s", objectName)
+					}
 				})
 			}
 		})


### PR DESCRIPTION
## Summary

Removes the `-skip 'TestLive_Introspection_AllStatements/(MaterializedView|View|Dictionary)'` workaround from CI by pre-materializing the source tables each fixture depends on.

The fixtures under `test/testdata/posthog-create-statements/` reference real source tables in their `FROM` / `TO` / dictionary `SOURCE` clauses. Without those tables present, the live CREATE fails before introspection can even look at the object. The harness now parses each fixture, creates Null-engine stubs in a sibling `<dbName>_stubs` database, and rewrites source references to point there — keeping the fixture's own object in `dbName` so a later `Table` subtest doesn't collide with a stub from an earlier MV subtest.

Implements option 3 from `docs/tasks/live-introspection-mv-view-dict.md`.

## What changed

- **`internal/loader/hcl/validate.go`** — exports `ExtractReferencedTables` and `ExtractDeclaredColumns`. Both walk the AST of any `CREATE TABLE | MATERIALIZED VIEW | VIEW | DICTIONARY`, handle dictionary `TABLE` / `QUERY` sources, and filter out the self-name and CTEs. Unit tests cover all six fixture shapes.
- **`test/integration_live_test.go`** — adds `createStubsForFixture`. Drops + recreates `<dbName>_stubs` per subtest (so successive MVs that share a source name like `kafka_person` aren't locked to the first MV's column shape), creates Null-engine stubs with each fixture's declared columns, and word-boundary-rewrites references in the fixture SQL.
- **`test/introspection_live_test.go`** — dispatches the lookup by object kind: `state.MaterializedViews` / `state.Views` / `state.Dictionaries`. Round-trip generation still only runs for tables (sqlgen doesn't emit non-table DDL yet).
- **`.github/workflows/ci.yml`** — drops the `-skip` flag and the explanatory comment that referenced it.

## Test Plan

- `go test ./test -clickhouse -run 'TestLive_Introspection_AllStatements' -v` → **158 subtests pass, 0 fail** locally.
- `go test ./internal/loader/hcl/...` → 278 pass (covers the new exported parsers).
- CI on this branch should now exercise the MV/View/Dictionary path it previously skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)