### PR TITLE
fix(ci): correct docker/metadata-action SHA pin in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Image metadata (tags + labels)
       id: meta
-      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78c81 # v5.5.1
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
       with:
         images: 795637471508.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema
         tags: |


### PR DESCRIPTION
## Why

Every run of the new Publish workflow added in #12 has failed at "Set up job":

```
Unable to resolve action `docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78c81`,
unable to find version 8e5442c4ef9f78752691e2d8f8d19755c6f78c81
```

(Failing run: https://github.com/PostHog/chschema/actions/runs/26561272850)

## Fix

Single-character typo in the SHA pin. The real `v5.5.1` SHA ends in `…78e81`, not `…78c81`.

```diff
-uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78c81 # v5.5.1
+uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
```

Verified by resolving against the upstream:

```sh
$ gh api /repos/docker/metadata-action/commits/v5.5.1 --jq .sha
8e5442c4ef9f78752691e2d8f8d19755c6f78e81
```

Also checked every other action pin in `publish.yml` the same way — `actions/checkout`, `aws-actions/configure-aws-credentials`, `aws-actions/amazon-ecr-login`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/build-push-action` — all resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
