### PR TITLE
chore(deps): bump chparser fork to 782c78d05142

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,4 +50,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
-replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260527212412-00b27dd39286
+replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260528112828-782c78d05142

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/orian/clickhouse-sql-parser v0.0.0-20260527212412-00b27dd39286 h1:+M3J0jogKoBUDv9wiraCgI5cHENHpwa15oa4Ncl2NB4=
-github.com/orian/clickhouse-sql-parser v0.0.0-20260527212412-00b27dd39286/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
+github.com/orian/clickhouse-sql-parser v0.0.0-20260528112828-782c78d05142 h1:26G2lPD7P74LJy4xQnKBNhtpDKkHDwv7mYuyPDwrgJM=
+github.com/orian/clickhouse-sql-parser v0.0.0-20260528112828-782c78d05142/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
 github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=


### PR DESCRIPTION
Bumps github.com/orian/clickhouse-sql-parser (refactor-visitor branch) from v0.0.0-20260527212412-00b27dd39286 to v0.0.0-20260528112828-782c78d05142. The new HEAD picks up the index-text-kwargs fix (orian/clickhouse-sql-parser#5).

go vet and ./internal/... unit tests pass with the new pin.