### PR TITLE
ci: switch publish from Docker Hub back to ECR (AWS_ECR_PUBLISH_IAM_ROLE)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
     tags: ['v*']
 
 permissions:
+  id-token: write   # required for OIDC role assumption
   contents: read
 
 jobs:
@@ -13,26 +14,33 @@ jobs:
     runs-on: depot-ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up QEMU (for arm64 cross-build)
-      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
     - name: Set up Buildx
-      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-    - name: Docker Hub login
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+    - name: Configure AWS credentials (OIDC)
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        # Org-level secret already provisioned for PostHog/posthog's image
+        # publish workflows (cd-llm-analytics-image.yml, cd-ai-evals-image.yml).
+        role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+        aws-region: us-east-1
+
+    - name: Login to Amazon ECR
+      id: aws-ecr
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
     - name: Image metadata (tags + labels)
       id: meta
       uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
       with:
-        images: posthog/chschema
+        images: ${{ steps.aws-ecr.outputs.registry }}/posthog/chschema
         tags: |
+          type=ref,event=branch
           type=sha,format=short,prefix=sha-
           type=raw,value=latest,enable={{is_default_branch}}
           type=semver,pattern={{version}}
@@ -49,8 +57,3 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-
-# TODO: mirror to ECR (795637471508.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema)
-# once the publisher IAM role is provisioned in PostHog AWS. The original
-# OIDC-based job is in the PR history of #12 — restore it as a second job
-# that re-uses the same `meta` outputs and pushes to both images.

--- a/README.md
+++ b/README.md
@@ -244,18 +244,17 @@ hclexp diff \
 shell, no AWS CLI, no extras. It's built and pushed on every `main` push
 and Git tag.
 
-- Registry: [`docker.io/posthog/chschema`](https://hub.docker.com/r/posthog/chschema)
-  (planned: a parallel mirror to PostHog's private ECR at
-  `795637471508.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema` once the
-  publisher IAM role is provisioned)
+- Registry: `<account>.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema`
+  (PostHog's private ECR; the workflow resolves the registry hostname
+  at push time from the AWS account it assumes a role into)
 - Architectures: `linux/amd64`, `linux/arm64`
 - Tags:
-  - `main` push → `sha-<short>` + `latest`
+  - `main` push → `main` + `sha-<short>` + `latest`
   - `vX.Y.Z` tag → `X.Y.Z`, `X.Y`, `X`
 
 ```sh
-# Print usage
-docker run --rm posthog/chschema:latest -help
+# Print usage (substitute the ECR hostname for your account)
+docker run --rm <account>.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema:latest -help
 
 # Introspect into a host directory
 docker run --rm \
@@ -263,7 +262,7 @@ docker run --rm \
   -e CLICKHOUSE_USER=readonly -e CLICKHOUSE_PASSWORD=secret \
   -e CLICKHOUSE_SECURE=true -e CLICKHOUSE_TLS_SKIP_VERIFY=true \
   -v "$PWD/dump:/dump" \
-  posthog/chschema:latest \
+  <account>.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema:latest \
   introspect -database posthog,system -out /dump
 ```
 


### PR DESCRIPTION
## Why

#16 landed the Docker Hub variant of the publish workflow as a temporary unblock. Turns out PostHog's `DOCKERHUB_TOKEN` doesn't carry create-repo permission for new image names under the `posthog/` namespace, so the first push to `posthog/chschema` would fail. We need ECR after all.

## What

Switches `publish.yml` back to ECR, adopting the **exact pattern PostHog/posthog uses** in [`cd-llm-analytics-image.yml`](https://github.com/PostHog/posthog/blob/master/.github/workflows/cd-llm-analytics-image.yml) and [`cd-ai-evals-image.yml`](https://github.com/PostHog/posthog/blob/master/.github/workflows/cd-ai-evals-image.yml):

- `role-to-assume` reads `${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}` — the org-level OIDC role that already trusts PostHog-org repositories. No new role provisioning needed.
- Action SHAs aligned with the reference workflow: `actions/checkout@v6.0.2`, `aws-actions/configure-aws-credentials@v6.1.0`, `aws-actions/amazon-ecr-login@v2.1.2`, `docker/setup-buildx-action@v4.0.0`, `docker/setup-qemu-action@v4.0.0`.
- Registry hostname resolved at push time via `${{ steps.aws-ecr.outputs.registry }}` rather than hardcoded — works for any AWS account the role belongs to.
- `type=ref,event=branch` added to the `docker/metadata-action` tag list so a `main` push also produces a `main` tag, matching PostHog's master-branch convention; `sha-<short>` + `latest` and semver tags still emitted as before.
- `id-token: write` permission restored for OIDC. Docker Hub `TODO` comment dropped.

README's Container image section adjusted accordingly: ECR registry hostname (resolved per-account by the workflow), `<account>.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema` as the canonical reference, `main` added to the tag list.

## Verification

- `yq` parses cleanly.
- All action SHAs resolve via `gh api /repos/<repo>/commits/<tag>`.
- This PR doesn't trigger a push (no `main`/tag push). The actual ECR publish is exercised on the post-merge run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
