### PR TITLE
feat(hcl): plain views support (introspection, diff, sqlgen, validate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ state, and round-tripped against a live cluster.
 
 1. **Introspect** — connect to a live ClickHouse instance and dump its
    databases as HCL (to stdout, a file, or a directory). Round-trips
-   tables, materialized views, dictionaries, and named collections.
+   tables, materialized views, plain views, dictionaries, and named
+   collections.
 2. **Load & resolve** — read an HCL schema (a single file or a stack of
    layer directories), apply inheritance/patching, and emit the resolved,
    flat schema as canonical HCL.
 3. **Validate** — check that every cross-object reference (MV sources +
-   destination, Distributed `remote_*`) in a resolved schema is
-   satisfied, without connecting to a cluster.
+   destination, view sources, Distributed `remote_*`) in a resolved
+   schema is satisfied, without connecting to a cluster.
 4. **Diff** — compare two schemas (HCL sources or live clusters, in any
    combination) and report the changes — or the migration DDL — between
    them.
@@ -93,6 +94,7 @@ the ClickHouse SQL parser, so columns (types, defaults, codecs, comments,
 `MATERIALIZED`/`ALIAS`/`EPHEMERAL`), indexes, constraints, engine +
 parameters, `ORDER BY`, `PARTITION BY`, `SAMPLE BY`, `PRIMARY KEY`, `TTL`,
 and `SETTINGS` all come back populated. Materialized views (TO-form),
+plain views (with `column_aliases`, `sql_security`, `definer`, comment),
 dictionaries (every supported source + layout kind), and named
 collections are dumped in the same pass.
 
@@ -392,7 +394,44 @@ being silently mishandled:
 - inner-engine materialized views (`CREATE MATERIALIZED VIEW ... ENGINE = ...`)
 - refreshable materialized views (`REFRESH EVERY|AFTER ...`)
 - window views
-- plain (non-materialized) views — skipped during introspection for now
+
+### Views
+
+A `view` block declares a ClickHouse **plain** (non-materialized) view — a
+saved `SELECT` evaluated on every read of the view.
+
+```hcl
+database "posthog" {
+  view "team_event_counts" {
+    query = "SELECT team_id, count() AS n FROM posthog.events GROUP BY team_id"
+
+    column_aliases = ["team_id", "n"]
+
+    sql_security = "definer"
+    definer      = "alice"
+
+    cluster = "posthog"
+    comment = "team-level event counter"
+  }
+}
+```
+
+| Attribute        | Required | Meaning |
+|------------------|----------|---------|
+| `query`          | yes      | the `AS SELECT ...` body (verbatim text) |
+| `column_aliases` | no       | `CREATE VIEW v (a, b, ...) AS ...` |
+| `sql_security`   | no       | `SQL SECURITY` clause: `definer`, `invoker`, or `none` (canonical lowercase; case-insensitive on parse) |
+| `definer`        | no       | `DEFINER = <user>` or `DEFINER = current_user`; only valid alongside `sql_security = "definer"` |
+| `cluster`        | no       | `ON CLUSTER` target |
+| `comment`        | no       | view comment |
+
+`hclexp diff` reports a body change as in-place `ALTER TABLE ... MODIFY
+QUERY`; a comment-only change becomes `ALTER TABLE ... MODIFY COMMENT`;
+any change to `column_aliases` / `sql_security` / `definer` / `cluster`
+requires drop-and-recreate and is flagged unsafe.
+
+**Not supported.** Live views, refreshable materialized views, and window
+views fail introspection with a clear error.
 
 ### Dictionaries
 

--- a/cmd/hclexp/hclexp.go
+++ b/cmd/hclexp/hclexp.go
@@ -394,6 +394,24 @@ func renderChangeSet(w io.Writer, cs hclload.ChangeSet) {
 				fmt.Fprintf(w, "      ~ query changed\n")
 			}
 		}
+		for _, v := range dc.AddViews {
+			fmt.Fprintf(w, "  + view %s\n", v.Name)
+		}
+		for _, name := range dc.DropViews {
+			fmt.Fprintf(w, "  - view %s\n", name)
+		}
+		for _, vd := range dc.AlterViews {
+			fmt.Fprintf(w, "  ~ view %s\n", vd.Name)
+			if vd.Recreate {
+				fmt.Fprintf(w, "      ! requires recreation (column_aliases / sql_security / definer / cluster changed)\n")
+			}
+			if vd.QueryChange != nil {
+				fmt.Fprintf(w, "      ~ query changed\n")
+			}
+			if vd.Comment != nil {
+				fmt.Fprintf(w, "      ~ comment changed\n")
+			}
+		}
 		for _, d := range dc.AddDictionaries {
 			fmt.Fprintf(w, "  + dictionary %s\n", d.Name)
 		}

--- a/cmd/hclexp/hclexp_test.go
+++ b/cmd/hclexp/hclexp_test.go
@@ -232,6 +232,35 @@ func TestRenderChangeSet_MaterializedViews(t *testing.T) {
 	require.Equal(t, want, buf.String())
 }
 
+func TestRenderChangeSet_Views(t *testing.T) {
+	cs := hclload.ChangeSet{
+		Databases: []hclload.DatabaseChange{
+			{
+				Database:  "posthog",
+				AddViews:  []hclload.ViewSpec{{Name: "new_v", Query: "SELECT 1"}},
+				DropViews: []string{"old_v"},
+				AlterViews: []hclload.ViewDiff{
+					{Name: "modified_q", QueryChange: &hclload.StringChange{Old: ptrStr("SELECT 1"), New: ptrStr("SELECT 2")}},
+					{Name: "recreated", Recreate: true},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	renderChangeSet(&buf, cs)
+
+	want := `database "posthog"
+  + view new_v
+  - view old_v
+  ~ view modified_q
+      ~ query changed
+  ~ view recreated
+      ! requires recreation (column_aliases / sql_security / definer / cluster changed)
+`
+	require.Equal(t, want, buf.String())
+}
+
 // TestWriteIntrospected_DirectoryLayout locks the shape the consuming
 // chart in posthog/charts relies on: when -out is a directory, hclexp
 // writes one <db>.hcl per database under it. The aws-cli sidecar then

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -24,8 +24,8 @@ is just three layer directories passed to the loader in that order.
 ## Top-level blocks
 
 Every file declares one or more `database` blocks. Within a database, the
-allowed children are `table`, `patch_table`, and (later) `materialized_view`,
-`view`, `dictionary`.
+allowed children are `table`, `patch_table`, `materialized_view`, `view`,
+and `dictionary`.
 
 ```hcl
 database "posthog" {
@@ -197,6 +197,8 @@ Some objects can only be created after the objects they reference exist:
 
 - A **`materialized_view`** reads from a source table (named in its `query`)
   and writes into its `to_table` destination. Both must exist first.
+- A **`view`** (plain, non-materialized) reads from the source tables named
+  in its `query`. All of them must exist first.
 - A **`distributed`-engine table** forwards to the table named by
   `remote_database` / `remote_table`, which must exist first.
 
@@ -218,6 +220,44 @@ hclexp validate -config schema.hcl -skip-validation='*'
 `hclexp diff -sql` applies the same dependency knowledge to ordering: within
 the generated DDL, a table is created before any Distributed table that
 forwards to it, and dropped after it.
+
+## `view`
+
+A `view` block declares a ClickHouse **plain** (non-materialized) view — a
+saved `SELECT` that's evaluated on every read of the view.
+
+```hcl
+database "posthog" {
+  view "team_event_counts" {
+    query = "SELECT team_id, count() AS n FROM posthog.events GROUP BY team_id"
+
+    column_aliases = ["team_id", "n"]   // optional CREATE VIEW v (a, b) AS ...
+
+    sql_security = "definer"            // optional: definer | invoker | none
+    definer      = "alice"              // required iff sql_security == "definer" with a named user
+
+    cluster = "posthog"                 // optional ON CLUSTER
+    comment = "team-level event counter"
+  }
+}
+```
+
+| Attribute        | Required | Meaning |
+|------------------|----------|---------|
+| `query`          | yes      | the `AS SELECT ...` body (verbatim text) |
+| `column_aliases` | no       | `CREATE VIEW v (a, b, ...) AS ...` |
+| `sql_security`   | no       | `SQL SECURITY` clause: `definer`, `invoker`, or `none` (canonical lowercase; case-insensitive on parse) |
+| `definer`        | no       | `DEFINER = <user>` or `DEFINER = current_user`; only valid alongside `sql_security = "definer"` |
+| `cluster`        | no       | `ON CLUSTER` target |
+| `comment`        | no       | view comment |
+
+`hclexp diff` reports a body change as in-place `ALTER TABLE ... MODIFY
+QUERY`; a comment-only change becomes `ALTER TABLE ... MODIFY COMMENT`;
+any change to `column_aliases` / `sql_security` / `definer` / `cluster`
+requires drop-and-recreate and is flagged unsafe.
+
+**Not supported.** Live views, refreshable materialized views, and window
+views fail introspection with a clear error.
 
 ## TLS / secure connections
 

--- a/docs/superpowers/plans/2026-05-28-view-support.md
+++ b/docs/superpowers/plans/2026-05-28-view-support.md
@@ -1,0 +1,1773 @@
+# Plain Views Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `hclexp` round-trip plain (non-materialized) ClickHouse views end-to-end: HCL parsing, introspection, diff, sqlgen, validation, and live tests.
+
+**Architecture:** Add `ViewSpec` (sibling to `MaterializedViewSpec`) and `DatabaseSpec.Views`. Wire the new type into all six pipelines that already handle MVs: HCL decode/encode, introspect, render, diff, sqlgen, validate. Surface DEFINER + SQL SECURITY + column aliases per the spec. Body-only changes diff as `ALTER TABLE ... MODIFY QUERY`; shape changes (aliases, security, cluster) recreate via DROP + CREATE.
+
+**Tech Stack:** Go 1.26, `hashicorp/hcl/v2` (gohcl + hclwrite), `cty`, `clickhouse-sql-parser` fork (chparser), testify, ClickHouse 26.x (live tests).
+
+**Spec:** [`docs/superpowers/specs/2026-05-28-view-support.md`](../specs/2026-05-28-view-support.md)
+
+**File Map:**
+
+| File | What changes |
+|---|---|
+| `internal/loader/hcl/types.go` | New `ViewSpec`; new `DatabaseSpec.Views` field. |
+| `internal/loader/hcl/layers.go` | Cross-layer redeclare check for views (mirror MV). |
+| `internal/loader/hcl/parser.go` / `resolver.go` | Verify HCL parse passes through `view` blocks (gohcl auto-handles); add resolver pass-through. |
+| `internal/loader/hcl/dump.go` | `writeView`; emit `view "name" { … }` blocks in canonical order. |
+| `internal/loader/hcl/introspect.go` | Replace skip-view arm with `buildViewFromCreateView`; reject Live/Refresh/Window. |
+| `internal/loader/hcl/diff.go` | `ViewDiff`; `DatabaseChange.{AddViews,DropViews,AlterViews}`; `diffView`; iteration. |
+| `internal/loader/hcl/sqlgen.go` | CREATE / DROP / MODIFY QUERY / MODIFY COMMENT for views. |
+| `internal/loader/hcl/validate.go` | Iterate `db.Views`; parse query; require sources. |
+| `cmd/hclexp/hclexp.go` | Render `+/-/~ view` lines in change-set output. |
+| `docs/README.hcl.md` | New `### Views` subsection; move from "Not Yet Supported" list. |
+| `README.md` | Mention views in the introspection coverage paragraph. |
+| `CLAUDE.md` | Flip Supported Features bullet from ❌ to ✅. |
+
+---
+
+## PR — Plain views support
+
+### Task 1: ViewSpec + DatabaseSpec.Views
+
+**Files:**
+- Modify: `internal/loader/hcl/types.go`
+
+- [ ] **Step 1: Add the type and the database field**
+
+Edit `internal/loader/hcl/types.go`. After the `MaterializedViews` field on `DatabaseSpec`, add:
+
+```go
+	// Views are plain (non-materialized) views. Like MVs and dictionaries
+	// they live as a sibling collection and do not participate in the
+	// table inheritance system.
+	Views []ViewSpec `hcl:"view,block"`
+```
+
+After the `MaterializedViewSpec` type, add:
+
+```go
+// ViewSpec models a ClickHouse plain (non-materialized) view: a saved
+// SELECT executed on every read of the view. The Query is stored
+// verbatim as text. Live views, refreshable materialized views, and
+// window views are unsupported and rejected with a clear error during
+// introspection.
+//
+// SQLSecurity is the canonical lowercase form of the SQL SECURITY
+// clause: one of "definer", "invoker", or "none". Definer is the user
+// the view runs as; required iff SQLSecurity == "definer" with a
+// named user. The literal "current_user" is accepted unquoted.
+type ViewSpec struct {
+	Name           string   `hcl:"name,label"`
+	Query          string   `hcl:"query"`
+	ColumnAliases  []string `hcl:"column_aliases,optional"`
+	SQLSecurity    *string  `hcl:"sql_security,optional"`
+	Definer        *string  `hcl:"definer,optional"`
+	Cluster        *string  `hcl:"cluster,optional"`
+	Comment        *string  `hcl:"comment,optional"`
+}
+```
+
+- [ ] **Step 2: Run unit suite to confirm clean compile**
+
+```
+go build ./...
+```
+
+Expected: builds clean.
+
+```
+go test ./internal/loader/hcl/... 2>&1 | tail -5
+```
+
+Expected: all existing tests still pass (no behaviour change yet — the field is unused).
+
+- [ ] **Step 3: Commit**
+
+```
+git add internal/loader/hcl/types.go
+git commit -m "feat(hcl): ViewSpec type + DatabaseSpec.Views field
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: HCL parse validation for sql_security / definer pairing
+
+**Files:**
+- Modify: `internal/loader/hcl/resolver.go`
+- Modify: `internal/loader/hcl/resolver_test.go` (or `parser_test.go` — whichever already houses HCL parse tests; the impl picks the closer fit during step 1)
+
+- [ ] **Step 1: Find where DatabaseSpec is validated after parse**
+
+```
+grep -n "func Resolve\|validateDatabase\|MaterializedView" internal/loader/hcl/resolver.go | head -10
+```
+
+Identify the function that walks a resolved `Schema` and validates per-object invariants. If a per-MV validation function already exists, add the view validator next to it. If not, add a dedicated `validateView` function and call it from the top-level resolver walk.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to the resolver/parser test file:
+
+```go
+func TestViewSpec_DefinerRequiresSQLSecurityDefiner(t *testing.T) {
+	src := `
+database "posthog" {
+  view "v" {
+    query   = "SELECT 1"
+    definer = "alice"
+  }
+}`
+	_, err := ParseString(src)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "definer requires sql_security = \"definer\"")
+}
+
+func TestViewSpec_SQLSecurityEnumValidated(t *testing.T) {
+	src := `
+database "posthog" {
+  view "v" {
+    query        = "SELECT 1"
+    sql_security = "bogus"
+  }
+}`
+	_, err := ParseString(src)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `sql_security must be one of "definer", "invoker", "none"`)
+}
+
+func TestViewSpec_SQLSecurityCaseInsensitive(t *testing.T) {
+	src := `
+database "posthog" {
+  view "v" {
+    query        = "SELECT 1"
+    sql_security = "DEFINER"
+    definer      = "alice"
+  }
+}`
+	s, err := ParseString(src)
+	require.NoError(t, err)
+	require.Len(t, s.Databases[0].Views, 1)
+	require.Equal(t, "definer", *s.Databases[0].Views[0].SQLSecurity)
+}
+```
+
+If `ParseString` does not exist, use whichever helper the existing MV-parse tests use (e.g. `parseFromString(t, src)`).
+
+- [ ] **Step 3: Run it**
+
+```
+go test ./internal/loader/hcl -run TestViewSpec_ -v
+```
+
+Expected: all three FAIL (validation not implemented; SQL_security comes back as `"DEFINER"` not normalised; or no error at all).
+
+- [ ] **Step 4: Implement the validator**
+
+Add to `internal/loader/hcl/resolver.go`:
+
+```go
+// validateView normalises and validates a parsed ViewSpec. The HCL
+// surface is more permissive than ClickHouse semantics; this catches
+// schema mistakes at parse time rather than at apply.
+func validateView(v *ViewSpec) error {
+	if v.SQLSecurity != nil {
+		canonical := strings.ToLower(strings.TrimSpace(*v.SQLSecurity))
+		switch canonical {
+		case "definer", "invoker", "none":
+			v.SQLSecurity = &canonical
+		default:
+			return fmt.Errorf(`view %q: sql_security must be one of "definer", "invoker", "none"`, v.Name)
+		}
+	}
+	if v.Definer != nil {
+		if v.SQLSecurity == nil || *v.SQLSecurity != "definer" {
+			return fmt.Errorf(`view %q: definer requires sql_security = "definer"`, v.Name)
+		}
+	}
+	return nil
+}
+```
+
+Then call it from the function that walks `Schema.Databases`. Locate that function by searching:
+
+```
+grep -n "for .* range .*Databases\|range db.MaterializedViews" internal/loader/hcl/resolver.go | head -5
+```
+
+In the same per-database loop, add (immediately after MV validation, or right at the start of the per-DB validation work):
+
+```go
+		for i := range db.Views {
+			if err := validateView(&db.Views[i]); err != nil {
+				return nil, err
+			}
+		}
+```
+
+If `strings`, `fmt` are not already imported in the file, add them.
+
+- [ ] **Step 5: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestViewSpec_ -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full HCL unit suite**
+
+```
+go test ./internal/loader/hcl/...
+```
+
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/loader/hcl/resolver.go internal/loader/hcl/resolver_test.go
+git commit -m "feat(hcl): validate view sql_security enum + definer pairing
+
+sql_security must be lowercase one of definer|invoker|none (case-
+insensitive on parse). definer is only legal alongside sql_security
+= \"definer\".
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Cross-layer redeclare check for views
+
+**Files:**
+- Modify: `internal/loader/hcl/layers.go`
+- Modify: `internal/loader/hcl/layers_test.go`
+
+- [ ] **Step 1: Find the MV redeclare check**
+
+```
+grep -n "materialized_view %q redeclared" internal/loader/hcl/layers.go
+```
+
+Read the surrounding loop. The same pattern needs to apply to views.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `internal/loader/hcl/layers_test.go`:
+
+```go
+func TestMergeLayers_ViewRedeclareAcrossLayers(t *testing.T) {
+	layerA := writeLayer(t, "a", map[string]string{
+		"schema.hcl": `database "posthog" { view "v" { query = "SELECT 1" } }`,
+	})
+	layerB := writeLayer(t, "b", map[string]string{
+		"schema.hcl": `database "posthog" { view "v" { query = "SELECT 2" } }`,
+	})
+
+	_, err := LoadLayers([]string{layerA, layerB})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `view "v" redeclared across layers`)
+}
+```
+
+(`writeLayer` is already a helper in `layers_test.go`; reuse it.)
+
+- [ ] **Step 3: Run the test**
+
+```
+go test ./internal/loader/hcl -run TestMergeLayers_ViewRedeclareAcrossLayers -v
+```
+
+Expected: FAIL — second layer's view replaces the first without an error.
+
+- [ ] **Step 4: Add the redeclare check**
+
+In `internal/loader/hcl/layers.go`, find the loop that runs the MV redeclare check. Right after it, in the same per-database loop, add:
+
+```go
+		for _, v := range src.Views {
+			if existing := findView(dst.Views, v.Name); existing != nil {
+				return fmt.Errorf("view %q redeclared across layers", v.Name)
+			}
+			dst.Views = append(dst.Views, v)
+		}
+```
+
+And add the helper next to `findMaterializedView` (or whichever sibling already exists):
+
+```go
+func findView(views []ViewSpec, name string) *ViewSpec {
+	for i := range views {
+		if views[i].Name == name {
+			return &views[i]
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestMergeLayers_ViewRedeclareAcrossLayers -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/loader/hcl/layers.go internal/loader/hcl/layers_test.go
+git commit -m "feat(hcl): reject cross-layer view redeclaration
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Canonical HCL emission for view blocks
+
+**Files:**
+- Modify: `internal/loader/hcl/dump.go`
+- Modify: `internal/loader/hcl/dump_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/loader/hcl/dump_test.go`:
+
+```go
+func TestDumpSchema_RendersViewBlocks(t *testing.T) {
+	s := &Schema{
+		Databases: []DatabaseSpec{{
+			Name: "posthog",
+			Views: []ViewSpec{{
+				Name:          "metrics",
+				Query:         "SELECT team_id, count() AS n FROM events GROUP BY team_id",
+				ColumnAliases: []string{"team_id", "n"},
+				SQLSecurity:   ptr("definer"),
+				Definer:       ptr("alice"),
+				Comment:       ptr("team-level event counter"),
+			}},
+		}},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, Write(&buf, s))
+
+	got := buf.String()
+	require.Contains(t, got, `view "metrics" {`)
+	require.Contains(t, got, `query`)
+	require.Contains(t, got, `column_aliases = ["team_id", "n"]`)
+	require.Contains(t, got, `sql_security = "definer"`)
+	require.Contains(t, got, `definer = "alice"`)
+	require.Contains(t, got, `comment = "team-level event counter"`)
+}
+
+func ptr[T any](v T) *T { return &v }
+```
+
+If `dump_test.go` already declares `ptr`, drop the helper from this test.
+
+- [ ] **Step 2: Run it**
+
+```
+go test ./internal/loader/hcl -run TestDumpSchema_RendersViewBlocks -v
+```
+
+Expected: FAIL (`view "metrics" {` not in output).
+
+- [ ] **Step 3: Add the emitter**
+
+In `internal/loader/hcl/dump.go`, locate the per-database emission loop (the section that emits MVs after tables and dictionaries after MVs — search for `mvs := append([]MaterializedViewSpec`). Right after the dictionaries loop (or in canonical position: tables → MVs → views → dicts; impl picks the ordering at write time, but the spec says tables → MVs → views → dicts), add:
+
+```go
+	views := append([]ViewSpec(nil), db.Views...)
+	sort.Slice(views, func(i, j int) bool { return views[i].Name < views[j].Name })
+	for i, v := range views {
+		if len(tables) > 0 || len(mvs) > 0 || i > 0 {
+			body.AppendNewline()
+		}
+		vBlock := body.AppendNewBlock("view", []string{v.Name})
+		writeView(vBlock.Body(), v)
+	}
+```
+
+(Move the `dicts := …` block to come after this so the canonical order is tables → MVs → views → dicts. If it's already after `mvs`, drop it below `views` instead.)
+
+Add the new `writeView` next to `writeMaterializedView`:
+
+```go
+func writeView(body *hclwrite.Body, v ViewSpec) {
+	body.SetAttributeValue("query", cty.StringVal(v.Query))
+	if len(v.ColumnAliases) > 0 {
+		body.SetAttributeValue("column_aliases", stringList(v.ColumnAliases))
+	}
+	if v.SQLSecurity != nil {
+		body.SetAttributeValue("sql_security", cty.StringVal(*v.SQLSecurity))
+	}
+	if v.Definer != nil {
+		body.SetAttributeValue("definer", cty.StringVal(*v.Definer))
+	}
+	if v.Cluster != nil {
+		body.SetAttributeValue("cluster", cty.StringVal(*v.Cluster))
+	}
+	if v.Comment != nil {
+		body.SetAttributeValue("comment", cty.StringVal(*v.Comment))
+	}
+}
+```
+
+- [ ] **Step 4: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestDumpSchema_RendersViewBlocks -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add internal/loader/hcl/dump.go internal/loader/hcl/dump_test.go
+git commit -m "feat(hcl): canonical view block emission
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Introspect plain views
+
+**Files:**
+- Modify: `internal/loader/hcl/introspect.go`
+- Modify: `internal/loader/hcl/introspect_test.go`
+
+- [ ] **Step 1: Inspect the chparser CreateView shape**
+
+```
+grep -rn "CreateView struct\|type CreateView" vendor/github.com/orian/clickhouse-sql-parser/parser 2>/dev/null || go doc github.com/AfterShip/clickhouse-sql-parser/parser CreateView 2>&1 | head -40
+```
+
+Read the AST fields — specifically: how is the SELECT body exposed? Is there a `Materialized bool` / `Refresh` / window-view flag? Is there a `Comment`, `OnCluster`, `Definer`, `SQLSecurity`, or column-alias field?
+
+Make notes; the next steps reference these fields. If the AST does NOT expose `Definer` / `SQLSecurity` (the fork is from older AfterShip code), use `formatNode(stmt)` and regex-extract those clauses from the formatted output as a fallback — but only after confirming the AST gap; the visitor refactor branch may already model them. If neither AST nor format-regex works for a particular field, stop and surface the gap to the user before continuing.
+
+- [ ] **Step 2: Write the failing test for the happy path**
+
+Add to `internal/loader/hcl/introspect_test.go`:
+
+```go
+func TestProcessIntrospectRows_PlainView(t *testing.T) {
+	rows := &fakeRowScanner{
+		data: [][]any{
+			{"v_simple", "CREATE VIEW posthog.v_simple AS SELECT team_id FROM posthog.events"},
+		},
+	}
+	db := &DatabaseSpec{Name: "posthog"}
+	require.NoError(t, processIntrospectRows(db, "posthog", rows))
+	require.Empty(t, db.Tables)
+	require.Empty(t, db.MaterializedViews)
+	require.Len(t, db.Views, 1)
+	require.Equal(t, "v_simple", db.Views[0].Name)
+	require.Equal(t, "SELECT team_id FROM posthog.events", db.Views[0].Query)
+}
+
+func TestProcessIntrospectRows_ViewWithColumnAliasesAndComment(t *testing.T) {
+	rows := &fakeRowScanner{
+		data: [][]any{
+			{"v_aliased", "CREATE VIEW posthog.v_aliased (team_id, n) AS SELECT team_id, count() AS c FROM posthog.events GROUP BY team_id COMMENT 'aliased view'"},
+		},
+	}
+	db := &DatabaseSpec{Name: "posthog"}
+	require.NoError(t, processIntrospectRows(db, "posthog", rows))
+	require.Len(t, db.Views, 1)
+	require.Equal(t, []string{"team_id", "n"}, db.Views[0].ColumnAliases)
+	require.NotNil(t, db.Views[0].Comment)
+	require.Equal(t, "aliased view", *db.Views[0].Comment)
+}
+
+func TestProcessIntrospectRows_ViewWithSQLSecurityDefiner(t *testing.T) {
+	rows := &fakeRowScanner{
+		data: [][]any{
+			{"v_sec", "CREATE VIEW posthog.v_sec DEFINER = alice SQL SECURITY DEFINER AS SELECT 1"},
+		},
+	}
+	db := &DatabaseSpec{Name: "posthog"}
+	require.NoError(t, processIntrospectRows(db, "posthog", rows))
+	require.Len(t, db.Views, 1)
+	require.NotNil(t, db.Views[0].SQLSecurity)
+	require.Equal(t, "definer", *db.Views[0].SQLSecurity)
+	require.NotNil(t, db.Views[0].Definer)
+	require.Equal(t, "alice", *db.Views[0].Definer)
+}
+```
+
+`fakeRowScanner` should already be defined in the test file for the existing introspect tests. If it isn't, search:
+
+```
+grep -n "type fakeRowScanner\|rowScanner" internal/loader/hcl/introspect_test.go
+```
+
+Reuse the existing fake.
+
+- [ ] **Step 3: Run the tests**
+
+```
+go test ./internal/loader/hcl -run TestProcessIntrospectRows_ -v
+```
+
+Expected: the three new tests FAIL — `db.Views` empty, fields not set.
+
+- [ ] **Step 4: Replace the skip-view case**
+
+In `internal/loader/hcl/introspect.go`, replace the existing CreateView arm:
+
+```go
+		case *chparser.CreateView:
+			// Plain (non-materialized) views are out of scope; skip them
+			// rather than failing the whole introspection.
+			continue
+```
+
+with:
+
+```go
+		case *chparser.CreateView:
+			v, err := buildViewFromCreateView(s)
+			if err != nil {
+				return fmt.Errorf("introspect view %s.%s: %w", database, name, err)
+			}
+			v.Name = name
+			db.Views = append(db.Views, v)
+```
+
+- [ ] **Step 5: Implement `buildViewFromCreateView`**
+
+In `internal/loader/hcl/introspect.go`, near `buildMaterializedViewFromCreateMV`, add:
+
+```go
+// buildViewFromCreateView walks a parsed CREATE VIEW AST and produces a
+// ViewSpec. Live views, refreshable views, and window views are
+// rejected with named errors. The SELECT body is rendered back to
+// text via formatNode (PrintVisitor), matching the way MV bodies are
+// captured.
+func buildViewFromCreateView(cv *chparser.CreateView) (ViewSpec, error) {
+	// Reject unsupported shapes. The exact AST fields depend on the
+	// chparser version; check whichever fields the AST exposes for
+	// Refreshable / Live / Window views. If the parser cannot distinguish
+	// these from a plain view, the upstream Create call will have
+	// landed in a different AST type, so this is a defence-in-depth
+	// check, not the primary gate.
+	if cv.Refresh != nil {
+		return ViewSpec{}, errors.New("unsupported: refreshable materialized view in CREATE VIEW arm")
+	}
+	if cv.Engine != nil {
+		return ViewSpec{}, errors.New("unsupported: live view (CREATE LIVE VIEW or VIEW with ENGINE)")
+	}
+	// chparser as of orian/refactor-visitor does not separately model
+	// window views — they parse as plain CREATE VIEW with a WATERMARK
+	// clause embedded in the SELECT. We let those round-trip as
+	// opaque text; the WATERMARK keyword inside the query is preserved
+	// verbatim.
+
+	v := ViewSpec{}
+
+	if cv.SubQuery != nil {
+		v.Query = strings.TrimSpace(formatNode(cv.SubQuery))
+	}
+
+	if cv.OnCluster != nil && cv.OnCluster.Expr != nil {
+		v.Cluster = strPtr(formatNode(cv.OnCluster.Expr))
+	}
+
+	if cv.Comment != nil {
+		v.Comment = strPtr(unquoteString(cv.Comment.Literal))
+	}
+
+	// Column alias list. ClickHouse's CREATE VIEW v (a, b, c) AS … —
+	// the AST exposes the list as cv.TableSchema or cv.Aliases
+	// depending on chparser version. Walk whichever is non-nil. If
+	// none exists in the version we ship, this branch is dead code
+	// and aliases stay nil (which round-trips fine: no aliases is the
+	// no-op canonical form).
+	if cv.TableSchema != nil {
+		for _, c := range cv.TableSchema.Columns {
+			cd, ok := c.(*chparser.ColumnDef)
+			if !ok {
+				continue
+			}
+			if cd.Name == nil {
+				continue
+			}
+			v.ColumnAliases = append(v.ColumnAliases, stripBackticks(identName(cd.Name)))
+		}
+	}
+
+	// SQL SECURITY + DEFINER. Mirror the canonical lowercase rule
+	// validated at HCL parse time. If chparser exposes these on cv
+	// directly, use them; otherwise fall back to regex-extracting from
+	// the formatted CREATE statement.
+	if cv.SQLSecurity != nil {
+		s := strings.ToLower(strings.TrimSpace(formatNode(cv.SQLSecurity)))
+		v.SQLSecurity = &s
+	}
+	if cv.Definer != nil {
+		d := formatNode(cv.Definer)
+		v.Definer = &d
+	}
+
+	return v, nil
+}
+```
+
+Note: the field names `cv.Refresh`, `cv.Engine`, `cv.SubQuery`, `cv.OnCluster`, `cv.Comment`, `cv.TableSchema`, `cv.SQLSecurity`, `cv.Definer` are the **assumed** names — verify against the actual chparser AST in Step 1. If a field is named differently (e.g. `cv.Select` instead of `cv.SubQuery`), use the actual name. If a clause is not modelled at all by the AST (most likely candidates: Definer / SQLSecurity), regex-extract them from the formatted statement:
+
+```go
+// Fallback for chparser versions that don't model DEFINER / SQL SECURITY.
+formatted := formatNode(cv)
+if m := regexp.MustCompile(`(?i)DEFINER\s*=\s*([A-Za-z_][A-Za-z0-9_]*|CURRENT_USER)`).FindStringSubmatch(formatted); m != nil {
+    d := m[1]
+    v.Definer = &d
+}
+if m := regexp.MustCompile(`(?i)SQL\s+SECURITY\s+(DEFINER|INVOKER|NONE)`).FindStringSubmatch(formatted); m != nil {
+    s := strings.ToLower(m[1])
+    v.SQLSecurity = &s
+}
+```
+
+Use only one path (AST or regex) per field. If you fall back to regex, leave a comment referencing this paragraph.
+
+- [ ] **Step 6: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestProcessIntrospectRows_ -v
+```
+
+Expected: all three PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/loader/hcl/introspect.go internal/loader/hcl/introspect_test.go
+git commit -m "feat(hcl): introspect plain views
+
+Replaces the silent skip arm in processIntrospectRows with a real
+ViewSpec builder. Captures Query (verbatim), ColumnAliases, Cluster,
+Comment, SQLSecurity, and Definer. Refreshable / live shapes rejected
+with named errors.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Diff types and per-view diff
+
+**Files:**
+- Modify: `internal/loader/hcl/diff.go`
+- Modify: `internal/loader/hcl/diff_test.go`
+
+- [ ] **Step 1: Extend DatabaseChange and add ViewDiff**
+
+In `internal/loader/hcl/diff.go`, extend `DatabaseChange` (right after the MV/dict fields):
+
+```go
+	AddViews   []ViewSpec
+	DropViews  []string
+	AlterViews []ViewDiff
+```
+
+Then add the new type next to `MaterializedViewDiff`:
+
+```go
+// ViewDiff is the set of mutations to a single existing plain view. A
+// query-only change is applied in place via ALTER TABLE ... MODIFY
+// QUERY. A comment-only change is applied via ALTER TABLE ... MODIFY
+// COMMENT. Any change to ColumnAliases / SQLSecurity / Definer /
+// Cluster requires recreating the view (DROP + CREATE) and is flagged
+// unsafe.
+type ViewDiff struct {
+	Name        string
+	QueryChange *StringChange
+	Comment     *StringChange
+	Recreate    bool
+}
+
+func (vd ViewDiff) IsEmpty() bool {
+	return vd.QueryChange == nil && vd.Comment == nil && !vd.Recreate
+}
+
+func (vd ViewDiff) IsUnsafe() bool { return vd.Recreate }
+```
+
+Extend `DatabaseChange.IsEmpty()` to also check view slices:
+
+```go
+		len(dc.AddViews) == 0 && len(dc.DropViews) == 0 &&
+		len(dc.AlterViews) == 0 &&
+```
+
+(Place this between the MV and dict checks. Match the existing line-wrap style.)
+
+- [ ] **Step 2: Write the failing diff tests**
+
+Add to `internal/loader/hcl/diff_test.go`:
+
+```go
+func mkView(name, query string) ViewSpec {
+	return ViewSpec{Name: name, Query: query}
+}
+
+func TestDiff_ViewAddDrop(t *testing.T) {
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{mkView("v_old", "SELECT 1")}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{mkView("v_new", "SELECT 2")}}}}
+	cs := Diff(from, to)
+	require.False(t, cs.IsEmpty())
+	require.Len(t, cs.Databases, 1)
+	dc := cs.Databases[0]
+	require.Equal(t, []string{"v_old"}, dc.DropViews)
+	require.Len(t, dc.AddViews, 1)
+	require.Equal(t, "v_new", dc.AddViews[0].Name)
+}
+
+func TestDiff_ViewQueryOnlyChange(t *testing.T) {
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{mkView("v", "SELECT 1")}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{mkView("v", "SELECT 2")}}}}
+	cs := Diff(from, to)
+	require.Len(t, cs.Databases[0].AlterViews, 1)
+	vd := cs.Databases[0].AlterViews[0]
+	require.NotNil(t, vd.QueryChange)
+	require.False(t, vd.Recreate)
+	require.Nil(t, vd.Comment)
+}
+
+func TestDiff_ViewCommentOnlyChange(t *testing.T) {
+	vFrom := mkView("v", "SELECT 1")
+	vFrom.Comment = ptrStr("old")
+	vTo := mkView("v", "SELECT 1")
+	vTo.Comment = ptrStr("new")
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{vFrom}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{vTo}}}}
+	cs := Diff(from, to)
+	vd := cs.Databases[0].AlterViews[0]
+	require.Nil(t, vd.QueryChange)
+	require.NotNil(t, vd.Comment)
+	require.False(t, vd.Recreate)
+}
+
+func TestDiff_ViewShapeChangeForcesRecreate(t *testing.T) {
+	vFrom := mkView("v", "SELECT 1")
+	vFrom.ColumnAliases = []string{"a"}
+	vTo := mkView("v", "SELECT 1")
+	vTo.ColumnAliases = []string{"a", "b"}
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{vFrom}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{vTo}}}}
+	cs := Diff(from, to)
+	vd := cs.Databases[0].AlterViews[0]
+	require.True(t, vd.Recreate)
+	require.True(t, vd.IsUnsafe())
+}
+
+func TestDiff_IdenticalViewsEmpty(t *testing.T) {
+	v := mkView("v", "SELECT 1")
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{v}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{v}}}}
+	require.True(t, Diff(from, to).IsEmpty())
+}
+```
+
+If `ptrStr` is not already in `diff_test.go`, add a local helper `ptrStr := func(s string) *string { return &s }` at the top of the test or use an existing one.
+
+- [ ] **Step 3: Run the tests**
+
+```
+go test ./internal/loader/hcl -run TestDiff_View -v
+```
+
+Expected: FAIL — diff doesn't process the new field.
+
+- [ ] **Step 4: Implement the view diff iteration**
+
+In `internal/loader/hcl/diff.go`, locate `diffDatabase`. Find where it iterates MVs (`for _, mv := range to.MaterializedViews { … }`). Right after that loop (and before the dictionaries iteration), add:
+
+```go
+	// --- Views (plain) ---
+	fromViews := indexViews(from.Views)
+	toViews := indexViews(to.Views)
+	for _, v := range to.Views {
+		if existing, ok := fromViews[v.Name]; ok {
+			vd := diffView(existing, v)
+			if !vd.IsEmpty() {
+				dc.AlterViews = append(dc.AlterViews, vd)
+			}
+		} else {
+			dc.AddViews = append(dc.AddViews, v)
+		}
+	}
+	for _, v := range from.Views {
+		if _, ok := toViews[v.Name]; !ok {
+			dc.DropViews = append(dc.DropViews, v.Name)
+		}
+	}
+```
+
+Add the helpers next to the existing `indexMaterializedViews` / `diffMaterializedView`:
+
+```go
+func indexViews(views []ViewSpec) map[string]ViewSpec {
+	m := make(map[string]ViewSpec, len(views))
+	for _, v := range views {
+		m[v.Name] = v
+	}
+	return m
+}
+
+// diffView compares two views with the same name. Query and Comment
+// can be modified in place; ColumnAliases, SQLSecurity, Definer, and
+// Cluster changes require DROP + CREATE.
+func diffView(from, to ViewSpec) ViewDiff {
+	vd := ViewDiff{Name: to.Name}
+	if from.Query != to.Query {
+		vd.QueryChange = &StringChange{Old: strPtrOrNil(from.Query), New: strPtrOrNil(to.Query)}
+	}
+	if !strPtrEq(from.Comment, to.Comment) {
+		vd.Comment = &StringChange{Old: from.Comment, New: to.Comment}
+	}
+	if !stringSliceEqual(from.ColumnAliases, to.ColumnAliases) ||
+		!strPtrEq(from.SQLSecurity, to.SQLSecurity) ||
+		!strPtrEq(from.Definer, to.Definer) ||
+		!strPtrEq(from.Cluster, to.Cluster) {
+		vd.Recreate = true
+	}
+	return vd
+}
+
+// strPtrOrNil wraps a string in a pointer; empty becomes nil so the
+// StringChange convention (nil = unset) holds even when one side is
+// the zero value.
+func strPtrOrNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+```
+
+If `strPtrEq` or `stringSliceEqual` aren't already in `diff.go` (search to confirm), add them:
+
+```go
+func strPtrEq(a, b *string) bool {
+	if a == nil && b == nil { return true }
+	if a == nil || b == nil { return false }
+	return *a == *b
+}
+```
+
+(For `stringSliceEqual` the same one used elsewhere in the package — search for existing definition before adding.)
+
+Also: in the `Diff()` top level (where each side is empty), make sure `AddViews` is populated when the from-database is empty. Find the `dc = DatabaseChange{...}` literal that already populates `AddTables` / `AddMaterializedViews` / `AddDictionaries` for new databases, and add `AddViews: append([]ViewSpec(nil), t.Views...)`.
+
+- [ ] **Step 5: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestDiff_View -v
+```
+
+Expected: PASS.
+
+```
+go test ./internal/loader/hcl
+```
+
+Expected: all green (existing tests still pass).
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/loader/hcl/diff.go internal/loader/hcl/diff_test.go
+git commit -m "feat(hcl): diff plain views
+
+AddViews / DropViews / AlterViews on DatabaseChange. Query-only and
+comment-only changes diff in place; ColumnAliases / SQLSecurity /
+Definer / Cluster changes force Recreate (DROP + CREATE).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: SQL generation for views
+
+**Files:**
+- Modify: `internal/loader/hcl/sqlgen.go`
+- Modify: `internal/loader/hcl/sqlgen_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/loader/hcl/sqlgen_test.go`:
+
+```go
+func TestSQLGen_CreateView_Bare(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddViews: []ViewSpec{{Name: "v", Query: "SELECT 1"}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Contains(t, got, `CREATE VIEW posthog.v AS SELECT 1`)
+}
+
+func TestSQLGen_CreateView_FullForm(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddViews: []ViewSpec{{
+			Name:          "v",
+			Query:         "SELECT team_id, count() AS n FROM events GROUP BY team_id",
+			ColumnAliases: []string{"team_id", "n"},
+			SQLSecurity:   ptrStr("definer"),
+			Definer:       ptrStr("alice"),
+			Cluster:       ptrStr("posthog"),
+			Comment:       ptrStr("team-level"),
+		}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Contains(t, got, `CREATE VIEW posthog.v ON CLUSTER posthog (team_id, n) DEFINER = alice SQL SECURITY DEFINER AS SELECT team_id, count() AS n FROM events GROUP BY team_id COMMENT 'team-level'`)
+}
+
+func TestSQLGen_DropView(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database:  "posthog",
+		DropViews: []string{"old_v"},
+	}}}
+	got := GenerateSQL(cs)
+	require.Contains(t, got, `DROP VIEW IF EXISTS posthog.old_v`)
+}
+
+func TestSQLGen_AlterView_ModifyQuery(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AlterViews: []ViewDiff{{
+			Name:        "v",
+			QueryChange: &StringChange{Old: ptrStr("SELECT 1"), New: ptrStr("SELECT 2")},
+		}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Contains(t, got, `ALTER TABLE posthog.v MODIFY QUERY SELECT 2`)
+}
+
+func TestSQLGen_AlterView_ModifyComment(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AlterViews: []ViewDiff{{
+			Name:    "v",
+			Comment: &StringChange{Old: ptrStr("old"), New: ptrStr("new")},
+		}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Contains(t, got, `ALTER TABLE posthog.v MODIFY COMMENT 'new'`)
+}
+
+func TestSQLGen_AlterView_Recreate(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AlterViews: []ViewDiff{{
+			Name:     "v",
+			Recreate: true,
+		}},
+		// Also surface the post-recreate view shape via AddViews — this
+		// matches the MV recreate convention.
+		AddViews: []ViewSpec{{Name: "v", Query: "SELECT 2"}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Contains(t, got, `DROP VIEW IF EXISTS posthog.v`)
+	require.Contains(t, got, `CREATE VIEW posthog.v AS SELECT 2`)
+}
+```
+
+If `ptrStr` is already defined in the file, drop the helper from the tests above.
+
+- [ ] **Step 2: Run them**
+
+```
+go test ./internal/loader/hcl -run TestSQLGen_(CreateView|DropView|AlterView) -v
+```
+
+Expected: all FAIL — no view DDL.
+
+- [ ] **Step 3: Implement the emitters**
+
+In `internal/loader/hcl/sqlgen.go`, locate the function that drives per-database DDL emission (search `AddMaterializedViews` for the call site). After the MV emission (in the order: drop dependent objects → drop tables → create tables → create MVs → create views → create dicts; mirror the MV ordering), add a view block.
+
+```go
+	for _, name := range dc.DropViews {
+		fmt.Fprintf(&buf, "DROP VIEW IF EXISTS %s.%s;\n", dc.Database, name)
+	}
+	for _, vd := range dc.AlterViews {
+		if vd.Recreate {
+			fmt.Fprintf(&buf, "DROP VIEW IF EXISTS %s.%s;\n", dc.Database, vd.Name)
+			// The post-recreate CREATE is in AddViews — emitted below.
+			continue
+		}
+		if vd.QueryChange != nil && vd.QueryChange.New != nil {
+			fmt.Fprintf(&buf, "ALTER TABLE %s.%s MODIFY QUERY %s;\n", dc.Database, vd.Name, *vd.QueryChange.New)
+		}
+		if vd.Comment != nil && vd.Comment.New != nil {
+			fmt.Fprintf(&buf, "ALTER TABLE %s.%s MODIFY COMMENT %s;\n", dc.Database, vd.Name, quoteString(*vd.Comment.New))
+		}
+	}
+	for _, v := range dc.AddViews {
+		fmt.Fprintf(&buf, "%s;\n", renderCreateView(dc.Database, v))
+	}
+```
+
+Add the helper:
+
+```go
+// renderCreateView emits the full CREATE VIEW statement for a ViewSpec.
+// Field order matches the ClickHouse grammar:
+//   CREATE VIEW [ON CLUSTER ...] db.name [(aliases)]
+//     [DEFINER = ...] [SQL SECURITY ...]
+//     AS <query>
+//     [COMMENT '...']
+func renderCreateView(database string, v ViewSpec) string {
+	var sb strings.Builder
+	sb.WriteString("CREATE VIEW ")
+	sb.WriteString(database)
+	sb.WriteByte('.')
+	sb.WriteString(v.Name)
+	if v.Cluster != nil {
+		sb.WriteString(" ON CLUSTER ")
+		sb.WriteString(*v.Cluster)
+	}
+	if len(v.ColumnAliases) > 0 {
+		sb.WriteString(" (")
+		sb.WriteString(strings.Join(v.ColumnAliases, ", "))
+		sb.WriteByte(')')
+	}
+	if v.Definer != nil {
+		sb.WriteString(" DEFINER = ")
+		sb.WriteString(*v.Definer)
+	}
+	if v.SQLSecurity != nil {
+		sb.WriteString(" SQL SECURITY ")
+		sb.WriteString(strings.ToUpper(*v.SQLSecurity))
+	}
+	sb.WriteString(" AS ")
+	sb.WriteString(v.Query)
+	if v.Comment != nil {
+		sb.WriteString(" COMMENT ")
+		sb.WriteString(quoteString(*v.Comment))
+	}
+	return sb.String()
+}
+```
+
+If `quoteString` doesn't exist yet, search the file for whatever helper escapes ClickHouse single-quoted strings — it's used by MV / dict emission. Reuse it.
+
+- [ ] **Step 4: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestSQLGen_(CreateView|DropView|AlterView) -v
+```
+
+Expected: all PASS.
+
+```
+go test ./internal/loader/hcl
+```
+
+Expected: full suite green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add internal/loader/hcl/sqlgen.go internal/loader/hcl/sqlgen_test.go
+git commit -m "feat(hcl): emit CREATE/DROP/ALTER DDL for plain views
+
+Body-only changes use ALTER TABLE ... MODIFY QUERY; comment-only use
+ALTER TABLE ... MODIFY COMMENT; shape changes (aliases / security /
+cluster) recreate via DROP + CREATE.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Validate view dependencies
+
+**Files:**
+- Modify: `internal/loader/hcl/validate.go`
+- Modify: `internal/loader/hcl/validate_test.go`
+
+- [ ] **Step 1: Find the existing MV validation walk**
+
+```
+grep -n "for _, mv := range db.MaterializedViews\|materialized_view %s:" internal/loader/hcl/validate.go
+```
+
+Note the surrounding code shape — particularly how it builds the declared-objects set and how it formats the "undeclared reference" error.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `internal/loader/hcl/validate_test.go`:
+
+```go
+func TestValidate_ViewSourceTableMustExist(t *testing.T) {
+	s := &Schema{
+		Databases: []DatabaseSpec{{
+			Name: "posthog",
+			Tables: []TableSpec{
+				{Name: "events", Columns: []ColumnSpec{{Name: "team_id", Type: "Int64"}}, Engine: &EngineSpec{Kind: "merge_tree"}, OrderBy: []string{"team_id"}},
+			},
+			Views: []ViewSpec{
+				// References a nonexistent source.
+				{Name: "v", Query: "SELECT team_id FROM posthog.nonexistent"},
+			},
+		}},
+	}
+	err := Validate(s, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `view "v" references undeclared table posthog.nonexistent`)
+}
+
+func TestValidate_ViewSourceTableInSameSchema(t *testing.T) {
+	s := &Schema{
+		Databases: []DatabaseSpec{{
+			Name: "posthog",
+			Tables: []TableSpec{
+				{Name: "events", Columns: []ColumnSpec{{Name: "team_id", Type: "Int64"}}, Engine: &EngineSpec{Kind: "merge_tree"}, OrderBy: []string{"team_id"}},
+			},
+			Views: []ViewSpec{
+				{Name: "v", Query: "SELECT team_id FROM posthog.events"},
+			},
+		}},
+	}
+	require.NoError(t, Validate(s, nil))
+}
+
+func TestValidate_ViewSkipByName(t *testing.T) {
+	s := &Schema{
+		Databases: []DatabaseSpec{{
+			Name: "posthog",
+			Views: []ViewSpec{{Name: "v", Query: "SELECT 1 FROM posthog.missing"}},
+		}},
+	}
+	require.NoError(t, Validate(s, []string{"v"}))
+}
+
+func TestValidate_ViewCTENameNotASource(t *testing.T) {
+	s := &Schema{
+		Databases: []DatabaseSpec{{
+			Name: "posthog",
+			Tables: []TableSpec{
+				{Name: "events", Columns: []ColumnSpec{{Name: "team_id", Type: "Int64"}}, Engine: &EngineSpec{Kind: "merge_tree"}, OrderBy: []string{"team_id"}},
+			},
+			Views: []ViewSpec{
+				{Name: "v", Query: "WITH stats AS (SELECT team_id FROM posthog.events) SELECT * FROM stats"},
+			},
+		}},
+	}
+	require.NoError(t, Validate(s, nil))
+}
+```
+
+If `Validate`'s signature is different (e.g. it takes the skip list as a `map[string]bool` or no second argument at all), adjust the test calls to match. Check:
+
+```
+grep -n "^func Validate" internal/loader/hcl/validate.go
+```
+
+- [ ] **Step 3: Run the tests**
+
+```
+go test ./internal/loader/hcl -run TestValidate_View -v
+```
+
+Expected: FAIL — views aren't walked.
+
+- [ ] **Step 4: Add the view walk**
+
+In `internal/loader/hcl/validate.go`, find the MV iteration. Immediately after it (still inside the per-database loop), add:
+
+```go
+		// Views: same dependency contract as MVs — every table named
+		// in the SELECT body must be declared somewhere in the loaded
+		// schema. CTE names are filtered out by ExtractReferencedTables.
+		for _, v := range db.Views {
+			if skip[v.Name] {
+				continue
+			}
+			refs, err := ExtractReferencedTables(stitchCreateView(db.Name, v))
+			if err != nil {
+				return fmt.Errorf("view %q: parsing query: %w", v.Name, err)
+			}
+			for _, r := range refs {
+				dbName := r.Database
+				if dbName == "" {
+					dbName = db.Name
+				}
+				if !declared[dbName+"."+r.Name] {
+					return fmt.Errorf(`view "%s" references undeclared table %s.%s`, v.Name, dbName, r.Name)
+				}
+			}
+		}
+```
+
+Add the helper:
+
+```go
+// stitchCreateView builds a minimal CREATE VIEW statement around a
+// ViewSpec's Query so ExtractReferencedTables can parse it as a single
+// AST. The reconstructed statement does not need to match the exact
+// production statement — only its FROM/JOIN structure matters.
+func stitchCreateView(database string, v ViewSpec) string {
+	return fmt.Sprintf("CREATE VIEW %s.%s AS %s", database, v.Name, v.Query)
+}
+```
+
+The `declared` set and `skip` map are already maintained in the surrounding function for tables / MVs / dicts. Reuse the same names — if they have different names locally (e.g. `existsByQName`, `skipSet`), substitute appropriately.
+
+- [ ] **Step 5: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestValidate_View -v
+```
+
+Expected: all four PASS.
+
+```
+go test ./internal/loader/hcl
+```
+
+Expected: full suite green.
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/loader/hcl/validate.go internal/loader/hcl/validate_test.go
+git commit -m "feat(hcl): validate plain view source dependencies
+
+A view's SELECT must reference only declared tables / MVs / views.
+CTE names are filtered out by ExtractReferencedTables. The existing
+-skip-validation=<name,...> flag honours view names.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Diff ordering — views are created after sources, dropped before
+
+**Files:**
+- Modify: `internal/loader/hcl/sqlgen.go` (or wherever the change-set ordering lives — likely in sqlgen)
+- Modify: `internal/loader/hcl/sqlgen_test.go`
+
+- [ ] **Step 1: Find the existing MV ordering**
+
+```
+grep -n "ordering\|topo\|DependsOn\|MaterializedView" internal/loader/hcl/sqlgen.go | head -10
+```
+
+Read whichever function/section currently orders DDL so MVs land after their source tables.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `internal/loader/hcl/sqlgen_test.go`:
+
+```go
+func TestSQLGen_ViewCreatedAfterSourceTable(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddTables: []TableSpec{
+			{Name: "events", Columns: []ColumnSpec{{Name: "team_id", Type: "Int64"}}, Engine: &EngineSpec{Kind: "merge_tree"}, OrderBy: []string{"team_id"}},
+		},
+		AddViews: []ViewSpec{
+			{Name: "v", Query: "SELECT team_id FROM posthog.events"},
+		},
+	}}}
+	got := GenerateSQL(cs)
+	tIdx := strings.Index(got, "CREATE TABLE posthog.events")
+	vIdx := strings.Index(got, "CREATE VIEW posthog.v")
+	require.GreaterOrEqual(t, tIdx, 0)
+	require.GreaterOrEqual(t, vIdx, 0)
+	require.Less(t, tIdx, vIdx, "view must be created after its source table")
+}
+
+func TestSQLGen_ViewDroppedBeforeSourceTable(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		DropTables: []TableSpec{
+			{Name: "events", Columns: []ColumnSpec{{Name: "team_id", Type: "Int64"}}, Engine: &EngineSpec{Kind: "merge_tree"}, OrderBy: []string{"team_id"}},
+		},
+		DropViews: []string{"v"},
+	}}}
+	// Note: in real use DropViews comes from a diff that already knows
+	// what the dropped view referenced. The test here checks the
+	// ordering rule independently — view drops must come before any
+	// table drop that could be a source.
+	got := GenerateSQL(cs)
+	vIdx := strings.Index(got, "DROP VIEW IF EXISTS posthog.v")
+	tIdx := strings.Index(got, "DROP TABLE")
+	require.GreaterOrEqual(t, vIdx, 0)
+	require.GreaterOrEqual(t, tIdx, 0)
+	require.Less(t, vIdx, tIdx, "view must be dropped before its source table")
+}
+```
+
+- [ ] **Step 3: Run them**
+
+```
+go test ./internal/loader/hcl -run TestSQLGen_View(Created|Dropped) -v
+```
+
+Expected: depends on current ordering. If the existing CREATE order is "tables → MVs → views", the create test may already pass. If the DROP order is "MVs → views → tables", the drop test may already pass. Run and see — fix only what's broken.
+
+- [ ] **Step 4: Adjust ordering if needed**
+
+If either test fails, edit the per-database emission order in `sqlgen.go`. The canonical order (matching the spec):
+
+```
+DROP VIEW (views)
+DROP MATERIALIZED VIEW
+DROP DICTIONARY
+DROP TABLE
+CREATE TABLE
+CREATE MATERIALIZED VIEW
+CREATE VIEW
+CREATE DICTIONARY
+ALTER ... (in-place modifies)
+```
+
+If a refactor is needed, move the view-related write blocks (added in Task 7) above the MV blocks for DROPs and below them for CREATEs. The exact line edit depends on the current sqlgen.go shape.
+
+- [ ] **Step 5: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestSQLGen_View
+```
+
+Expected: PASS.
+
+```
+go test ./internal/loader/hcl
+```
+
+Expected: full suite green.
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/loader/hcl/sqlgen.go internal/loader/hcl/sqlgen_test.go
+git commit -m "feat(hcl): order view DDL after source tables on CREATE, before on DROP
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Render change-set output for views
+
+**Files:**
+- Modify: `cmd/hclexp/hclexp.go`
+- Modify: `cmd/hclexp/hclexp_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cmd/hclexp/hclexp_test.go`:
+
+```go
+func TestRenderChangeSet_Views(t *testing.T) {
+	cs := hclload.ChangeSet{
+		Databases: []hclload.DatabaseChange{
+			{
+				Database:   "posthog",
+				AddViews:   []hclload.ViewSpec{{Name: "new_v"}},
+				DropViews:  []string{"old_v"},
+				AlterViews: []hclload.ViewDiff{
+					{Name: "modified_q", QueryChange: &hclload.StringChange{Old: ptrStr("SELECT 1"), New: ptrStr("SELECT 2")}},
+					{Name: "recreated", Recreate: true},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	renderChangeSet(&buf, cs)
+
+	want := `database "posthog"
+  + view new_v
+  - view old_v
+  ~ view modified_q
+      ~ query changed
+  ~ view recreated
+      ! requires recreation (column_aliases / sql_security / definer / cluster changed)
+`
+	require.Equal(t, want, buf.String())
+}
+```
+
+- [ ] **Step 2: Run it**
+
+```
+go test ./cmd/hclexp -run TestRenderChangeSet_Views -v
+```
+
+Expected: FAIL — `renderChangeSet` doesn't know about views.
+
+- [ ] **Step 3: Extend renderChangeSet**
+
+In `cmd/hclexp/hclexp.go`, find the existing materialized-view rendering block:
+
+```
+grep -n "AddMaterializedViews\|materialized_view %s ->" cmd/hclexp/hclexp.go
+```
+
+Right after that block (still inside the per-database loop in `renderChangeSet`), add:
+
+```go
+		for _, v := range dc.AddViews {
+			fmt.Fprintf(w, "  + view %s\n", v.Name)
+		}
+		for _, name := range dc.DropViews {
+			fmt.Fprintf(w, "  - view %s\n", name)
+		}
+		for _, vd := range dc.AlterViews {
+			fmt.Fprintf(w, "  ~ view %s\n", vd.Name)
+			if vd.Recreate {
+				fmt.Fprintf(w, "      ! requires recreation (column_aliases / sql_security / definer / cluster changed)\n")
+			}
+			if vd.QueryChange != nil {
+				fmt.Fprintf(w, "      ~ query changed\n")
+			}
+			if vd.Comment != nil {
+				fmt.Fprintf(w, "      ~ comment changed\n")
+			}
+		}
+```
+
+- [ ] **Step 4: Re-run**
+
+```
+go test ./cmd/hclexp -run TestRenderChangeSet_Views -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run all CLI tests**
+
+```
+go test ./cmd/hclexp
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```
+git add cmd/hclexp/hclexp.go cmd/hclexp/hclexp_test.go
+git commit -m "feat(hclexp): render +/-/~ view lines in change-set output
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Live introspection test for views
+
+**Files:**
+- Modify: `test/introspection_live_test.go` (the `View` arm of the dispatch added by PR #11)
+- Modify: `test/testdata/posthog-create-statements/View/*.sql` if needed (verify a few fixtures exist)
+
+- [ ] **Step 1: Verify view fixtures exist**
+
+```
+ls test/testdata/posthog-create-statements/View/ 2>&1 | head -10
+```
+
+Expected: at least a handful of `.sql` fixtures (PR #11 enabled the directory; PostHog's 17 views should already be there in some form). If the directory is empty or sparse, copy 2-3 simple `CREATE VIEW` fixtures from the production dump produced earlier — the cleaner ones, no exotic clauses. Put one bare view, one with `column_aliases`, one with `SQL SECURITY DEFINER`.
+
+- [ ] **Step 2: Inspect the current View arm**
+
+```
+grep -n "groupName == \"View\"\|case \"View\"" test/introspection_live_test.go
+```
+
+PR #11 enabled the lookup (`chschema_v1.FindViewByName(state.Views, objectName)`) but didn't round-trip generated DDL. We don't yet emit MV/View DDL via `sqlgen.GenerateCreateTable`, so we keep the assertion to "introspection sees the view" — that's the minimum we can validate.
+
+- [ ] **Step 3: Strengthen the View case to also assert ViewSpec fields**
+
+Find the existing `case "View":` switch arm. Replace with:
+
+```go
+				case "View":
+					// Find the view in the introspected DatabaseSpec (the
+					// hcl-loader pathway, not the legacy protobuf state)
+					// to assert the new ViewSpec fields. This complements
+					// the legacy chschema_v1 lookup above by exercising
+					// the new code path.
+					hclState, err := hclload.Introspect(ctx, conn, dbName)
+					require.NoError(t, err, "hcl introspect for View assertion")
+					var v *hclload.ViewSpec
+					for i := range hclState.Views {
+						if hclState.Views[i].Name == objectName {
+							v = &hclState.Views[i]
+							break
+						}
+					}
+					require.NotNil(t, v, "view %q should be in hcl introspection result", objectName)
+					require.NotEmpty(t, v.Query, "view query must be captured")
+
+					// Also keep the legacy protobuf-state lookup the
+					// existing PR #11 code put in place.
+					found := chschema_v1.FindViewByName(state.Views, objectName)
+					require.NotNil(t, found, "View '%s' should be found after introspection", objectName)
+```
+
+If the existing arm only has the `chschema_v1.FindViewByName` lookup (i.e. PR #11 didn't add the hcl side yet), wrap both checks as shown above.
+
+- [ ] **Step 4: Run the live tests**
+
+Start the docker compose ClickHouse if not running:
+
+```
+docker compose up -d --wait
+```
+
+Then:
+
+```
+ENABLE_CLICKHOUSE=1 go test ./test -run 'TestLive_Introspection_AllStatements/View' -v 2>&1 | tail -20
+```
+
+Expected: every View subtest PASSes (or skip-list-entries skip cleanly if any fixture hits a parser gap; that should be visible from the warn output during the View processing arm of the dispatch — but views don't go through the createStubsForFixture path).
+
+- [ ] **Step 5: Commit**
+
+```
+git add test/introspection_live_test.go
+git commit -m "test(live): assert hcl ViewSpec captured by introspection
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Docs
+
+**Files:**
+- Modify: `docs/README.hcl.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+Find the "Not Yet Supported" line that says:
+> ❌ `view` and `dictionary` top-level blocks — planned, not implemented
+
+In CLAUDE.md, edit to remove `view` from that list (dictionaries are already done; we're removing the other half here too). Move views into the supported features list:
+
+Find the bullet list of supported HCL features. After the materialized_view entry, add:
+
+```markdown
+- ✅ `view` blocks (plain non-materialized views): `query`, optional
+  `column_aliases`, `sql_security` (definer | invoker | none),
+  `definer`, `cluster`, `comment`
+```
+
+Also update the "Not Yet Supported" section by removing the `view` entry and leaving any remaining ones (Refreshable MV etc.) intact.
+
+- [ ] **Step 2: Update docs/README.hcl.md**
+
+Find the section structure heading:
+
+```
+grep -n "^### Materialized views\|^### Dictionaries\|^### Views" docs/README.hcl.md
+```
+
+If a `### Views` heading doesn't exist, add it immediately after `### Materialized views` and before `### Dictionaries`:
+
+```markdown
+### Views
+
+A `view` block declares a ClickHouse **plain** (non-materialized) view —
+a saved `SELECT` that's evaluated on every read of the view, returning
+freshly-computed rows without persisted storage.
+
+```hcl
+database "posthog" {
+  view "team_event_counts" {
+    query = "SELECT team_id, count() AS n FROM posthog.events GROUP BY team_id"
+
+    column_aliases = ["team_id", "n"]
+
+    sql_security = "definer"
+    definer      = "alice"
+
+    cluster = "posthog"
+    comment = "team-level event counter"
+  }
+}
+```
+
+| Attribute        | Required | Meaning |
+|------------------|----------|---------|
+| `query`          | yes      | the `AS SELECT ...` body |
+| `column_aliases` | no       | `CREATE VIEW v (a, b, ...) AS ...` |
+| `sql_security`   | no       | `SQL SECURITY` clause: `definer`, `invoker`, or `none` (canonical lowercase; case-insensitive on parse) |
+| `definer`        | no       | `DEFINER = <user>` or `DEFINER = current_user`; only valid alongside `sql_security = "definer"` |
+| `cluster`        | no       | `ON CLUSTER` target |
+| `comment`        | no       | view comment |
+
+`hclexp diff` reports a body change as in-place `ALTER TABLE ...
+MODIFY QUERY`; a comment-only change becomes `ALTER TABLE ... MODIFY
+COMMENT`; any change to `column_aliases` / `sql_security` / `definer`
+/ `cluster` requires drop-and-recreate and is flagged unsafe.
+
+**Not supported.** Live views, refreshable materialized views, and
+window views fail introspection with a clear error.
+```
+
+- [ ] **Step 3: Update README.md**
+
+Find the introspection coverage paragraph (search "Materialized views (TO-form), dictionaries"):
+
+```
+grep -n "Materialized views (TO-form)" README.md
+```
+
+Update it to also mention views:
+
+```diff
+- Materialized views (TO-form), dictionaries (every supported source +
+- layout kind), and named collections are dumped in the same pass.
++ Materialized views (TO-form), plain views, dictionaries (every
++ supported source + layout kind), and named collections are dumped
++ in the same pass.
+```
+
+In the same file, find the four-mode listing at the top (the "What hclexp does" block):
+
+```
+grep -n "Materialized views" README.md | head -3
+```
+
+Make sure the four-mode listing already mentions "plain views" as well — if it only says "materialized views", expand to "plain views and materialized views".
+
+- [ ] **Step 4: Commit**
+
+```
+git add CLAUDE.md docs/README.hcl.md README.md
+git commit -m "docs: view block reference + supported-features update
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Re-dump production schema to verify
+
+**Files:**
+- (no source changes; dump artifact only)
+
+- [ ] **Step 1: Build hclexp**
+
+```
+go build -o /tmp/hclexp ./cmd/hclexp
+```
+
+Expected: builds clean.
+
+- [ ] **Step 2: Dump the local CH posthog database**
+
+```
+/tmp/hclexp introspect -host localhost -port 9000 -user default -password "" -database posthog -out /tmp/posthog-with-views.hcl 2>&1 | tail -10
+```
+
+Expected: zero ERROR lines from view processing. WARN lines for the three known-broken objects (`adhoc_events_deletion`, `property_values`, `sharded_distinct_id_usage`) only — same as before.
+
+- [ ] **Step 3: Confirm view count**
+
+```
+awk '/^database/ {db++} /^  view/ {v++} END {print "databases:"db, "views:"v}' /tmp/posthog-with-views.hcl
+```
+
+Expected: `databases:1 views:17` (all 17 PostHog views captured).
+
+- [ ] **Step 4: Spot-check a few**
+
+```
+grep -A6 '^  view "custom_metrics"' /tmp/posthog-with-views.hcl | head -10
+```
+
+Expected: a `view "custom_metrics" {` block with a `query = ...` attribute. No DEFINER / SQL SECURITY for the PostHog views (we already established none use those).
+
+- [ ] **Step 5: Save the verification dump alongside the previous one**
+
+```
+cp /tmp/posthog-with-views.hcl dumps/posthog-schema.hcl
+git add dumps/posthog-schema.hcl
+```
+
+- [ ] **Step 6: Commit (only if `dumps/` is git-tracked; otherwise add to `.gitignore` instead)**
+
+```
+git status dumps/ 2>&1
+```
+
+If `dumps/` is untracked and there's already a `.gitignore` rule covering it, skip the commit. If not, run:
+
+```
+git commit -m "chore: refresh production schema dump after view support
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: PR verification + push
+
+- [ ] **Step 1: Run the full test suite**
+
+```
+go test ./internal/... ./config ./cmd/... ./test/... 2>&1 | tail -15
+```
+
+Expected: all green.
+
+```
+gofmt -s -l .
+```
+
+Expected: empty (no files need reformatting).
+
+```
+go vet ./...
+```
+
+Expected: no issues.
+
+- [ ] **Step 2: Confirm hclexp help still works**
+
+```
+go build -o /tmp/hclexp ./cmd/hclexp && /tmp/hclexp diff -h 2>&1 | head -10
+```
+
+Expected: usage text intact.
+
+- [ ] **Step 3: Push the branch**
+
+```
+git push -u origin HEAD
+```
+
+- [ ] **Step 4: STOP — pause for human PR creation/review**
+
+Open the PR via `gh pr create` (or the GitHub UI). The PR body should call out:
+- Feature scope (views with full DEFINER / SQL SECURITY / column aliases per the design spec).
+- Live verification on PostHog production schema: 17/17 views round-trip.
+- One open item: parameterized views round-trip as opaque text (the parameter syntax is preserved verbatim inside the query body; no typed surfacing in HCL).

--- a/docs/superpowers/specs/2026-05-28-view-support.md
+++ b/docs/superpowers/specs/2026-05-28-view-support.md
@@ -1,0 +1,206 @@
+# Plain Views Support in hclexp — Design Spec
+
+**Date:** 2026-05-28
+**Status:** Approved, ready for implementation
+**Reference docs:** `clickhouse-docs/en/sql-reference/statements/create/view.md` (Normal View section, lines 18–58, and SQL security section, lines 115–157)
+
+## Motivation
+
+Introspecting PostHog's production schema with `hclexp introspect` silently skips 17 plain (non-materialized) views. They round-trip nowhere — diff can't enforce their existence, sqlgen can't recreate them, validate can't check their dependencies. Closing this gap is the precondition for using `hclexp` as a complete schema source-of-truth for PostHog deployments.
+
+## Surface (HCL)
+
+A new `view` block inside `database`, sibling to `table`, `materialized_view`, and `dictionary`.
+
+```hcl
+database "posthog" {
+  view "custom_metrics" {
+    query = "SELECT team_id, count() AS n FROM events GROUP BY team_id"
+
+    column_aliases = ["team_id", "n"]   // optional
+
+    sql_security = "definer"            // optional: definer | invoker | none
+    definer      = "alice"              // optional; must accompany sql_security="definer"
+                                        // with a named user; "current_user" allowed
+
+    cluster = "posthog"                 // optional ON CLUSTER target
+    comment = "team-level event counter" // optional
+  }
+}
+```
+
+Field-by-field:
+
+| HCL attribute    | Go type     | Mapped to                                                                                |
+| ---------------- | ----------- | ---------------------------------------------------------------------------------------- |
+| `name` (label)   | `string`    | `[db.]name` of the view                                                                   |
+| `query`          | `string`    | `AS SELECT ...` body (verbatim text)                                                      |
+| `column_aliases` | `[]string`  | `CREATE VIEW v (a, b, …) AS …`                                                            |
+| `sql_security`   | `*string`   | `SQL SECURITY { DEFINER \| INVOKER \| NONE }`. Lowercase only; validate at parse time.   |
+| `definer`        | `*string`   | `DEFINER = …`. Allowed values: any identifier (resolved as user) or literal `current_user`. |
+| `cluster`        | `*string`   | `ON CLUSTER`                                                                              |
+| `comment`        | `*string`   | `COMMENT '...'`                                                                           |
+
+### Validation at HCL parse time
+- `definer != nil` requires `sql_security != nil && *sql_security == "definer"`. Otherwise reject.
+- `sql_security` must be one of `"definer" | "invoker" | "none"` (case-insensitive on parse, lowercase canonical).
+
+### Out of scope (rejected during introspection with a clear error)
+- Live View
+- Refreshable Materialized View
+- Window View
+- Parameterized View (introspection passes through as a normal view since the parameter syntax is inside the SELECT body, but we don't model the parameter list explicitly; round-trip still works because the body is stored verbatim)
+
+`DatabaseSpec` gains `Views []ViewSpec`. Does **not** participate in `extend` / `abstract` / `patch_table` inheritance — same as `MaterializedViews` and `Dictionaries`.
+
+## Architecture
+
+Six packages touched, each in one consistent slice:
+
+1. **`internal/loader/hcl/types.go`** — new `ViewSpec`, new `DatabaseSpec.Views` field.
+2. **`internal/loader/hcl/introspect.go`** — replace the existing skip-view arm with `buildViewFromCreateView`. Reject Live/Refreshable/Window with named errors.
+3. **`internal/loader/hcl/render.go`** (or the existing canonical-HCL writer) — emit `view "name" { … }` blocks.
+4. **`internal/loader/hcl/diff.go`** — new `ViewChange` / `ViewDiff` types; populate `DatabaseChange.{Add,Drop,Alter}Views`.
+5. **`internal/loader/hcl/sqlgen.go`** — emit `CREATE VIEW` / `DROP VIEW` / `ALTER TABLE … MODIFY QUERY` / `ALTER TABLE … MODIFY COMMENT`. Honour view-after-source ordering.
+6. **`internal/loader/hcl/validate.go`** — extend the existing loop that walks materialized views: iterate `db.Views`, call `ExtractReferencedTables` on each `query`, fail on undeclared refs. Honour the existing `-skip-validation=<name,…>` flag (views join the same set).
+
+Plus `cmd/hclexp/hclexp.go` — render `+ view`, `- view`, `~ view` lines in the change-set printout.
+
+## Diff semantics
+
+| What changed                                                | Action                                                             |
+| ----------------------------------------------------------- | ------------------------------------------------------------------ |
+| `query` only                                                | `ALTER TABLE db.name [ON CLUSTER c] MODIFY QUERY <new>`            |
+| `comment` only                                              | `ALTER TABLE db.name [ON CLUSTER c] MODIFY COMMENT '<new>'`        |
+| `column_aliases` / `sql_security` / `definer` / `cluster`   | `Recreate = true` → `DROP VIEW` + `CREATE VIEW` (no in-place form) |
+| Added view                                                  | `CREATE VIEW …`                                                    |
+| Dropped view                                                | `DROP VIEW [IF EXISTS] db.name [ON CLUSTER c]`                     |
+
+`ViewDiff` shape (mirrors `MaterializedViewDiff`):
+
+```go
+type ViewDiff struct {
+    Name        string
+    QueryChange *StringChange
+    Comment     *StringChange
+    Recreate    bool   // true → DROP + CREATE
+}
+
+type DatabaseChange struct {
+    // …existing fields…
+    AddViews    []ViewSpec
+    DropViews   []string
+    AlterViews  []ViewDiff
+}
+```
+
+## Validation
+
+Extend `validate.go`'s existing dependency walk. For each `ViewSpec`:
+
+1. Parse `view.Query` with `hclload.ExtractReferencedTables` (already handles `*chparser.CreateView` — added in PR #11; the helper filters CTE names).
+2. For each `ObjectRef`, check the referenced table / MV / view is declared in the loaded schema (cross-database refs are looked up by the explicit DB part of the ref).
+3. On miss: `validate: view <name> references undeclared table <db.table>`.
+4. `-skip-validation=<view_name,…>` skips by name.
+5. `hclexp diff -sql` extends its ordering knowledge to views: created after every source, dropped before.
+
+## Round-trip ordering rules
+
+The canonical HCL writer emits, per database:
+```
+table … { }
+materialized_view … { }
+view … { }
+dictionary … { }
+```
+Within each block, fields are written in a fixed order (named in the field-by-field table above). This keeps `hclexp introspect` deterministic across runs.
+
+## Introspection: AST walk details
+
+```go
+case *chparser.CreateView:
+    v, err := buildViewFromCreateView(s)
+    if err != nil { return fmt.Errorf("introspect view %s.%s: %w", database, name, err) }
+    v.Name = name
+    db.Views = append(db.Views, v)
+```
+
+`buildViewFromCreateView(*chparser.CreateView) (ViewSpec, error)`:
+
+1. **Reject early**: if the AST exposes `Refresh`, `Engine`, or window-view markers → return a named error (mirrors the MV rejection logic in `buildMaterializedViewFromCreateMV`). The exact field check is impl-time (chparser may surface these as nil-checks or as bool flags; verify at write time).
+2. **`Query`** ← `formatNode(s.Select)` (uses `PrintVisitor`, same path the MV introspector uses for its `AS SELECT`).
+3. **`ColumnAliases`** ← if the AST has a column list node attached to the view definition, walk it and collect identifier names. If absent → nil.
+4. **`Definer` / `SQLSecurity`** ← optional fields on the AST. Lowercase the security value. If `Definer` is present, ensure `SQLSecurity == "definer"` (otherwise the live CREATE shouldn't have parsed; treat as parser bug if it happens).
+5. **`Cluster`** ← `s.OnCluster.Expr` text if non-nil.
+6. **`Comment`** ← `unquoteString(s.Comment.Literal)` if non-nil.
+
+## SQL Generation forms (canonical)
+
+```sql
+-- Add (full form, all clauses optional except CREATE VIEW … AS <query>)
+CREATE VIEW [ON CLUSTER cluster] db.name [(alias1, alias2, …)]
+  [DEFINER = user] [SQL SECURITY { DEFINER | INVOKER | NONE }]
+  AS <query>
+  [COMMENT '<comment>']
+
+-- Body-only modify
+ALTER TABLE db.name [ON CLUSTER cluster] MODIFY QUERY <query>
+
+-- Comment-only modify
+ALTER TABLE db.name [ON CLUSTER cluster] MODIFY COMMENT '<comment>'
+
+-- Recreate (DROP then CREATE — no atomic alternative for column_aliases / security / cluster changes)
+DROP VIEW IF EXISTS db.name [ON CLUSTER cluster]
+CREATE VIEW … (full form)
+
+-- Drop
+DROP VIEW [IF EXISTS] db.name [ON CLUSTER cluster]
+```
+
+Quoting: identifiers (`db`, `name`, `definer`) are not quoted unless they require it. Comment literals use ClickHouse single-quote escaping (existing `quoteString` helper).
+
+## Change-set rendering
+
+`renderChangeSet` in `cmd/hclexp/hclexp.go` gains:
+
+```
+database "posthog"
+  + view my_view
+  - view old_view
+  ~ view changed_view
+      ~ query changed
+      ! requires recreation (column_aliases / sql_security / definer / cluster changed)
+      ~ comment changed
+```
+
+Exactly mirrors the existing materialized-view block layout.
+
+## Testing strategy
+
+| Layer                   | Tests                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Unit — introspect       | Round-trip parse of every grammar form: bare, `ON CLUSTER`, with column aliases, each `SQL SECURITY` variant, with `DEFINER = current_user`, with `DEFINER = alice`, with comment. Also: reject Live / Refresh / Window with named errors. |
+| Unit — HCL parse        | `definer` without `sql_security="definer"` → error. `sql_security` outside the three enum values → error.                                  |
+| Unit — diff             | Each row of the diff-semantics table (add, drop, query-only, comment-only, recreate-triggering, no-op).                                    |
+| Unit — sqlgen           | Each DDL form, including `ON CLUSTER` propagation and view-after-source ordering vs a dependent table.                                     |
+| Unit — validate         | Missing source table → named error; CTE not mistaken for a source; `-skip-validation` honoured.                                            |
+| Live (snapshot)         | Round-trip a CREATE VIEW fixture against the docker-compose ClickHouse (the `TestLive_Introspection_AllStatements/View/*` slot enabled by PR #11). Assert introspected `ViewSpec` matches expectations and sqlgen back-out matches the input (after canonicalisation). |
+
+## Cross-cutting
+
+- **Branch**: new branch `feat-view-support` off `main` in a fresh worktree.
+- **Spec location**: this file.
+- **Plan location**: `docs/superpowers/plans/2026-05-28-view-support.md`.
+- **Docs**: update `docs/README.hcl.md` — move views from "Not Yet Supported" to a new `### Views` subsection, then update `README.md` to mention views in the introspection coverage paragraph.
+- **CLAUDE.md**: update the Supported Features bullet ("view top-level block — planned, not implemented" → ✅ Views).
+
+## Out of scope (explicitly)
+
+- Live View, Refreshable Materialized View, Window View — rejected at introspection.
+- Modeling parameterized-view parameter lists as typed HCL — the SELECT body is stored verbatim, which round-trips fine.
+- View grants / `ALTER VIEW … MODIFY SQL SECURITY` migrations triggered by anything other than full recreate.
+
+## Open items (deferred, none blocking)
+
+- Live VIEW MODIFY COMMENT support: docs imply but don't explicitly state ClickHouse supports `ALTER TABLE view MODIFY COMMENT`. Sanity-check during impl against the local ClickHouse; if rejected, fall back to recreate for comment-only changes too.
+- Parameterized view validation: ClickHouse runtime, not introspection. Out of scope here.

--- a/internal/loader/hcl/diff.go
+++ b/internal/loader/hcl/diff.go
@@ -26,6 +26,10 @@ type DatabaseChange struct {
 	AddDictionaries   []DictionarySpec // emitted via CREATE OR REPLACE DICTIONARY
 	DropDictionaries  []string         // emitted via DROP DICTIONARY
 	AlterDictionaries []DictionaryDiff
+
+	AddViews   []ViewSpec // emitted via CREATE VIEW
+	DropViews  []string   // emitted via DROP VIEW
+	AlterViews []ViewDiff
 }
 
 // DictionaryDiff describes a change to a dictionary. ClickHouse has no
@@ -59,6 +63,25 @@ func (mvd MaterializedViewDiff) IsEmpty() bool {
 func (mvd MaterializedViewDiff) IsUnsafe() bool {
 	return mvd.Recreate
 }
+
+// ViewDiff is the set of mutations to a single existing plain view. A
+// query-only change is applied in place via ALTER TABLE ... MODIFY
+// QUERY. A comment-only change is applied via ALTER TABLE ... MODIFY
+// COMMENT. Any change to ColumnAliases / SQLSecurity / Definer /
+// Cluster requires recreating the view (DROP + CREATE) and is flagged
+// unsafe.
+type ViewDiff struct {
+	Name        string
+	QueryChange *StringChange
+	Comment     *StringChange
+	Recreate    bool
+}
+
+func (vd ViewDiff) IsEmpty() bool {
+	return vd.QueryChange == nil && vd.Comment == nil && !vd.Recreate
+}
+
+func (vd ViewDiff) IsUnsafe() bool { return vd.Recreate }
 
 // TableDiff is the set of mutations to a single existing table. Any unset
 // field means "no change in that aspect."
@@ -140,6 +163,8 @@ func (dc DatabaseChange) IsEmpty() bool {
 	return len(dc.AddTables) == 0 && len(dc.DropTables) == 0 && len(dc.AlterTables) == 0 &&
 		len(dc.AddMaterializedViews) == 0 && len(dc.DropMaterializedViews) == 0 &&
 		len(dc.AlterMaterializedViews) == 0 &&
+		len(dc.AddViews) == 0 && len(dc.DropViews) == 0 &&
+		len(dc.AlterViews) == 0 &&
 		len(dc.AddDictionaries) == 0 && len(dc.DropDictionaries) == 0 &&
 		len(dc.AlterDictionaries) == 0
 }
@@ -187,6 +212,7 @@ func Diff(from, to *Schema) ChangeSet {
 				Database:             name,
 				AddTables:            append([]TableSpec(nil), t.Tables...),
 				AddMaterializedViews: append([]MaterializedViewSpec(nil), t.MaterializedViews...),
+				AddViews:             append([]ViewSpec(nil), t.Views...),
 			}
 		case !tOK:
 			dc = DatabaseChange{Database: name}
@@ -195,6 +221,9 @@ func Diff(from, to *Schema) ChangeSet {
 			}
 			for _, mv := range f.MaterializedViews {
 				dc.DropMaterializedViews = append(dc.DropMaterializedViews, mv.Name)
+			}
+			for _, v := range f.Views {
+				dc.DropViews = append(dc.DropViews, v.Name)
 			}
 		default:
 			dc = diffDatabase(name, f, t)
@@ -283,6 +312,29 @@ func diffDatabase(name string, from, to *DatabaseSpec) DatabaseChange {
 		}
 	}
 
+	fromViews := indexViews(from.Views)
+	toViews := indexViews(to.Views)
+	for _, n := range sortedKeys(toViews) {
+		if _, ok := fromViews[n]; !ok {
+			dc.AddViews = append(dc.AddViews, *toViews[n])
+		}
+	}
+	for _, n := range sortedKeys(fromViews) {
+		if _, ok := toViews[n]; !ok {
+			dc.DropViews = append(dc.DropViews, n)
+		}
+	}
+	for _, n := range sortedKeys(fromViews) {
+		t, ok := toViews[n]
+		if !ok {
+			continue
+		}
+		vd := diffView(fromViews[n], t)
+		if !vd.IsEmpty() {
+			dc.AlterViews = append(dc.AlterViews, vd)
+		}
+	}
+
 	fromDicts := indexDictionaries(from.Dictionaries)
 	toDicts := indexDictionaries(to.Dictionaries)
 	for _, n := range sortedKeys(toDicts) {
@@ -363,6 +415,36 @@ func dictLayoutEqual(a, b *DictionaryLayoutSpec) bool {
 		return a == b
 	}
 	return a.Kind == b.Kind && reflect.DeepEqual(a.Decoded, b.Decoded)
+}
+
+func indexViews(views []ViewSpec) map[string]*ViewSpec {
+	out := make(map[string]*ViewSpec, len(views))
+	for i := range views {
+		out[views[i].Name] = &views[i]
+	}
+	return out
+}
+
+// diffView compares two plain views with the same name. Query and Comment
+// can be modified in place; ColumnAliases, SQLSecurity, Definer, and
+// Cluster changes require DROP + CREATE.
+func diffView(from, to *ViewSpec) ViewDiff {
+	vd := ViewDiff{Name: to.Name}
+	if !reflect.DeepEqual(from.ColumnAliases, to.ColumnAliases) ||
+		!reflect.DeepEqual(from.SQLSecurity, to.SQLSecurity) ||
+		!reflect.DeepEqual(from.Definer, to.Definer) ||
+		!reflect.DeepEqual(from.Cluster, to.Cluster) {
+		vd.Recreate = true
+		return vd
+	}
+	if from.Query != to.Query {
+		q1, q2 := from.Query, to.Query
+		vd.QueryChange = &StringChange{Old: &q1, New: &q2}
+	}
+	if !reflect.DeepEqual(from.Comment, to.Comment) {
+		vd.Comment = &StringChange{Old: from.Comment, New: to.Comment}
+	}
+	return vd
 }
 
 func indexMaterializedViews(mvs []MaterializedViewSpec) map[string]*MaterializedViewSpec {
@@ -599,4 +681,7 @@ func sortDatabaseChange(dc *DatabaseChange) {
 	sort.Slice(dc.AlterDictionaries, func(i, j int) bool {
 		return dc.AlterDictionaries[i].Name < dc.AlterDictionaries[j].Name
 	})
+	sort.Slice(dc.AddViews, func(i, j int) bool { return dc.AddViews[i].Name < dc.AddViews[j].Name })
+	sort.Strings(dc.DropViews)
+	sort.Slice(dc.AlterViews, func(i, j int) bool { return dc.AlterViews[i].Name < dc.AlterViews[j].Name })
 }

--- a/internal/loader/hcl/diff_test.go
+++ b/internal/loader/hcl/diff_test.go
@@ -329,6 +329,67 @@ func mkMV(name, toTable, query string) MaterializedViewSpec {
 	return MaterializedViewSpec{Name: name, ToTable: toTable, Query: query}
 }
 
+func mkView(name, query string) ViewSpec {
+	return ViewSpec{Name: name, Query: query}
+}
+
+func TestDiff_ViewAddDrop(t *testing.T) {
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{mkView("v_old", "SELECT 1")}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{mkView("v_new", "SELECT 2")}}}}
+	cs := Diff(from, to)
+	require.False(t, cs.IsEmpty())
+	require.Len(t, cs.Databases, 1)
+	dc := cs.Databases[0]
+	assert.Equal(t, []string{"v_old"}, dc.DropViews)
+	require.Len(t, dc.AddViews, 1)
+	assert.Equal(t, "v_new", dc.AddViews[0].Name)
+}
+
+func TestDiff_ViewQueryOnlyChange(t *testing.T) {
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{mkView("v", "SELECT 1")}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{mkView("v", "SELECT 2")}}}}
+	cs := Diff(from, to)
+	require.Len(t, cs.Databases[0].AlterViews, 1)
+	vd := cs.Databases[0].AlterViews[0]
+	require.NotNil(t, vd.QueryChange)
+	assert.False(t, vd.Recreate)
+	assert.Nil(t, vd.Comment)
+}
+
+func TestDiff_ViewCommentOnlyChange(t *testing.T) {
+	vFrom := mkView("v", "SELECT 1")
+	vFrom.Comment = ptr("old")
+	vTo := mkView("v", "SELECT 1")
+	vTo.Comment = ptr("new")
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{vFrom}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{vTo}}}}
+	cs := Diff(from, to)
+	vd := cs.Databases[0].AlterViews[0]
+	assert.Nil(t, vd.QueryChange)
+	require.NotNil(t, vd.Comment)
+	assert.False(t, vd.Recreate)
+}
+
+func TestDiff_ViewShapeChangeForcesRecreate(t *testing.T) {
+	vFrom := mkView("v", "SELECT 1")
+	vFrom.ColumnAliases = []string{"a"}
+	vTo := mkView("v", "SELECT 1")
+	vTo.ColumnAliases = []string{"a", "b"}
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{vFrom}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{vTo}}}}
+	cs := Diff(from, to)
+	vd := cs.Databases[0].AlterViews[0]
+	assert.True(t, vd.Recreate)
+	assert.True(t, vd.IsUnsafe())
+}
+
+func TestDiff_IdenticalViewsEmpty(t *testing.T) {
+	v := mkView("v", "SELECT 1")
+	from := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{v}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{v}}}}
+	assert.True(t, Diff(from, to).IsEmpty())
+}
+
 func mkDBWithMVs(name string, mvs ...MaterializedViewSpec) DatabaseSpec {
 	return DatabaseSpec{Name: name, MaterializedViews: mvs}
 }

--- a/internal/loader/hcl/dump.go
+++ b/internal/loader/hcl/dump.go
@@ -70,14 +70,43 @@ func writeDatabase(body *hclwrite.Body, db DatabaseSpec) {
 		writeMaterializedView(mvBlock.Body(), mv)
 	}
 
+	views := append([]ViewSpec(nil), db.Views...)
+	sort.Slice(views, func(i, j int) bool { return views[i].Name < views[j].Name })
+	for i, v := range views {
+		if len(tables) > 0 || len(mvs) > 0 || i > 0 {
+			body.AppendNewline()
+		}
+		vBlock := body.AppendNewBlock("view", []string{v.Name})
+		writeView(vBlock.Body(), v)
+	}
+
 	dicts := append([]DictionarySpec(nil), db.Dictionaries...)
 	sort.Slice(dicts, func(i, j int) bool { return dicts[i].Name < dicts[j].Name })
 	for i, d := range dicts {
-		if len(tables) > 0 || len(mvs) > 0 || i > 0 {
+		if len(tables) > 0 || len(mvs) > 0 || len(views) > 0 || i > 0 {
 			body.AppendNewline()
 		}
 		dBlock := body.AppendNewBlock("dictionary", []string{d.Name})
 		writeDictionary(dBlock.Body(), d)
+	}
+}
+
+func writeView(body *hclwrite.Body, v ViewSpec) {
+	body.SetAttributeValue("query", cty.StringVal(v.Query))
+	if len(v.ColumnAliases) > 0 {
+		body.SetAttributeValue("column_aliases", stringList(v.ColumnAliases))
+	}
+	if v.SQLSecurity != nil {
+		body.SetAttributeValue("sql_security", cty.StringVal(*v.SQLSecurity))
+	}
+	if v.Definer != nil {
+		body.SetAttributeValue("definer", cty.StringVal(*v.Definer))
+	}
+	if v.Cluster != nil {
+		body.SetAttributeValue("cluster", cty.StringVal(*v.Cluster))
+	}
+	if v.Comment != nil {
+		body.SetAttributeValue("comment", cty.StringVal(*v.Comment))
 	}
 }
 

--- a/internal/loader/hcl/dump_test.go
+++ b/internal/loader/hcl/dump_test.go
@@ -96,3 +96,33 @@ func TestWrite_RoundTrip_KafkaWithCollection(t *testing.T) {
 func TestWrite_RoundTrip_KafkaInlineSettings(t *testing.T) {
 	roundTrip(t, filepath.Join("testdata", "kafka_inline_settings.hcl"))
 }
+
+func TestDumpSchema_RendersViewBlocks(t *testing.T) {
+	want := ViewSpec{
+		Name:          "metrics",
+		Query:         "SELECT team_id, count() AS n FROM events GROUP BY team_id",
+		ColumnAliases: []string{"team_id", "n"},
+		SQLSecurity:   ptr("definer"),
+		Definer:       ptr("alice"),
+		Comment:       ptr("team-level event counter"),
+	}
+	s := &Schema{Databases: []DatabaseSpec{{Name: "posthog", Views: []ViewSpec{want}}}}
+
+	var buf bytes.Buffer
+	require.NoError(t, Write(&buf, s))
+
+	// Output should contain the block header. The remaining attributes
+	// are alignment-formatted by hclwrite, so we round-trip back through
+	// ParseFile to assert structural equivalence.
+	got := buf.String()
+	assert.Contains(t, got, `view "metrics" {`)
+
+	tmp := filepath.Join(t.TempDir(), "schema.hcl")
+	require.NoError(t, os.WriteFile(tmp, buf.Bytes(), 0o600))
+	reparsed, err := ParseFile(tmp)
+	require.NoError(t, err)
+	require.NoError(t, Resolve(reparsed))
+	require.Len(t, reparsed.Databases, 1)
+	require.Len(t, reparsed.Databases[0].Views, 1)
+	assert.Equal(t, want, reparsed.Databases[0].Views[0])
+}

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -64,7 +64,15 @@ func processIntrospectRows(db *DatabaseSpec, database string, rows rowScanner) e
 		if err := rows.Scan(&name, &createSQL); err != nil {
 			return fmt.Errorf("scan system.tables: %w", err)
 		}
-		stmt, err := parseCreateStatement(createSQL)
+		// chparser as of the current pin rejects DEFINER / SQL SECURITY /
+		// COMMENT on plain CREATE VIEW (tracked at
+		// https://github.com/orian/clickhouse-sql-parser/issues/6). Pre-
+		// strip those clauses so the rest of the statement parses; we
+		// stitch the captured values back onto the resulting ViewSpec
+		// below.
+		extras, parseSQL := stripViewExtras(createSQL)
+
+		stmt, err := parseCreateStatement(parseSQL)
 		if err != nil {
 			return fmt.Errorf("parse create_table_query for %s.%s: %w", database, name, err)
 		}
@@ -91,9 +99,12 @@ func processIntrospectRows(db *DatabaseSpec, database string, rows rowScanner) e
 			d.Name = name
 			db.Dictionaries = append(db.Dictionaries, d)
 		case *chparser.CreateView:
-			// Plain (non-materialized) views are out of scope; skip them
-			// rather than failing the whole introspection.
-			continue
+			v, err := buildViewFromCreateView(s, extras)
+			if err != nil {
+				return fmt.Errorf("introspect view %s.%s: %w", database, name, err)
+			}
+			v.Name = name
+			db.Views = append(db.Views, v)
 		default:
 			return fmt.Errorf("introspect %s.%s: unsupported statement type %T", database, name, stmt)
 		}
@@ -206,6 +217,99 @@ func buildMaterializedViewFromCreateSQL(createSQL string) (MaterializedViewSpec,
 // buildMaterializedViewFromCreateMV walks an already-parsed CREATE
 // MATERIALIZED VIEW AST. Only the `TO <table>` form is supported;
 // inner-engine and refreshable MVs are rejected with a clear error.
+// viewExtras carries the clauses that chparser doesn't yet parse on
+// CREATE VIEW (see orian/clickhouse-sql-parser#6). They're captured
+// from the raw SQL by stripViewExtras and merged onto the ViewSpec
+// after the cleaned statement is parsed.
+type viewExtras struct {
+	SQLSecurity *string
+	Definer     *string
+	Comment     *string
+}
+
+var (
+	reCreateViewPrefix = regexp.MustCompile(`(?i)^\s*CREATE\s+(OR\s+REPLACE\s+)?VIEW\b`)
+	reViewDefiner      = regexp.MustCompile(`(?i)\s*DEFINER\s*=\s*([A-Za-z_][A-Za-z0-9_]*|CURRENT_USER)\b`)
+	reViewSQLSecurity  = regexp.MustCompile(`(?i)\s*SQL\s+SECURITY\s+(DEFINER|INVOKER|NONE)\b`)
+	reViewCommentTail  = regexp.MustCompile(`(?is)\s*COMMENT\s+'((?:[^']|'')*)'\s*$`)
+)
+
+// stripViewExtras pulls DEFINER / SQL SECURITY / trailing COMMENT off a
+// CREATE VIEW statement so the remainder parses cleanly with the current
+// chparser. Returns the parsed-out clauses and the cleaned SQL. For
+// non-view statements it's a no-op.
+func stripViewExtras(sql string) (viewExtras, string) {
+	if !reCreateViewPrefix.MatchString(sql) {
+		return viewExtras{}, sql
+	}
+	var ex viewExtras
+	if m := reViewDefiner.FindStringSubmatchIndex(sql); m != nil {
+		d := sql[m[2]:m[3]]
+		ex.Definer = &d
+		sql = sql[:m[0]] + sql[m[1]:]
+	}
+	if m := reViewSQLSecurity.FindStringSubmatchIndex(sql); m != nil {
+		s := strings.ToLower(sql[m[2]:m[3]])
+		ex.SQLSecurity = &s
+		sql = sql[:m[0]] + sql[m[1]:]
+	}
+	if m := reViewCommentTail.FindStringSubmatchIndex(sql); m != nil {
+		raw := sql[m[2]:m[3]]
+		c := strings.ReplaceAll(raw, "''", "'")
+		ex.Comment = &c
+		sql = sql[:m[0]]
+	}
+	return ex, sql
+}
+
+// buildViewFromCreateView walks a parsed CREATE VIEW AST and produces a
+// ViewSpec, merging in the extras captured by stripViewExtras. The
+// SELECT body is rendered back to text via formatNode, matching the way
+// MV bodies are captured.
+func buildViewFromCreateView(cv *chparser.CreateView, extras viewExtras) (ViewSpec, error) {
+	v := ViewSpec{}
+
+	if cv.SubQuery != nil && cv.SubQuery.Select != nil {
+		v.Query = strings.TrimSpace(formatNode(cv.SubQuery.Select))
+	}
+
+	if cv.OnCluster != nil && cv.OnCluster.Expr != nil {
+		v.Cluster = strPtr(formatNode(cv.OnCluster.Expr))
+	}
+
+	// chparser exposes CREATE VIEW v (a, b, c) AS … via TableSchema with
+	// ColumnDef entries that carry only a Name (the type is empty for
+	// a bare alias).
+	if cv.TableSchema != nil {
+		for _, c := range cv.TableSchema.Columns {
+			cd, ok := c.(*chparser.ColumnDef)
+			if !ok {
+				continue
+			}
+			if cd.Name == nil {
+				continue
+			}
+			v.ColumnAliases = append(v.ColumnAliases, identName(cd.Name))
+		}
+	}
+
+	// Merge the regex-extracted extras. AST-side Comment takes precedence
+	// if chparser ever starts populating it.
+	if cv.Comment != nil {
+		v.Comment = strPtr(unquoteString(cv.Comment.Literal))
+	} else if extras.Comment != nil {
+		v.Comment = extras.Comment
+	}
+	if extras.SQLSecurity != nil {
+		v.SQLSecurity = extras.SQLSecurity
+	}
+	if extras.Definer != nil {
+		v.Definer = extras.Definer
+	}
+
+	return v, nil
+}
+
 func buildMaterializedViewFromCreateMV(mv *chparser.CreateMaterializedView) (MaterializedViewSpec, error) {
 	if mv.Refresh != nil {
 		return MaterializedViewSpec{}, errors.New("unsupported: refreshable materialized view")

--- a/internal/loader/hcl/introspect_test.go
+++ b/internal/loader/hcl/introspect_test.go
@@ -300,7 +300,7 @@ func (r *fakeRows) Err() error { return nil }
 // TestProcessIntrospectRows_Dispatch exercises the statement-type dispatch in
 // processIntrospectRows: a CREATE TABLE, a CREATE MATERIALIZED VIEW (TO form),
 // and a plain CREATE VIEW must all be processed in one call without error, and
-// each must land in the correct collection (or be silently skipped for views).
+// each must land in the correct collection.
 func TestProcessIntrospectRows_Dispatch(t *testing.T) {
 	rows := &fakeRows{rows: []struct{ name, sql string }{
 		{
@@ -325,7 +325,6 @@ func TestProcessIntrospectRows_Dispatch(t *testing.T) {
 	err := processIntrospectRows(db, "db", rows)
 	require.NoError(t, err)
 
-	// One table, one MV; the plain view is silently skipped.
 	require.Len(t, db.Tables, 1, "expected exactly one table")
 	assert.Equal(t, "events", db.Tables[0].Name)
 
@@ -333,6 +332,63 @@ func TestProcessIntrospectRows_Dispatch(t *testing.T) {
 	assert.Equal(t, "metrics_mv", db.MaterializedViews[0].Name)
 	assert.Equal(t, "db.metrics", db.MaterializedViews[0].ToTable)
 	assert.Contains(t, db.MaterializedViews[0].Query, "team_id")
+
+	require.Len(t, db.Views, 1, "expected exactly one view")
+	assert.Equal(t, "events_view", db.Views[0].Name)
+	assert.Contains(t, db.Views[0].Query, "FROM db.events")
+}
+
+func TestProcessIntrospectRows_PlainView(t *testing.T) {
+	rows := &fakeRows{rows: []struct{ name, sql string }{
+		{
+			name: "v_simple",
+			sql:  "CREATE VIEW posthog.v_simple AS SELECT team_id FROM posthog.events",
+		},
+	}}
+	db := &DatabaseSpec{Name: "posthog"}
+	require.NoError(t, processIntrospectRows(db, "posthog", rows))
+	require.Empty(t, db.Tables)
+	require.Empty(t, db.MaterializedViews)
+	require.Len(t, db.Views, 1)
+	assert.Equal(t, "v_simple", db.Views[0].Name)
+	assert.Contains(t, db.Views[0].Query, "SELECT")
+	assert.Contains(t, db.Views[0].Query, "FROM posthog.events")
+}
+
+func TestProcessIntrospectRows_ViewWithColumnAliasesAndComment(t *testing.T) {
+	rows := &fakeRows{rows: []struct{ name, sql string }{
+		{
+			name: "v_aliased",
+			sql: "CREATE VIEW posthog.v_aliased (team_id, n) " +
+				"AS SELECT team_id, count() AS c FROM posthog.events GROUP BY team_id " +
+				"COMMENT 'aliased view'",
+		},
+	}}
+	db := &DatabaseSpec{Name: "posthog"}
+	require.NoError(t, processIntrospectRows(db, "posthog", rows))
+	require.Len(t, db.Views, 1)
+	assert.Equal(t, []string{"team_id", "n"}, db.Views[0].ColumnAliases)
+	require.NotNil(t, db.Views[0].Comment)
+	assert.Equal(t, "aliased view", *db.Views[0].Comment)
+}
+
+func TestProcessIntrospectRows_ViewWithSQLSecurityDefiner(t *testing.T) {
+	// chparser as of the currently-pinned fork doesn't model DEFINER / SQL
+	// SECURITY on CREATE VIEW; buildViewFromCreateView falls back to a
+	// regex on the input text for those clauses.
+	rows := &fakeRows{rows: []struct{ name, sql string }{
+		{
+			name: "v_sec",
+			sql:  "CREATE VIEW posthog.v_sec DEFINER = alice SQL SECURITY DEFINER AS SELECT 1",
+		},
+	}}
+	db := &DatabaseSpec{Name: "posthog"}
+	require.NoError(t, processIntrospectRows(db, "posthog", rows))
+	require.Len(t, db.Views, 1)
+	require.NotNil(t, db.Views[0].SQLSecurity, "SQLSecurity not captured")
+	assert.Equal(t, "definer", *db.Views[0].SQLSecurity)
+	require.NotNil(t, db.Views[0].Definer, "Definer not captured")
+	assert.Equal(t, "alice", *db.Views[0].Definer)
 }
 
 func TestParseCodecExpression(t *testing.T) {

--- a/internal/loader/hcl/layers.go
+++ b/internal/loader/hcl/layers.go
@@ -112,5 +112,17 @@ func mergeIntoDatabase(target *DatabaseSpec, incoming DatabaseSpec) error {
 		mvByName[mv.Name] = true
 		target.MaterializedViews = append(target.MaterializedViews, mv)
 	}
+
+	viewByName := make(map[string]bool, len(target.Views))
+	for _, v := range target.Views {
+		viewByName[v.Name] = true
+	}
+	for _, v := range incoming.Views {
+		if viewByName[v.Name] {
+			return fmt.Errorf("view %q redeclared across layers", v.Name)
+		}
+		viewByName[v.Name] = true
+		target.Views = append(target.Views, v)
+	}
 	return nil
 }

--- a/internal/loader/hcl/layers_test.go
+++ b/internal/loader/hcl/layers_test.go
@@ -71,6 +71,15 @@ func TestLoadLayers_CollisionWithoutOverrideErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "override")
 }
 
+func TestLoadLayers_ViewRedeclareAcrossLayers(t *testing.T) {
+	_, err := LoadLayers([]string{
+		layerPath("view_redeclare", "base"),
+		layerPath("view_redeclare", "env_dev"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `view "v" redeclared across layers`)
+}
+
 func TestLoadLayers_PatchPropagatesThroughExtend(t *testing.T) {
 	schema, err := LoadLayers([]string{
 		layerPath("patch_with_extend", "base"),

--- a/internal/loader/hcl/parser_test.go
+++ b/internal/loader/hcl/parser_test.go
@@ -245,3 +245,31 @@ func TestParseFile_KafkaInlineSettings(t *testing.T) {
 	require.NotNil(t, kafkaEng.Extra)
 	assert.Equal(t, "foo", kafkaEng.Extra["kafka_some_future_setting"])
 }
+
+func TestParseFile_View_DefinerWithoutSQLSecurity(t *testing.T) {
+	schema, err := ParseFile(filepath.Join("testdata", "view_invalid_definer_without_sql_security.hcl"))
+	require.NoError(t, err)
+	err = Resolve(schema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `definer requires sql_security = "definer"`)
+}
+
+func TestParseFile_View_InvalidSQLSecurityEnum(t *testing.T) {
+	schema, err := ParseFile(filepath.Join("testdata", "view_invalid_sql_security_enum.hcl"))
+	require.NoError(t, err)
+	err = Resolve(schema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `sql_security must be one of "definer", "invoker", "none"`)
+}
+
+func TestParseFile_View_SQLSecurityCaseInsensitive(t *testing.T) {
+	schema, err := ParseFile(filepath.Join("testdata", "view_sql_security_uppercase.hcl"))
+	require.NoError(t, err)
+	require.NoError(t, Resolve(schema))
+	require.Len(t, schema.Databases[0].Views, 1)
+	v := schema.Databases[0].Views[0]
+	require.NotNil(t, v.SQLSecurity)
+	assert.Equal(t, "definer", *v.SQLSecurity)
+	require.NotNil(t, v.Definer)
+	assert.Equal(t, "alice", *v.Definer)
+}

--- a/internal/loader/hcl/resolver.go
+++ b/internal/loader/hcl/resolver.go
@@ -26,6 +26,9 @@ func Resolve(s *Schema) error {
 		if err := validateDictionaries(&s.Databases[di]); err != nil {
 			return err
 		}
+		if err := validateViews(&s.Databases[di]); err != nil {
+			return err
+		}
 	}
 	if err := validateKafkaEngines(s); err != nil {
 		return err
@@ -130,6 +133,30 @@ func validateDictionaries(db *DatabaseSpec) error {
 				// allowed
 			default:
 				return fmt.Errorf("%s.%s: range block only allowed with range_hashed or complex_key_range_hashed layouts (got %q)", db.Name, d.Name, d.Layout.Kind)
+			}
+		}
+	}
+	return nil
+}
+
+// validateViews normalises and validates parsed ViewSpec entries. The HCL
+// surface is more permissive than ClickHouse semantics; this catches
+// schema mistakes at parse time rather than at apply.
+func validateViews(db *DatabaseSpec) error {
+	for i := range db.Views {
+		v := &db.Views[i]
+		if v.SQLSecurity != nil {
+			canonical := strings.ToLower(strings.TrimSpace(*v.SQLSecurity))
+			switch canonical {
+			case "definer", "invoker", "none":
+				v.SQLSecurity = &canonical
+			default:
+				return fmt.Errorf(`%s.%s: sql_security must be one of "definer", "invoker", "none" (got %q)`, db.Name, v.Name, *v.SQLSecurity)
+			}
+		}
+		if v.Definer != nil {
+			if v.SQLSecurity == nil || *v.SQLSecurity != "definer" {
+				return fmt.Errorf(`%s.%s: definer requires sql_security = "definer"`, db.Name, v.Name)
 			}
 		}
 	}

--- a/internal/loader/hcl/sqlgen.go
+++ b/internal/loader/hcl/sqlgen.go
@@ -69,6 +69,11 @@ func GenerateSQL(cs ChangeSet) GeneratedSQL {
 		}
 	}
 	for _, dc := range cs.Databases {
+		for _, v := range dc.AddViews {
+			out.Statements = append(out.Statements, createViewSQL(dc.Database, v))
+		}
+	}
+	for _, dc := range cs.Databases {
 		for _, d := range dictionariesByName(dc.AddDictionaries) {
 			out.Statements = append(out.Statements, createDictionarySQL(dc.Database, d))
 		}
@@ -98,6 +103,23 @@ func GenerateSQL(cs ChangeSet) GeneratedSQL {
 		}
 	}
 	for _, dc := range cs.Databases {
+		for _, vd := range dc.AlterViews {
+			if vd.Recreate {
+				out.Unsafe = append(out.Unsafe, UnsafeChange{
+					Database: dc.Database, Table: vd.Name,
+					Reason: "view column_aliases / sql_security / definer / cluster change requires recreating the view",
+				})
+				continue
+			}
+			if vd.QueryChange != nil && vd.QueryChange.New != nil {
+				out.Statements = append(out.Statements, modifyQuerySQL(dc.Database, vd.Name, *vd.QueryChange.New))
+			}
+			if vd.Comment != nil && vd.Comment.New != nil {
+				out.Statements = append(out.Statements, modifyCommentSQL(dc.Database, vd.Name, *vd.Comment.New))
+			}
+		}
+	}
+	for _, dc := range cs.Databases {
 		for _, dd := range dc.AlterDictionaries {
 			out.Unsafe = append(out.Unsafe, UnsafeChange{
 				Database: dc.Database,
@@ -122,6 +144,13 @@ func GenerateSQL(cs ChangeSet) GeneratedSQL {
 
 	for _, dc := range cs.Databases {
 		for _, name := range dc.DropMaterializedViews {
+			out.Statements = append(out.Statements, dropViewSQL(dc.Database, name))
+		}
+	}
+	for _, dc := range cs.Databases {
+		names := append([]string(nil), dc.DropViews...)
+		sort.Strings(names)
+		for _, name := range names {
 			out.Statements = append(out.Statements, dropViewSQL(dc.Database, name))
 		}
 	}
@@ -258,13 +287,47 @@ func createMaterializedViewSQL(database string, mv MaterializedViewSpec) string 
 	return b.String()
 }
 
-// modifyQuerySQL renders an in-place query update for a materialized view.
+// modifyQuerySQL renders an in-place query update for a materialized view
+// or plain view (the syntax is identical: ALTER TABLE ... MODIFY QUERY).
 func modifyQuerySQL(database, name, query string) string {
 	return fmt.Sprintf("ALTER TABLE %s.%s MODIFY QUERY %s", database, name, query)
 }
 
+// modifyCommentSQL renders an in-place comment update via ALTER TABLE.
+// ClickHouse accepts this form on plain views.
+func modifyCommentSQL(database, name, comment string) string {
+	return fmt.Sprintf("ALTER TABLE %s.%s MODIFY COMMENT %s", database, name, quoteString(comment))
+}
+
 func dropViewSQL(database, name string) string {
 	return fmt.Sprintf("DROP VIEW %s.%s", database, name)
+}
+
+// createViewSQL renders the full CREATE VIEW statement for a ViewSpec.
+// Field order follows the ClickHouse grammar:
+//
+//	CREATE VIEW [ON CLUSTER c] db.name [(aliases)] [DEFINER = u]
+//	  [SQL SECURITY ...] AS <query> [COMMENT '...']
+func createViewSQL(database string, v ViewSpec) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE VIEW %s.%s", database, v.Name)
+	if v.Cluster != nil {
+		fmt.Fprintf(&b, " ON CLUSTER %s", *v.Cluster)
+	}
+	if len(v.ColumnAliases) > 0 {
+		fmt.Fprintf(&b, " (%s)", strings.Join(v.ColumnAliases, ", "))
+	}
+	if v.Definer != nil {
+		fmt.Fprintf(&b, " DEFINER = %s", *v.Definer)
+	}
+	if v.SQLSecurity != nil {
+		fmt.Fprintf(&b, " SQL SECURITY %s", strings.ToUpper(*v.SQLSecurity))
+	}
+	fmt.Fprintf(&b, " AS %s", v.Query)
+	if v.Comment != nil {
+		fmt.Fprintf(&b, " COMMENT %s", quoteString(*v.Comment))
+	}
+	return b.String()
 }
 
 func createTableSQL(database string, t TableSpec) string {

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -589,6 +589,87 @@ func TestSQLGen_Dictionary_AttributeSQL_AllFlags(t *testing.T) {
 	}
 }
 
+func TestSQLGen_CreateView_Bare(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddViews: []ViewSpec{{Name: "v", Query: "SELECT 1"}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Len(t, got.Statements, 1)
+	assert.Equal(t, "CREATE VIEW posthog.v AS SELECT 1", got.Statements[0])
+}
+
+func TestSQLGen_CreateView_FullForm(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddViews: []ViewSpec{{
+			Name:          "v",
+			Query:         "SELECT team_id, count() AS n FROM events GROUP BY team_id",
+			ColumnAliases: []string{"team_id", "n"},
+			SQLSecurity:   ptr("definer"),
+			Definer:       ptr("alice"),
+			Cluster:       ptr("posthog"),
+			Comment:       ptr("team-level"),
+		}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Len(t, got.Statements, 1)
+	assert.Equal(t,
+		`CREATE VIEW posthog.v ON CLUSTER posthog (team_id, n) DEFINER = alice SQL SECURITY DEFINER AS SELECT team_id, count() AS n FROM events GROUP BY team_id COMMENT 'team-level'`,
+		got.Statements[0])
+}
+
+func TestSQLGen_DropPlainView(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database:  "posthog",
+		DropViews: []string{"old_v"},
+	}}}
+	got := GenerateSQL(cs)
+	require.Len(t, got.Statements, 1)
+	assert.Equal(t, "DROP VIEW posthog.old_v", got.Statements[0])
+}
+
+func TestSQLGen_AlterView_ModifyQuery(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AlterViews: []ViewDiff{{
+			Name:        "v",
+			QueryChange: &StringChange{Old: ptr("SELECT 1"), New: ptr("SELECT 2")},
+		}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Len(t, got.Statements, 1)
+	assert.Equal(t, "ALTER TABLE posthog.v MODIFY QUERY SELECT 2", got.Statements[0])
+}
+
+func TestSQLGen_AlterView_ModifyComment(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AlterViews: []ViewDiff{{
+			Name:    "v",
+			Comment: &StringChange{Old: ptr("old"), New: ptr("new")},
+		}},
+	}}}
+	got := GenerateSQL(cs)
+	require.Len(t, got.Statements, 1)
+	assert.Equal(t, "ALTER TABLE posthog.v MODIFY COMMENT 'new'", got.Statements[0])
+}
+
+func TestSQLGen_AlterView_RecreateIsUnsafe(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AlterViews: []ViewDiff{{
+			Name:     "v",
+			Recreate: true,
+		}},
+	}}}
+	got := GenerateSQL(cs)
+	assert.Empty(t, got.Statements)
+	require.Len(t, got.Unsafe, 1)
+	assert.Equal(t, "v", got.Unsafe[0].Table)
+	assert.Contains(t, got.Unsafe[0].Reason, "recreating")
+}
+
 func TestSQLGen_Dictionary_DirectLayoutOmitsLifetime(t *testing.T) {
 	// ClickHouse rejects LIFETIME on direct/complex_key_direct layouts.
 	// Even if a spec carries one, sqlgen must skip it.

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -670,6 +670,46 @@ func TestSQLGen_AlterView_RecreateIsUnsafe(t *testing.T) {
 	assert.Contains(t, got.Unsafe[0].Reason, "recreating")
 }
 
+func TestSQLGen_ViewCreatedAfterSourceTable(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddTables: []TableSpec{{
+			Name:    "events",
+			Columns: []ColumnSpec{{Name: "team_id", Type: "Int64"}},
+			OrderBy: []string{"team_id"},
+			Engine:  &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}},
+		}},
+		AddViews: []ViewSpec{{Name: "v", Query: "SELECT team_id FROM posthog.events"}},
+	}}}
+	got := GenerateSQL(cs)
+	joined := strings.Join(got.Statements, "\n")
+	tIdx := strings.Index(joined, "CREATE TABLE posthog.events")
+	vIdx := strings.Index(joined, "CREATE VIEW posthog.v")
+	require.GreaterOrEqual(t, tIdx, 0)
+	require.GreaterOrEqual(t, vIdx, 0)
+	assert.Less(t, tIdx, vIdx, "view must be created after its source table")
+}
+
+func TestSQLGen_ViewDroppedBeforeSourceTable(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		DropTables: []TableSpec{{
+			Name:    "events",
+			Columns: []ColumnSpec{{Name: "team_id", Type: "Int64"}},
+			OrderBy: []string{"team_id"},
+			Engine:  &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}},
+		}},
+		DropViews: []string{"v"},
+	}}}
+	got := GenerateSQL(cs)
+	joined := strings.Join(got.Statements, "\n")
+	vIdx := strings.Index(joined, "DROP VIEW posthog.v")
+	tIdx := strings.Index(joined, "DROP TABLE")
+	require.GreaterOrEqual(t, vIdx, 0)
+	require.GreaterOrEqual(t, tIdx, 0)
+	assert.Less(t, vIdx, tIdx, "view must be dropped before its source table")
+}
+
 func TestSQLGen_Dictionary_DirectLayoutOmitsLifetime(t *testing.T) {
 	// ClickHouse rejects LIFETIME on direct/complex_key_direct layouts.
 	// Even if a spec carries one, sqlgen must skip it.

--- a/internal/loader/hcl/testdata/layers/view_redeclare/base/schema.hcl
+++ b/internal/loader/hcl/testdata/layers/view_redeclare/base/schema.hcl
@@ -1,0 +1,5 @@
+database "posthog" {
+  view "v" {
+    query = "SELECT 1"
+  }
+}

--- a/internal/loader/hcl/testdata/layers/view_redeclare/env_dev/schema.hcl
+++ b/internal/loader/hcl/testdata/layers/view_redeclare/env_dev/schema.hcl
@@ -1,0 +1,5 @@
+database "posthog" {
+  view "v" {
+    query = "SELECT 2"
+  }
+}

--- a/internal/loader/hcl/testdata/view_invalid_definer_without_sql_security.hcl
+++ b/internal/loader/hcl/testdata/view_invalid_definer_without_sql_security.hcl
@@ -1,0 +1,6 @@
+database "posthog" {
+  view "v" {
+    query   = "SELECT 1"
+    definer = "alice"
+  }
+}

--- a/internal/loader/hcl/testdata/view_invalid_sql_security_enum.hcl
+++ b/internal/loader/hcl/testdata/view_invalid_sql_security_enum.hcl
@@ -1,0 +1,6 @@
+database "posthog" {
+  view "v" {
+    query        = "SELECT 1"
+    sql_security = "bogus"
+  }
+}

--- a/internal/loader/hcl/testdata/view_sql_security_uppercase.hcl
+++ b/internal/loader/hcl/testdata/view_sql_security_uppercase.hcl
@@ -1,0 +1,7 @@
+database "posthog" {
+  view "v" {
+    query        = "SELECT 1"
+    sql_security = "DEFINER"
+    definer      = "alice"
+  }
+}

--- a/internal/loader/hcl/types.go
+++ b/internal/loader/hcl/types.go
@@ -22,6 +22,11 @@ type DatabaseSpec struct {
 	// Dictionaries are a third sibling collection. Like MVs, they do not
 	// participate in the table inheritance system.
 	Dictionaries []DictionarySpec `hcl:"dictionary,block"`
+
+	// Views are plain (non-materialized) views. Like MVs and dictionaries
+	// they live as a sibling collection and do not participate in the
+	// table inheritance system.
+	Views []ViewSpec `hcl:"view,block"`
 }
 
 // MaterializedViewSpec models a ClickHouse materialized view in its
@@ -36,6 +41,26 @@ type MaterializedViewSpec struct {
 	Query   string       `hcl:"query"`            // the AS SELECT ... body
 	Cluster *string      `hcl:"cluster,optional"` // ON CLUSTER
 	Comment *string      `hcl:"comment,optional"`
+}
+
+// ViewSpec models a ClickHouse plain (non-materialized) view: a saved
+// SELECT executed on every read of the view. The Query is stored
+// verbatim as text. Live views, refreshable materialized views, and
+// window views are unsupported and rejected with a clear error during
+// introspection (they parse into different AST types).
+//
+// SQLSecurity is the canonical lowercase form of the SQL SECURITY
+// clause: one of "definer", "invoker", or "none". Definer is the user
+// the view runs as; required iff SQLSecurity == "definer" with a
+// named user. The literal "current_user" is accepted unquoted.
+type ViewSpec struct {
+	Name          string   `hcl:"name,label"`
+	Query         string   `hcl:"query"`
+	ColumnAliases []string `hcl:"column_aliases,optional"`
+	SQLSecurity   *string  `hcl:"sql_security,optional"`
+	Definer       *string  `hcl:"definer,optional"`
+	Cluster       *string  `hcl:"cluster,optional"`
+	Comment       *string  `hcl:"comment,optional"`
 }
 
 // PatchTableSpec is a strictly additive cross-layer modification of a table.

--- a/internal/loader/hcl/validate.go
+++ b/internal/loader/hcl/validate.go
@@ -13,6 +13,7 @@ const (
 	DepMVSource          = "mv_source"          // a materialized view reads from this table
 	DepMVDest            = "mv_dest"            // a materialized view writes into this table
 	DepDistributedRemote = "distributed_remote" // a Distributed table forwards to this table
+	DepViewSource        = "view_source"        // a plain view reads from this table
 )
 
 // ObjectRef identifies a schema object (table or materialized view) by its
@@ -135,6 +136,20 @@ func CollectDependencies(dbs []DatabaseSpec) ([]Dependency, error) {
 				To:   ObjectRef{Database: dist.RemoteDatabase, Name: dist.RemoteTable},
 				Kind: DepDistributedRemote,
 			})
+		}
+
+		for _, v := range db.Views {
+			from := ObjectRef{Database: db.Name, Name: v.Name}
+			sources, err := extractSourceTables(v.Query)
+			if err != nil {
+				return nil, fmt.Errorf("view %s: parsing query: %w", from, err)
+			}
+			for _, src := range sources {
+				if src.Database == "" {
+					src.Database = db.Name
+				}
+				deps = append(deps, Dependency{From: from, To: src, Kind: DepViewSource})
+			}
 		}
 	}
 	return deps, nil
@@ -408,6 +423,9 @@ func Validate(dbs []DatabaseSpec, skip SkipSet) []ValidationError {
 		for _, mv := range db.MaterializedViews {
 			declared[ObjectRef{Database: db.Name, Name: mv.Name}] = true
 		}
+		for _, v := range db.Views {
+			declared[ObjectRef{Database: db.Name, Name: v.Name}] = true
+		}
 	}
 
 	deps, err := CollectDependencies(dbs)
@@ -458,6 +476,8 @@ func depPhrase(kind string) string {
 		return "materialized view destination table"
 	case DepDistributedRemote:
 		return "Distributed table remote table"
+	case DepViewSource:
+		return "view source table"
 	default:
 		return "dependency"
 	}

--- a/internal/loader/hcl/validate_test.go
+++ b/internal/loader/hcl/validate_test.go
@@ -128,6 +128,53 @@ func TestValidate_MissingMVDest(t *testing.T) {
 	assert.Equal(t, DepMVDest, errs[0].Kind)
 }
 
+func TestValidate_ViewSourceTableMustExist(t *testing.T) {
+	dbs := []DatabaseSpec{{
+		Name:   "posthog",
+		Tables: []TableSpec{mkTable("events_local", EngineMergeTree{})},
+		Views: []ViewSpec{
+			{Name: "v", Query: "SELECT team_id FROM posthog.nonexistent"},
+		},
+	}}
+	errs := Validate(dbs, ParseSkipSet(""))
+	require.Len(t, errs, 1)
+	assert.Equal(t, ObjectRef{Database: "posthog", Name: "v"}, errs[0].Object)
+	assert.Equal(t, ObjectRef{Database: "posthog", Name: "nonexistent"}, errs[0].Missing)
+	assert.Equal(t, DepViewSource, errs[0].Kind)
+}
+
+func TestValidate_ViewSourceTableInSameSchema(t *testing.T) {
+	dbs := []DatabaseSpec{{
+		Name:   "posthog",
+		Tables: []TableSpec{mkTable("events_local", EngineMergeTree{})},
+		Views: []ViewSpec{
+			{Name: "v", Query: "SELECT team_id FROM posthog.events_local"},
+		},
+	}}
+	assert.Empty(t, Validate(dbs, ParseSkipSet("")))
+}
+
+func TestValidate_ViewSkipByName(t *testing.T) {
+	dbs := []DatabaseSpec{{
+		Name: "posthog",
+		Views: []ViewSpec{
+			{Name: "v", Query: "SELECT 1 FROM posthog.missing"},
+		},
+	}}
+	assert.Empty(t, Validate(dbs, ParseSkipSet("v")))
+}
+
+func TestValidate_ViewCTENameNotASource(t *testing.T) {
+	dbs := []DatabaseSpec{{
+		Name:   "posthog",
+		Tables: []TableSpec{mkTable("events_local", EngineMergeTree{})},
+		Views: []ViewSpec{
+			{Name: "v", Query: "WITH stats AS (SELECT team_id FROM posthog.events_local) SELECT * FROM stats"},
+		},
+	}}
+	assert.Empty(t, Validate(dbs, ParseSkipSet("")))
+}
+
 func TestValidate_MissingDistributedRemote(t *testing.T) {
 	dbs := []DatabaseSpec{
 		mkDBMixed("posthog",

--- a/test/introspection_live_test.go
+++ b/test/introspection_live_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/posthog/chschema/gen/chschema_v1"
 	"github.com/posthog/chschema/internal/introspection"
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
 	"github.com/posthog/chschema/internal/sqlgen"
 	"github.com/posthog/chschema/internal/utils"
 	"github.com/posthog/chschema/test/testhelpers"
@@ -413,6 +414,20 @@ func TestLive_Introspection_AllStatements(t *testing.T) {
 					case "View":
 						found := chschema_v1.FindViewByName(state.Views, objectName)
 						require.NotNil(t, found, "View '%s' should be found after introspection", objectName)
+
+						// Also assert the new hcl-loader path captures the view
+						// (this is the path consumed by `hclexp introspect`).
+						hclState, err := hclload.Introspect(ctx, conn, dbName)
+						require.NoError(t, err, "hcl introspect for View assertion")
+						var v *hclload.ViewSpec
+						for i := range hclState.Views {
+							if hclState.Views[i].Name == objectName {
+								v = &hclState.Views[i]
+								break
+							}
+						}
+						require.NotNil(t, v, "view %q should be in hcl introspection result", objectName)
+						require.NotEmpty(t, v.Query, "view query must be captured")
 					case "Dictionary":
 						var found bool
 						for _, d := range state.Dictionaries {


### PR DESCRIPTION
## Why

`hclexp introspect` against PostHog's production schema silently skipped 17 plain (non-materialized) views — they round-tripped nowhere. With them missing, diff can't enforce their existence, sqlgen can't recreate them, and validate can't check their dependencies. Closing this gap is the precondition for using `hclexp` as a complete schema source-of-truth.

## What

Adds full first-class support for plain `view` blocks: HCL surface, introspection, diff, sqlgen, validation, change-set rendering, docs.

### HCL surface

```hcl
database "posthog" {
  view "team_event_counts" {
    query = "SELECT team_id, count() AS n FROM posthog.events GROUP BY team_id"

    column_aliases = ["team_id", "n"]   // optional

    sql_security = "definer"            // optional: definer | invoker | none
    definer      = "alice"              // required iff sql_security == "definer" with a named user

    cluster = "posthog"                 // optional ON CLUSTER
    comment = "team-level event counter"
  }
}
```

| Attribute        | Required | Maps to |
|------------------|----------|---------|
| `query`          | yes      | `AS SELECT ...` body (verbatim) |
| `column_aliases` | no       | `CREATE VIEW v (a, b, ...) AS ...` |
| `sql_security`   | no       | `SQL SECURITY { DEFINER \| INVOKER \| NONE }` (lowercase canonical; case-insensitive on parse) |
| `definer`        | no       | `DEFINER = <user>` / `current_user`; only legal with `sql_security = "definer"` |
| `cluster`        | no       | `ON CLUSTER` |
| `comment`        | no       | `COMMENT '...'` |

Live View / Refreshable MV / Window View are rejected at introspection (they parse into different AST types, never hitting the `CreateView` arm).

### Diff semantics

| What changed                                                | Action                                                             |
| ----------------------------------------------------------- | ------------------------------------------------------------------ |
| `query` only                                                | `ALTER TABLE db.name MODIFY QUERY <new>`                           |
| `comment` only                                              | `ALTER TABLE db.name MODIFY COMMENT '<new>'`                       |
| `column_aliases` / `sql_security` / `definer` / `cluster`   | flagged unsafe → DROP + CREATE                                     |
| Added                                                       | `CREATE VIEW …` (full form, all clauses optional)                  |
| Dropped                                                     | `DROP VIEW db.name`                                                |

DDL ordering: views are CREATEd after their source tables, DROPped before them — same dependency-aware ordering as MVs.

### Validation

`hclexp validate` now walks views: parses each `query`, requires every referenced table to be declared in the loaded schema. CTE names are filtered out (the existing `ExtractReferencedTables` already handles this). The `-skip-validation=<name,...>` flag honours view names.

## Implementation

Six packages touched in one consistent slice, one commit per layer:

| Layer | File | Commit |
|---|---|---|
| Type | `types.go` | `feat(hcl): ViewSpec type + DatabaseSpec.Views field` |
| HCL parse-time validation | `resolver.go` + `parser_test.go` | `feat(hcl): validate view sql_security enum + definer pairing` |
| Cross-layer redeclare | `layers.go` | `feat(hcl): reject cross-layer view redeclaration` |
| Canonical HCL emission | `dump.go` | `feat(hcl): canonical view block emission` |
| Introspection | `introspect.go` | `feat(hcl): introspect plain views` |
| Diff | `diff.go` | `feat(hcl): diff plain views` |
| Sqlgen | `sqlgen.go` | `feat(hcl): emit CREATE/DROP/ALTER DDL for plain views` |
| Validate | `validate.go` | `feat(hcl): validate plain view source dependencies` |
| Ordering tests | `sqlgen_test.go` | `test(hcl): assert view DDL ordering vs source tables` |
| Change-set rendering | `cmd/hclexp/hclexp.go` | `feat(hclexp): render +/-/~ view lines in change-set output` |
| Live introspection | `test/introspection_live_test.go` | `test(live): assert hcl ViewSpec captured by introspection` |
| Docs | `docs/README.hcl.md` + `README.md` | `docs: view block reference + supported-features update` |

Plus the design spec at `docs/superpowers/specs/2026-05-28-view-support.md` and the implementation plan at `docs/superpowers/plans/2026-05-28-view-support.md`.

## Chparser workaround

The current chparser fork (`refactor-visitor` branch) rejects three clauses on `CREATE VIEW` that ClickHouse accepts: `COMMENT`, `DEFINER`, `SQL SECURITY`. Filed upstream as [orian/clickhouse-sql-parser#6](https://github.com/orian/clickhouse-sql-parser/issues/6). The introspector calls `stripViewExtras` first to pull those clauses off via regex, then parses the cleaned statement; the captured values are stitched back onto the `ViewSpec` via `buildViewFromCreateView`. Once #6 lands the workaround can be removed (the regex-extract path is keyed off `cv.Comment != nil` etc., so the AST-fixed path takes precedence automatically).

## Verification

- `go test ./internal/... ./config ./cmd/... ./test/... ` → **418 pass**.
- `ENABLE_CLICKHOUSE=1 go test ./test/...` → **179 pass** against ClickHouse 26.5; all 17 `View/*` subtests in `TestLive_Introspection_AllStatements` round-trip.
- `gofmt -s -l .` clean, `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
