### PR TITLE
ci: switch publish from ECR to GHCR (ghcr.io/posthog/chschema)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,8 @@ on:
     tags: ['v*']
 
 permissions:
-  id-token: write   # required for OIDC role assumption
   contents: read
+  packages: write   # required to push to ghcr.io
 
 jobs:
   publish:
@@ -22,23 +22,18 @@ jobs:
     - name: Set up Buildx
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-    - name: Configure AWS credentials (OIDC)
-      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+    - name: Login to ghcr.io
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
-        # Org-level secret already provisioned for PostHog/posthog's image
-        # publish workflows (cd-llm-analytics-image.yml, cd-ai-evals-image.yml).
-        role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
-        aws-region: us-east-1
-
-    - name: Login to Amazon ECR
-      id: aws-ecr
-      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Image metadata (tags + labels)
       id: meta
       uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
       with:
-        images: ${{ steps.aws-ecr.outputs.registry }}/posthog/chschema
+        images: ghcr.io/posthog/chschema
         tags: |
           type=ref,event=branch
           type=sha,format=short,prefix=sha-

--- a/README.md
+++ b/README.md
@@ -244,17 +244,17 @@ hclexp diff \
 shell, no AWS CLI, no extras. It's built and pushed on every `main` push
 and Git tag.
 
-- Registry: `<account>.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema`
-  (PostHog's private ECR; the workflow resolves the registry hostname
-  at push time from the AWS account it assumes a role into)
+- Registry: [`ghcr.io/posthog/chschema`](https://github.com/PostHog/chschema/pkgs/container/chschema)
+  (GitHub Container Registry; the chschema repo is public, so the image
+  is publicly pullable without authentication)
 - Architectures: `linux/amd64`, `linux/arm64`
 - Tags:
   - `main` push → `main` + `sha-<short>` + `latest`
   - `vX.Y.Z` tag → `X.Y.Z`, `X.Y`, `X`
 
 ```sh
-# Print usage (substitute the ECR hostname for your account)
-docker run --rm <account>.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema:latest -help
+# Print usage
+docker run --rm ghcr.io/posthog/chschema:latest -help
 
 # Introspect into a host directory
 docker run --rm \
@@ -262,7 +262,7 @@ docker run --rm \
   -e CLICKHOUSE_USER=readonly -e CLICKHOUSE_PASSWORD=secret \
   -e CLICKHOUSE_SECURE=true -e CLICKHOUSE_TLS_SKIP_VERIFY=true \
   -v "$PWD/dump:/dump" \
-  <account>.dkr.ecr.us-east-1.amazonaws.com/posthog/chschema:latest \
+  ghcr.io/posthog/chschema:latest \
   introspect -database posthog,system -out /dump
 ```
 


### PR DESCRIPTION
## Why

The ECR path landed in #17 is blocked on cloud-infra changes that I'm leaving in flight — see the still-open [PostHog/posthog-cloud-infra#8356](https://github.com/PostHog/posthog-cloud-infra/pull/8356) which provisions the repo, extends the OIDC role's `allowed_subjects`, and adds chschema to the `AWS_ECR_PUBLISH_IAM_ROLE` secret allowlist. None of that's needed if we publish to GHCR instead.

PostHog already publishes images to GHCR from the main repo (`PostHog/posthog/.github/workflows/cd-sandbox-base-image.yml`), so this isn't a new pattern.

## What

Re-targets `.github/workflows/publish.yml` from ECR to GHCR:

- Drop the AWS OIDC + ECR-login steps entirely.
- Add `docker/login-action@v4.1.0` targeting `registry: ghcr.io` with `${{ github.actor }}` / `${{ secrets.GITHUB_TOKEN }}`.
- `images: ghcr.io/posthog/chschema` (single fixed registry — no runtime resolution needed).
- `permissions`: drop `id-token: write`, add `packages: write`.

README's Container image section updated to match: `ghcr.io/posthog/chschema`, public-pull `docker run` examples (no auth needed — chschema is a public repo, so the image is publicly pullable on first push).

## Why this is the right answer

| | ECR (the currently broken path) | GHCR (this PR) |
|---|---|---|
| Infra changes | 3 Terraform edits in posthog-cloud-infra | None |
| Workflow auth | OIDC role assumption | Built-in `GITHUB_TOKEN` |
| Org secrets | `AWS_ECR_PUBLISH_IAM_ROLE` allowlist | None |
| K8s pull auth | IRSA / image pull creds | None for public images |

## Tag scheme (unchanged)

- `main` push → `main` + `sha-<short>` + `latest`
- `vX.Y.Z` tag → `X.Y.Z`, `X.Y`, `X`

## What stays open

PostHog/posthog-cloud-infra#8356 (the ECR provisioning PR) is **left open** — closing it is your call. If GHCR is the long-term answer, that PR can be closed. If you want ECR as a future mirror, leave it. I'm not touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
