### PR TITLE
fix(test): unique test database names via crypto/rand; DROP ... SYNC on cleanup

### DIFF
--- a/test/testhelpers/clickhouse.go
+++ b/test/testhelpers/clickhouse.go
@@ -2,11 +2,11 @@ package testhelpers
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
-	"strconv"
 	"sync"
 	"testing"
-	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/posthog/chschema/config"
@@ -62,24 +62,38 @@ func PingClickHouse(conn driver.Conn) error {
 	return conn.Ping(ctx)
 }
 
-// CreateTestDatabase creates a unique test database for isolation
+// CreateTestDatabase creates a uniquely-named test database and registers
+// a t.Cleanup that drops it synchronously.
+//
+// The unique suffix is 64 random bits from crypto/rand. Earlier versions
+// derived the suffix from `unsafe.Pointer(t)`, which is unreliable: Go
+// may reuse heap addresses for *testing.T after earlier tests complete,
+// so two tests that happen to land on the same address get the same
+// dbName. That manifested as intermittent "Replica /clickhouse/<db>/...
+// already exists" failures on ReplicatedMergeTree fixtures shared by
+// multiple tests (e.g. query_log_archive, sharded_events in
+// TestEnd2End vs. TestLive_Introspection_AllStatements) because their
+// ZK paths embed dbName.
+//
+// Cleanup uses DROP DATABASE ... SYNC so the database's ZooKeeper
+// metadata is released before the test returns — without SYNC,
+// ClickHouse delays the drop by `database_atomic_delay_before_drop_table_sec`
+// (default 480s), which leaves Replica entries lingering and racing
+// later tests that happen to pick a colliding name.
 func CreateTestDatabase(t *testing.T, conn driver.Conn) string {
-	dbName := fmt.Sprintf("chschema_test_%s", t.Name())
-	// Replace any invalid characters for database names
-	dbName = "chschema_test_" + strconv.FormatInt(int64(uintptr(unsafe.Pointer(t))), 36)
+	var rb [8]byte
+	if _, err := rand.Read(rb[:]); err != nil {
+		t.Fatalf("CreateTestDatabase: read random suffix: %v", err)
+	}
+	dbName := "chschema_test_" + hex.EncodeToString(rb[:])
 
 	ctx := context.Background()
-	query := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName)
-
-	err := conn.Exec(ctx, query)
-	if err != nil {
+	if err := conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName)); err != nil {
 		t.Fatalf("Failed to create test database %s: %v", dbName, err)
 	}
 
-	// Register cleanup
 	t.Cleanup(func() {
-		dropQuery := fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName)
-		_ = conn.Exec(context.Background(), dropQuery)
+		_ = conn.Exec(context.Background(), fmt.Sprintf("DROP DATABASE IF EXISTS %s SYNC", dbName))
 	})
 
 	return dbName


### PR DESCRIPTION
## Why

`test-live` has been intermittently red on `main` with errors like:

```
code: 253, message: Replica /clickhouse/chschema_test_5fo621new/tables/noshard/posthog.query_log_archive_new/replicas/ch1-01 already exists
```

Most recent occurrence: https://github.com/PostHog/chschema/actions/runs/26542192074 (post-merge run of #12).

## Root cause

`testhelpers.CreateTestDatabase` derived the dbName suffix from `unsafe.Pointer(t)`:

```go
dbName = "chschema_test_" + strconv.FormatInt(int64(uintptr(unsafe.Pointer(t))), 36)
```

Go may reuse heap addresses for `*testing.T` after earlier tests complete. When two tests in the same process happen to land on the same address, they get the same dbName. The ZooKeeper paths emitted by `cleanupSQL` are scoped on dbName — same dbName → same ZK path → "Replica already exists" on the second CREATE.

The flake hits `TestEnd2End/query_log_archive` & `TestEnd2End/sharded_events` versus `TestLive_Introspection_AllStatements/ReplicatedMergeTree/query_log_archive` & `TestLive_Introspection_AllStatements/ReplicatedReplacingMergeTree/sharded_events`. Same Replicated fixtures, two tests, occasional pointer-address collision.

## Fix

Two small changes in `test/testhelpers/clickhouse.go`:

1. **Random dbName suffix from `crypto/rand`** (64 bits, hex-encoded). Statistically unique across the lifetime of a test process — collision probability is `2^-64` per pair, so well under any practical concern.
2. **`DROP DATABASE ... SYNC`** in `t.Cleanup`. Without `SYNC`, ClickHouse delays the drop by `database_atomic_delay_before_drop_table_sec` (default 480s), which would leave Replica entries lingering and racing later tests on the (rare) chance of any future dbName reuse.

Drops the `unsafe` import along with the dead `pointer.Pointer` line.

## Verification

`go test ./test/...` with `ENABLE_CLICKHOUSE=1` against ClickHouse 26.5.1.882: **green across 3 consecutive runs** with a fresh `docker compose down -v && up`. `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
