### PR TITLE
feat(hcl): ReplicatedSummingMergeTree engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ attributes:
 | `replacing_merge_tree`              | `version_column`, `is_deleted_column` |
 | `replicated_replacing_merge_tree`   | `zoo_path`, `replica_name`, `version_column`, `is_deleted_column` |
 | `summing_merge_tree`                | `sum_columns` |
+| `replicated_summing_merge_tree`     | `zoo_path`, `replica_name`, `sum_columns` |
 | `collapsing_merge_tree`             | `sign_column` |
 | `replicated_collapsing_merge_tree`  | `zoo_path`, `replica_name`, `sign_column` |
 | `aggregating_merge_tree`            | — |

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -109,6 +109,7 @@ attributes depend on the kind.
 | `replacing_merge_tree`                | —                                                  | `version_column`       |
 | `replicated_replacing_merge_tree`     | `zoo_path`, `replica_name`                         | `version_column`       |
 | `summing_merge_tree`                  | —                                                  | `sum_columns = [...]`  |
+| `replicated_summing_merge_tree`       | `zoo_path`, `replica_name`                         | `sum_columns = [...]`  |
 | `collapsing_merge_tree`               | `sign_column`                                      | —                      |
 | `replicated_collapsing_merge_tree`    | `zoo_path`, `replica_name`, `sign_column`          | —                      |
 | `aggregating_merge_tree`              | —                                                  | —                      |

--- a/docs/superpowers/plans/2026-05-28-replicated-summing-merge-tree.md
+++ b/docs/superpowers/plans/2026-05-28-replicated-summing-merge-tree.md
@@ -1,0 +1,586 @@
+# ReplicatedSummingMergeTree Engine Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `ReplicatedSummingMergeTree` to hclexp's supported engine list so PostHog's `posthog.sharded_distinct_id_usage` table round-trips.
+
+**Architecture:** New `EngineReplicatedSummingMergeTree` Go struct following the existing one-type-per-engine convention; mirrors `EngineReplicatedReplacingMergeTree` field-by-field with `SumColumns` instead of `VersionColumn`. Wire it into HCL decode, two introspection switches, sqlgen, plus tests and docs.
+
+**Tech Stack:** Go 1.26, `hashicorp/hcl/v2` (gohcl), `clickhouse-sql-parser` fork (chparser).
+
+**Spec:** [`docs/superpowers/specs/2026-05-28-replicated-summing-merge-tree.md`](../specs/2026-05-28-replicated-summing-merge-tree.md)
+
+**File Map:**
+
+| File | What changes |
+|---|---|
+| `internal/loader/hcl/engines.go` | New `EngineReplicatedSummingMergeTree` type + `Kind()`; new `case` in `DecodeEngine`. |
+| `internal/loader/hcl/introspect.go` | New `case "ReplicatedSummingMergeTree"` in `engineFromAST` (~line 487); new `case strings.HasPrefix(decl, "ReplicatedSummingMergeTree")` in the engine-from-text path (~line 723). |
+| `internal/loader/hcl/sqlgen.go` | New `case EngineReplicatedSummingMergeTree:` in `engineSQL` (~line 545). |
+| `internal/loader/hcl/engines_test.go` | HCL decode round-trip test. |
+| `internal/loader/hcl/sqlgen_test.go` | DDL emission tests (with and without `sum_columns`). |
+| `internal/loader/hcl/introspect_test.go` | AST-side round-trip from a CREATE TABLE string. |
+| `test/testdata/posthog-create-statements/ReplicatedSummingMergeTree/sharded_distinct_id_usage.sql` | New live-test fixture. |
+| `docs/README.hcl.md` | Supported engines paragraph or table. |
+| `README.md` | Supported engines table. |
+| `CLAUDE.md` (if present) | Supported engines bullet list. |
+
+---
+
+### Task 1: Engine type + HCL decode case
+
+**Files:**
+- Modify: `internal/loader/hcl/engines.go`
+- Modify: `internal/loader/hcl/engines_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/loader/hcl/engines_test.go`, find the existing test for `EngineReplicatedReplacingMergeTree` (search `replicated_replacing_merge_tree`). Right after it, add:
+
+```go
+func TestDecodeEngine_ReplicatedSummingMergeTree(t *testing.T) {
+	hcl := `
+table "t" {
+  column "id" { type = "UInt64" }
+  engine "replicated_summing_merge_tree" {
+    zoo_path     = "/clickhouse/tables/{shard}/t"
+    replica_name = "{replica}"
+    sum_columns  = ["count"]
+  }
+}`
+	t.Run("with sum_columns", func(t *testing.T) {
+		e := decodeTableEngine(t, hcl)
+		got, ok := e.(EngineReplicatedSummingMergeTree)
+		require.True(t, ok, "expected EngineReplicatedSummingMergeTree, got %T", e)
+		assert.Equal(t, "/clickhouse/tables/{shard}/t", got.ZooPath)
+		assert.Equal(t, "{replica}", got.ReplicaName)
+		assert.Equal(t, []string{"count"}, got.SumColumns)
+		assert.Equal(t, "replicated_summing_merge_tree", got.Kind())
+	})
+
+	t.Run("without sum_columns", func(t *testing.T) {
+		hcl := `
+table "t" {
+  column "id" { type = "UInt64" }
+  engine "replicated_summing_merge_tree" {
+    zoo_path     = "/clickhouse/tables/{shard}/t"
+    replica_name = "{replica}"
+  }
+}`
+		e := decodeTableEngine(t, hcl)
+		got, ok := e.(EngineReplicatedSummingMergeTree)
+		require.True(t, ok, "expected EngineReplicatedSummingMergeTree, got %T", e)
+		assert.Empty(t, got.SumColumns)
+	})
+}
+```
+
+If `decodeTableEngine` doesn't exist in `engines_test.go`, search for the helper the existing replicated tests use. Most likely it's an inline shape: parse the HCL fragment via `hclparse.NewParser().ParseHCL(...)` then `gohcl.DecodeBody` into a `TableSpec` then call `DecodeEngine` on `tbl.Engine`. Reuse whatever helper the closest sibling test uses; if there is none, write a small `decodeTableEngine(t, src string) Engine` helper at the top of the file:
+
+```go
+func decodeTableEngine(t *testing.T, src string) Engine {
+	t.Helper()
+	p := hclparse.NewParser()
+	f, diags := p.ParseHCL([]byte(src), "test.hcl")
+	require.False(t, diags.HasErrors(), "parse: %v", diags)
+	var spec struct {
+		Tables []TableSpec `hcl:"table,block"`
+	}
+	diags = gohcl.DecodeBody(f.Body, nil, &spec)
+	require.False(t, diags.HasErrors(), "decode: %v", diags)
+	require.Len(t, spec.Tables, 1)
+	require.NotNil(t, spec.Tables[0].Engine)
+	decoded, err := DecodeEngine(spec.Tables[0].Engine)
+	require.NoError(t, err)
+	return decoded
+}
+```
+
+(Required imports: `"github.com/hashicorp/hcl/v2/hclparse"` and `"github.com/hashicorp/hcl/v2/gohcl"`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```
+go test ./internal/loader/hcl -run TestDecodeEngine_ReplicatedSummingMergeTree -v
+```
+
+Expected: FAIL — `EngineReplicatedSummingMergeTree` undefined.
+
+- [ ] **Step 3: Add the type**
+
+In `internal/loader/hcl/engines.go`, immediately after the existing `EngineSummingMergeTree` block (line 42-46), insert:
+
+```go
+type EngineReplicatedSummingMergeTree struct {
+	ZooPath     string   `hcl:"zoo_path"`
+	ReplicaName string   `hcl:"replica_name"`
+	SumColumns  []string `hcl:"sum_columns,optional"`
+}
+
+func (EngineReplicatedSummingMergeTree) Kind() string {
+	return "replicated_summing_merge_tree"
+}
+```
+
+- [ ] **Step 4: Add the DecodeEngine case**
+
+In the same file, find the `case "replicated_replacing_merge_tree"` arm in `DecodeEngine`. The `case "summing_merge_tree"` arm should be nearby — typically right after. Add a new arm:
+
+```go
+case "replicated_summing_merge_tree":
+	var e EngineReplicatedSummingMergeTree
+	diags = gohcl.DecodeBody(spec.Body, nil, &e)
+	target = e
+```
+
+Place it right after the `summing_merge_tree` case so it's grouped with its non-replicated sibling.
+
+- [ ] **Step 5: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestDecodeEngine_ReplicatedSummingMergeTree -v
+```
+
+Expected: both subtests PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/loader/hcl/engines.go internal/loader/hcl/engines_test.go
+git commit -m "feat(hcl): EngineReplicatedSummingMergeTree type + HCL decode
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: SQL generation
+
+**Files:**
+- Modify: `internal/loader/hcl/sqlgen.go`
+- Modify: `internal/loader/hcl/sqlgen_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `internal/loader/hcl/sqlgen_test.go`, search for `EngineReplicatedAggregatingMergeTree` to find where existing replicated-engine sqlgen tests live. Add right after them:
+
+```go
+func TestSQLGen_Engine_ReplicatedSummingMergeTree(t *testing.T) {
+	t.Run("with sum_columns", func(t *testing.T) {
+		clause, extra := engineSQL(EngineReplicatedSummingMergeTree{
+			ZooPath:     "/clickhouse/tables/{shard}/distinct_id_usage",
+			ReplicaName: "{replica}",
+			SumColumns:  []string{"count"},
+		})
+		assert.Equal(t, "ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/distinct_id_usage', '{replica}', (count))", clause)
+		assert.Nil(t, extra)
+	})
+
+	t.Run("without sum_columns", func(t *testing.T) {
+		clause, extra := engineSQL(EngineReplicatedSummingMergeTree{
+			ZooPath:     "/clickhouse/tables/{shard}/distinct_id_usage",
+			ReplicaName: "{replica}",
+		})
+		assert.Equal(t, "ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/distinct_id_usage', '{replica}')", clause)
+		assert.Nil(t, extra)
+	})
+
+	t.Run("with multiple sum_columns", func(t *testing.T) {
+		clause, extra := engineSQL(EngineReplicatedSummingMergeTree{
+			ZooPath:     "/zk",
+			ReplicaName: "r",
+			SumColumns:  []string{"a", "b"},
+		})
+		assert.Equal(t, "ReplicatedSummingMergeTree('/zk', 'r', (a, b))", clause)
+		assert.Nil(t, extra)
+	})
+}
+```
+
+The tuple-wrapping convention `(a, b)` mirrors the existing `EngineSummingMergeTree` emission (`sqlgen.go:535`), which is the ClickHouse-native form for a `Tuple` columns argument.
+
+- [ ] **Step 2: Run the tests**
+
+```
+go test ./internal/loader/hcl -run TestSQLGen_Engine_ReplicatedSummingMergeTree -v
+```
+
+Expected: FAIL — `engineSQL` falls through default for the unknown type.
+
+- [ ] **Step 3: Add the sqlgen arm**
+
+In `internal/loader/hcl/sqlgen.go`, find the existing `case EngineReplicatedAggregatingMergeTree:` (around line 544). Add a new arm directly after the existing `EngineSummingMergeTree` arm (around line 533–537) so the replicated/non-replicated pair stays together. The full insertion:
+
+```go
+case EngineReplicatedSummingMergeTree:
+	if len(v.SumColumns) > 0 {
+		return fmt.Sprintf("ReplicatedSummingMergeTree('%s', '%s', (%s))", v.ZooPath, v.ReplicaName, strings.Join(v.SumColumns, ", ")), nil
+	}
+	return fmt.Sprintf("ReplicatedSummingMergeTree('%s', '%s')", v.ZooPath, v.ReplicaName), nil
+```
+
+- [ ] **Step 4: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestSQLGen_Engine_ReplicatedSummingMergeTree -v
+```
+
+Expected: all three subtests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add internal/loader/hcl/sqlgen.go internal/loader/hcl/sqlgen_test.go
+git commit -m "feat(hcl): emit ReplicatedSummingMergeTree DDL
+
+Mirrors EngineSummingMergeTree's tuple-wrapped column emission;
+zoo_path and replica_name are quoted string literals, sum_columns
+are bare column identifiers inside a Tuple.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Introspection — AST path
+
+**Files:**
+- Modify: `internal/loader/hcl/introspect.go`
+- Modify: `internal/loader/hcl/introspect_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/loader/hcl/introspect_test.go`, search for `ReplicatedReplacingMergeTree` to find the existing replicated-engine introspection tests. Right after the closest one, add:
+
+```go
+func TestEngineFromAST_ReplicatedSummingMergeTree(t *testing.T) {
+	t.Run("with sum_columns", func(t *testing.T) {
+		const create = `CREATE TABLE db.t (` + "`id`" + ` UInt64, ` + "`count`" + ` UInt64) ` +
+			`ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/t', '{replica}', count) ` +
+			`ORDER BY id`
+		ts, err := buildTableFromCreateSQL(create)
+		require.NoError(t, err)
+		require.NotNil(t, ts.Engine)
+		got, ok := ts.Engine.Decoded.(EngineReplicatedSummingMergeTree)
+		require.True(t, ok, "expected EngineReplicatedSummingMergeTree, got %T", ts.Engine.Decoded)
+		assert.Equal(t, "/clickhouse/tables/{shard}/t", got.ZooPath)
+		assert.Equal(t, "{replica}", got.ReplicaName)
+		assert.Equal(t, []string{"count"}, got.SumColumns)
+	})
+
+	t.Run("without sum_columns", func(t *testing.T) {
+		const create = `CREATE TABLE db.t (` + "`id`" + ` UInt64) ` +
+			`ENGINE = ReplicatedSummingMergeTree('/zk', 'r') ` +
+			`ORDER BY id`
+		ts, err := buildTableFromCreateSQL(create)
+		require.NoError(t, err)
+		got := ts.Engine.Decoded.(EngineReplicatedSummingMergeTree)
+		assert.Equal(t, "/zk", got.ZooPath)
+		assert.Equal(t, "r", got.ReplicaName)
+		assert.Empty(t, got.SumColumns)
+	})
+}
+```
+
+If `buildTableFromCreateSQL` isn't directly accessible from tests, use whatever helper the existing `ReplicatedReplacingMergeTree` introspect tests use to drive `engineFromAST` (likely the same `buildTableFromCreateSQL` since it's exported at package scope).
+
+- [ ] **Step 2: Run the tests**
+
+```
+go test ./internal/loader/hcl -run TestEngineFromAST_ReplicatedSummingMergeTree -v
+```
+
+Expected: FAIL — the AST switch returns `unsupported engine: ReplicatedSummingMergeTree`.
+
+- [ ] **Step 3: Add the case to the AST switch**
+
+In `internal/loader/hcl/introspect.go`, find the existing `case "ReplicatedAggregatingMergeTree":` arm (around line 483). Insert a new arm directly after the existing `SummingMergeTree` case (around line 469-470) so the replicated/non-replicated pair stays together:
+
+```go
+case "ReplicatedSummingMergeTree":
+	if len(params) < 2 {
+		return nil, nil, fmt.Errorf("ReplicatedSummingMergeTree needs at least (zoo_path, replica_name[, sum_columns...])")
+	}
+	ee := EngineReplicatedSummingMergeTree{ZooPath: params[0], ReplicaName: params[1]}
+	if len(params) > 2 {
+		ee.SumColumns = params[2:]
+	}
+	return ee, allSettings, nil
+```
+
+- [ ] **Step 4: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestEngineFromAST_ReplicatedSummingMergeTree -v
+```
+
+Expected: both subtests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add internal/loader/hcl/introspect.go internal/loader/hcl/introspect_test.go
+git commit -m "feat(hcl): introspect ReplicatedSummingMergeTree (AST path)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Introspection — text-fallback path
+
+**Files:**
+- Modify: `internal/loader/hcl/introspect.go`
+- Modify: `internal/loader/hcl/introspect_test.go`
+
+- [ ] **Step 1: Find the second engine-parse code path**
+
+```
+grep -n "strings.HasPrefix(decl,\s*\"Replicated" internal/loader/hcl/introspect.go
+```
+
+This is the text-based fallback (~line 692 for ReplicatedReplacingMergeTree, ~line 705 for ReplicatedCollapsingMergeTree, ~line 714 for ReplicatedAggregatingMergeTree). It's the path that runs when the AST is unavailable. SummingMergeTree itself uses `parseSummingMergeTreeHCL` (line 733-734).
+
+- [ ] **Step 2: Write the failing test**
+
+The text-fallback path isn't always trivial to exercise directly — look for an existing test that hits `case strings.HasPrefix(decl, "ReplicatedAggregatingMergeTree")` to find the entry function (probably `parseEngineFromHCL` or similar — search:
+
+```
+grep -n "func .*\(decl string\) (Engine\|parseEngine" internal/loader/hcl/introspect.go
+```
+
+Mirror that test's shape:
+
+```go
+func TestParseEngineFromHCL_ReplicatedSummingMergeTree(t *testing.T) {
+	t.Run("with sum_columns", func(t *testing.T) {
+		e, err := <parseFunc>(`ReplicatedSummingMergeTree('/zk', 'r', count)`)
+		require.NoError(t, err)
+		got := e.(EngineReplicatedSummingMergeTree)
+		assert.Equal(t, "/zk", got.ZooPath)
+		assert.Equal(t, "r", got.ReplicaName)
+		assert.Equal(t, []string{"count"}, got.SumColumns)
+	})
+
+	t.Run("without sum_columns", func(t *testing.T) {
+		e, err := <parseFunc>(`ReplicatedSummingMergeTree('/zk', 'r')`)
+		require.NoError(t, err)
+		got := e.(EngineReplicatedSummingMergeTree)
+		assert.Empty(t, got.SumColumns)
+	})
+}
+```
+
+Replace `<parseFunc>` with the actual function name found above. If the parse function is unexported and unreached from a test, skip this task's test file edit and rely on Task 5's live test to exercise the path.
+
+- [ ] **Step 3: Run the test**
+
+```
+go test ./internal/loader/hcl -run TestParseEngineFromHCL_ReplicatedSummingMergeTree -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Add the case**
+
+In `internal/loader/hcl/introspect.go`, immediately after the `case strings.HasPrefix(decl, "ReplicatedAggregatingMergeTree"):` arm (around line 714-722), insert:
+
+```go
+case strings.HasPrefix(decl, "ReplicatedSummingMergeTree"):
+	p, err := extractEngineParams(decl)
+	if err != nil {
+		return nil, err
+	}
+	if len(p) < 2 {
+		return nil, fmt.Errorf("ReplicatedSummingMergeTree needs at least (zoo_path, replica_name[, sum_columns...]); got %v", p)
+	}
+	e := EngineReplicatedSummingMergeTree{ZooPath: p[0], ReplicaName: p[1]}
+	if len(p) > 2 {
+		e.SumColumns = p[2:]
+	}
+	return e, nil
+```
+
+This must be ordered BEFORE the existing `case strings.HasPrefix(decl, "SummingMergeTree"):` arm — Go's `case` evaluation in a `switch true {}` is sequential and `"ReplicatedSummingMergeTree"` also has prefix `"R"` matching the Replicated checks above. Verify by viewing the switch structure around line 705-734.
+
+The `extractEngineParams` helper already handles `(arg1, arg2, ...)` tokenisation — same path Replacing/Collapsing/Aggregating use.
+
+- [ ] **Step 5: Re-run**
+
+```
+go test ./internal/loader/hcl -run TestParseEngineFromHCL_ReplicatedSummingMergeTree -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/loader/hcl/introspect.go internal/loader/hcl/introspect_test.go
+git commit -m "feat(hcl): introspect ReplicatedSummingMergeTree (text-fallback path)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Live fixture + integration test
+
+**Files:**
+- Create: `test/testdata/posthog-create-statements/ReplicatedSummingMergeTree/sharded_distinct_id_usage.sql`
+
+- [ ] **Step 1: Verify the live-test discovery walks all engine subdirectories**
+
+```
+grep -n "filepath.Walk\|posthog-create-statements" test/introspection_live_test.go | head -3
+```
+
+`TestLive_Introspection_AllStatements` walks every subdirectory of `test/testdata/posthog-create-statements/`, so adding a new directory + `.sql` file automatically registers a new subtest under `ReplicatedSummingMergeTree`. No test code edits required for this task — only a fixture.
+
+- [ ] **Step 2: Write the fixture**
+
+Use the production-shape statement. If the local ClickHouse is running with the production schema, capture it via:
+
+```
+docker exec posthog-clickhouse-1 clickhouse-client --query "SELECT create_table_query FROM system.tables WHERE database = 'posthog' AND name = 'sharded_distinct_id_usage'"
+```
+
+Replace the database prefix from `posthog` to `default` (the fixture convention — the test runner rewrites `default` to the per-test database).
+
+If the production schema isn't available, use this hand-rolled fixture that mirrors PostHog's shape:
+
+`test/testdata/posthog-create-statements/ReplicatedSummingMergeTree/sharded_distinct_id_usage.sql`:
+
+```
+CREATE TABLE default.sharded_distinct_id_usage (`team_id` Int64, `distinct_id` String, `count` UInt64) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/posthog.distinct_id_usage', '{replica}', (count)) ORDER BY (team_id, distinct_id) SETTINGS index_granularity = 8192
+```
+
+- [ ] **Step 3: Run the live test**
+
+Start the docker compose ClickHouse if not running:
+
+```
+docker compose up -d --wait
+```
+
+Then:
+
+```
+ENABLE_CLICKHOUSE=1 go test ./test -run 'TestLive_Introspection_AllStatements/ReplicatedSummingMergeTree' -v 2>&1 | tail -10
+```
+
+Expected: `--- PASS: TestLive_Introspection_AllStatements/ReplicatedSummingMergeTree/sharded_distinct_id_usage`.
+
+- [ ] **Step 4: Run the full live suite**
+
+```
+ENABLE_CLICKHOUSE=1 go test -count=1 ./test/...
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add test/testdata/posthog-create-statements/ReplicatedSummingMergeTree/
+git commit -m "test(live): ReplicatedSummingMergeTree fixture (sharded_distinct_id_usage)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Docs
+
+**Files:**
+- Modify: `docs/README.hcl.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md` (only if it exists at repo root)
+
+- [ ] **Step 1: Update README.md supported-engines table**
+
+```
+grep -n "ReplicatedAggregatingMergeTree\|ReplicatedReplacingMergeTree\|ReplicatedCollapsingMergeTree" README.md
+```
+
+Find the supported-engines table or list (most likely in a "Supported Table Engines" subsection or "Engine blocks" reference table). Add a row/entry for `replicated_summing_merge_tree` between the existing `summing_merge_tree` and `replicated_collapsing_merge_tree` rows (or following the alphabetical/family-grouping convention that's already in place).
+
+If the table has columns "Kind | Attributes", the new row is:
+
+```
+| `replicated_summing_merge_tree` | `zoo_path`, `replica_name`, `sum_columns` |
+```
+
+- [ ] **Step 2: Update docs/README.hcl.md supported-engines list**
+
+```
+grep -n "summing_merge_tree\|replicated_replacing_merge_tree" docs/README.hcl.md
+```
+
+Find the engine list/reference. Add `replicated_summing_merge_tree` in the same family-grouped position. If the doc enumerates ClickHouse engine syntax round-trips, also add:
+
+```
+- `engine "replicated_summing_merge_tree" { zoo_path = "...", replica_name = "...", sum_columns = ["a", "b"] }`
+  → `ENGINE = ReplicatedSummingMergeTree('zoo_path', 'replica_name', (a, b))`
+```
+
+- [ ] **Step 3: Update CLAUDE.md (if present)**
+
+```
+test -f CLAUDE.md && grep -n "ReplicatedAggregating\|ReplicatedReplacing" CLAUDE.md
+```
+
+If CLAUDE.md exists and lists supported engines, add `ReplicatedSummingMergeTree` to the list in family-grouped order. If it doesn't exist or doesn't enumerate engines, skip this step.
+
+- [ ] **Step 4: Commit**
+
+```
+git add docs/README.hcl.md README.md $(ls CLAUDE.md 2>/dev/null)
+git commit -m "docs: list ReplicatedSummingMergeTree as a supported engine
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Verification + push
+
+- [ ] **Step 1: Run the full test suite**
+
+```
+go test ./internal/... ./config ./cmd/... ./test/...
+```
+
+Expected: all green.
+
+- [ ] **Step 2: gofmt / go vet**
+
+```
+gofmt -s -l . && echo "fmt clean"
+go vet ./...
+```
+
+Expected: `fmt clean` and no vet issues.
+
+- [ ] **Step 3: Confirm coverage in the live suite**
+
+```
+ENABLE_CLICKHOUSE=1 go test -count=1 -v ./test -run 'TestLive_Introspection_AllStatements/ReplicatedSummingMergeTree' 2>&1 | tail -5
+```
+
+Expected: PASS for `sharded_distinct_id_usage`.
+
+- [ ] **Step 4: Push the branch**
+
+This task lives on the view-support worktree (the next PR can stack on top). If a separate branch is preferred, the engineer running this plan should resolve before push. Otherwise:
+
+```
+git push -u origin HEAD
+```
+
+- [ ] **Step 5: STOP — pause for PR creation/review**
+
+Open the PR via `gh pr create` or the GitHub UI. The PR body should call out:
+- Single new replicated-engine variant; fills the only gap in the MergeTree pair list.
+- Production fixture `sharded_distinct_id_usage` round-trips.
+- No infrastructure or external dependency changes.

--- a/docs/superpowers/specs/2026-05-28-replicated-summing-merge-tree.md
+++ b/docs/superpowers/specs/2026-05-28-replicated-summing-merge-tree.md
@@ -1,0 +1,116 @@
+# ReplicatedSummingMergeTree Engine Support — Design Spec
+
+**Date:** 2026-05-28
+**Status:** Approved, ready for implementation
+
+## Motivation
+
+`hclexp introspect` against PostHog's production schema fails on one table — `posthog.sharded_distinct_id_usage` — because its `ReplicatedSummingMergeTree` engine is not modelled by hclexp. It's the only missing replicated/non-replicated pair in the MergeTree family: ReplicatedReplacing, ReplicatedCollapsing, ReplicatedAggregating, and `ReplicatedMergeTree` itself are all supported; the Summing variant was overlooked.
+
+This is a small, mechanical extension that follows the exact pattern of the four existing pairs. No new design decisions — just filling the gap.
+
+## Surface
+
+New `EngineReplicatedSummingMergeTree` type, registered as a sibling to the four existing replicated MergeTree types:
+
+```go
+type EngineReplicatedSummingMergeTree struct {
+    ZooPath     string   `hcl:"zoo_path"`
+    ReplicaName string   `hcl:"replica_name"`
+    SumColumns  []string `hcl:"sum_columns,optional"`
+}
+
+func (EngineReplicatedSummingMergeTree) Kind() string { return "replicated_summing_merge_tree" }
+```
+
+HCL block label: `"replicated_summing_merge_tree"`.
+
+```hcl
+table "sharded_distinct_id_usage" {
+  order_by = ["team_id", "distinct_id"]
+
+  column "team_id" { type = "Int64" }
+  column "distinct_id" { type = "String" }
+  column "count" { type = "UInt64" }
+
+  engine "replicated_summing_merge_tree" {
+    zoo_path     = "/clickhouse/tables/{shard}/distinct_id_usage"
+    replica_name = "{replica}"
+    sum_columns  = ["count"]   // optional; omit for the no-argument SummingMergeTree-style form
+  }
+}
+```
+
+ClickHouse syntax round-trip:
+
+| HCL                                                                                      | ClickHouse DDL                                                              |
+| ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `engine "replicated_summing_merge_tree" { zoo_path = "...", replica_name = "..." }`      | `ENGINE = ReplicatedSummingMergeTree('zk', 'replica')`                      |
+| `engine "replicated_summing_merge_tree" { zoo_path = ..., replica_name = ..., sum_columns = ["a", "b"] }` | `ENGINE = ReplicatedSummingMergeTree('zk', 'replica', a, b)`                |
+
+The optional `sum_columns` exactly mirrors the existing `EngineSummingMergeTree.SumColumns` field; identical handling.
+
+## Implementation
+
+Five touch points, one consistent slice. Each is a near-direct copy of the matching code path for an existing replicated/non-replicated pair (`EngineReplicatedReplacingMergeTree` and `EngineReplacingMergeTree` are the closest models).
+
+### 1. `internal/loader/hcl/engines.go`
+
+- Add the new struct + `Kind()` method directly after `EngineSummingMergeTree` (line 46), matching the position of `EngineReplicatedReplacingMergeTree` relative to `EngineReplacingMergeTree`.
+- Extend the `DecodeEngine` switch with a new `case "replicated_summing_merge_tree"` arm.
+
+### 2. `internal/loader/hcl/introspect.go`
+
+Two existing switch statements walk the `chparser.EngineExpr.Name` and need a new case each (line ~464 and ~700 — same pattern as `replicated_replacing_merge_tree` in both functions):
+
+```go
+case "ReplicatedSummingMergeTree":
+    if len(params) < 2 {
+        return nil, nil, fmt.Errorf("ReplicatedSummingMergeTree needs at least (zoo_path, replica_name)")
+    }
+    ee := EngineReplicatedSummingMergeTree{ZooPath: params[0], ReplicaName: params[1]}
+    if len(params) > 2 {
+        ee.SumColumns = params[2:]
+    }
+    return ee, allSettings, nil
+```
+
+The second occurrence (the simpler engineFromAST path around line 700) mirrors the structure of the `ReplicatedReplacingMergeTree` case there.
+
+### 3. `internal/loader/hcl/sqlgen.go`
+
+The `engineDDL` function (or equivalent — locate during impl) needs a new arm that emits:
+
+```go
+case EngineReplicatedSummingMergeTree:
+    parts := []string{quoteSQL(v.ZooPath), quoteSQL(v.ReplicaName)}
+    parts = append(parts, v.SumColumns...)
+    return fmt.Sprintf("ReplicatedSummingMergeTree(%s)", strings.Join(parts, ", "))
+```
+
+Mirrors how `EngineReplicatedReplacingMergeTree` is emitted (zoo_path + replica_name quoted, version_column unquoted; here sum_columns are unquoted column identifiers).
+
+### 4. Tests
+
+- **Unit (`engines_test.go`):** HCL decode round-trip — write HCL, decode to struct, check Kind/fields.
+- **Unit (`sqlgen_test.go`):** emit-and-compare for both with-and-without `sum_columns` shapes; assert the ClickHouse DDL is exactly correct.
+- **Unit (`introspect_test.go`):** parse a `CREATE TABLE … ENGINE = ReplicatedSummingMergeTree('zk', 'r', a, b)` string and assert the decoded `EngineReplicatedSummingMergeTree` matches.
+- **Live (`test/testdata/posthog-create-statements/ReplicatedSummingMergeTree/`):** new directory + at least one fixture (the real PostHog `sharded_distinct_id_usage`). The existing `TestLive_Introspection_AllStatements` discovery walks all directories automatically; the new fixture will round-trip via the default Table arm.
+
+### 5. Docs
+
+- `docs/README.hcl.md` "Supported Engines" table or list: add the new engine row, mirroring the `ReplicatedReplacingMergeTree` entry.
+- `README.md` supported-engines section (if there is one): same addition.
+- `CLAUDE.md`: update the supported-engines bullet list to include `ReplicatedSummingMergeTree`.
+
+## Verification
+
+- `go test ./internal/loader/hcl/... ./test/...` → green.
+- `go test ./test -run TestLive_Introspection_AllStatements/ReplicatedSummingMergeTree -clickhouse` → pass against the new fixture.
+- Re-introspecting the local PostHog database (when restarted) no longer logs `unsupported engine: ReplicatedSummingMergeTree`.
+
+## Out of scope
+
+- Refactoring the other replicated engines to share Go types (the existing one-type-per-engine convention stays).
+- Modelling `database_atomic_*` / `database_replicated` macros — unrelated.
+- Validation of zk_path uniqueness across tables — that's runtime ClickHouse behaviour, not schema-shape.

--- a/internal/loader/hcl/dump.go
+++ b/internal/loader/hcl/dump.go
@@ -156,6 +156,12 @@ func writeEngine(parent *hclwrite.Body, e Engine) {
 		if len(v.SumColumns) > 0 {
 			b.SetAttributeValue("sum_columns", stringList(v.SumColumns))
 		}
+	case EngineReplicatedSummingMergeTree:
+		b.SetAttributeValue("zoo_path", cty.StringVal(v.ZooPath))
+		b.SetAttributeValue("replica_name", cty.StringVal(v.ReplicaName))
+		if len(v.SumColumns) > 0 {
+			b.SetAttributeValue("sum_columns", stringList(v.SumColumns))
+		}
 	case EngineCollapsingMergeTree:
 		b.SetAttributeValue("sign_column", cty.StringVal(v.SignColumn))
 	case EngineReplicatedCollapsingMergeTree:

--- a/internal/loader/hcl/engines.go
+++ b/internal/loader/hcl/engines.go
@@ -45,6 +45,16 @@ type EngineSummingMergeTree struct {
 
 func (EngineSummingMergeTree) Kind() string { return "summing_merge_tree" }
 
+type EngineReplicatedSummingMergeTree struct {
+	ZooPath     string   `hcl:"zoo_path"`
+	ReplicaName string   `hcl:"replica_name"`
+	SumColumns  []string `hcl:"sum_columns,optional"`
+}
+
+func (EngineReplicatedSummingMergeTree) Kind() string {
+	return "replicated_summing_merge_tree"
+}
+
 type EngineCollapsingMergeTree struct {
 	SignColumn string `hcl:"sign_column"`
 }
@@ -162,6 +172,10 @@ func DecodeEngine(spec *EngineSpec) (Engine, error) {
 		target = e
 	case "summing_merge_tree":
 		var e EngineSummingMergeTree
+		diags = gohcl.DecodeBody(spec.Body, nil, &e)
+		target = e
+	case "replicated_summing_merge_tree":
+		var e EngineReplicatedSummingMergeTree
 		diags = gohcl.DecodeBody(spec.Body, nil, &e)
 		target = e
 	case "collapsing_merge_tree":

--- a/internal/loader/hcl/engines_test.go
+++ b/internal/loader/hcl/engines_test.go
@@ -42,6 +42,12 @@ func TestParseFile_AllEngineKinds(t *testing.T) {
 		SumColumns: []string{"a", "b"},
 	}, byName["t_summing_merge_tree"])
 
+	assert.Equal(t, EngineReplicatedSummingMergeTree{
+		ZooPath:     "/clickhouse/tables/{shard}/t_rsmt",
+		ReplicaName: "{replica}",
+		SumColumns:  []string{"a", "b"},
+	}, byName["t_replicated_summing_merge_tree"])
+
 	assert.Equal(t, EngineCollapsingMergeTree{
 		SignColumn: "sign",
 	}, byName["t_collapsing_merge_tree"])
@@ -98,6 +104,7 @@ func TestEngine_KindMethods(t *testing.T) {
 		{EngineReplacingMergeTree{}, "replacing_merge_tree"},
 		{EngineReplicatedReplacingMergeTree{}, "replicated_replacing_merge_tree"},
 		{EngineSummingMergeTree{}, "summing_merge_tree"},
+		{EngineReplicatedSummingMergeTree{}, "replicated_summing_merge_tree"},
 		{EngineCollapsingMergeTree{}, "collapsing_merge_tree"},
 		{EngineReplicatedCollapsingMergeTree{}, "replicated_collapsing_merge_tree"},
 		{EngineAggregatingMergeTree{}, "aggregating_merge_tree"},

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -364,6 +364,15 @@ func engineFromAST(e *chparser.EngineExpr) (Engine, map[string]string, error) {
 		return ee, allSettings, nil
 	case "SummingMergeTree":
 		return EngineSummingMergeTree{SumColumns: params}, allSettings, nil
+	case "ReplicatedSummingMergeTree":
+		if len(params) < 2 {
+			return nil, nil, fmt.Errorf("ReplicatedSummingMergeTree needs at least (zoo_path, replica_name[, sum_columns...])")
+		}
+		ee := EngineReplicatedSummingMergeTree{ZooPath: params[0], ReplicaName: params[1]}
+		if len(params) > 2 {
+			ee.SumColumns = params[2:]
+		}
+		return ee, allSettings, nil
 	case "CollapsingMergeTree":
 		if len(params) != 1 {
 			return nil, nil, fmt.Errorf("CollapsingMergeTree needs (sign_column)")
@@ -616,6 +625,19 @@ func ParseEngineString(engineFull string) (Engine, error) {
 			return nil, fmt.Errorf("ReplicatedAggregatingMergeTree needs (zoo_path, replica_name); got %v", p)
 		}
 		return EngineReplicatedAggregatingMergeTree{ZooPath: p[0], ReplicaName: p[1]}, nil
+	case strings.HasPrefix(decl, "ReplicatedSummingMergeTree"):
+		p, err := extractEngineParams(decl)
+		if err != nil {
+			return nil, err
+		}
+		if len(p) < 2 {
+			return nil, fmt.Errorf("ReplicatedSummingMergeTree needs at least (zoo_path, replica_name[, sum_columns...]); got %v", p)
+		}
+		e := EngineReplicatedSummingMergeTree{ZooPath: p[0], ReplicaName: p[1]}
+		if len(p) > 2 {
+			e.SumColumns = p[2:]
+		}
+		return e, nil
 	case strings.HasPrefix(decl, "ReplacingMergeTree"):
 		p, err := extractEngineParams(decl)
 		if err != nil {

--- a/internal/loader/hcl/introspect_test.go
+++ b/internal/loader/hcl/introspect_test.go
@@ -48,6 +48,18 @@ func TestParseEngineString(t *testing.T) {
 		},
 		{"summing_merge_tree_empty", "SummingMergeTree", EngineSummingMergeTree{}},
 		{
+			"replicated_summing_merge_tree",
+			"ReplicatedSummingMergeTree('/p', '{replica}', count) ORDER BY id",
+			EngineReplicatedSummingMergeTree{
+				ZooPath: "/p", ReplicaName: "{replica}", SumColumns: []string{"count"},
+			},
+		},
+		{
+			"replicated_summing_merge_tree_no_columns",
+			"ReplicatedSummingMergeTree('/p', '{replica}')",
+			EngineReplicatedSummingMergeTree{ZooPath: "/p", ReplicaName: "{replica}"},
+		},
+		{
 			"collapsing_merge_tree",
 			"CollapsingMergeTree(sign) ORDER BY id",
 			EngineCollapsingMergeTree{SignColumn: "sign"},

--- a/internal/loader/hcl/sqlgen.go
+++ b/internal/loader/hcl/sqlgen.go
@@ -472,6 +472,11 @@ func engineSQL(e Engine) (clause string, extraSettings map[string]string) {
 			return fmt.Sprintf("SummingMergeTree((%s))", strings.Join(v.SumColumns, ", ")), nil
 		}
 		return "SummingMergeTree()", nil
+	case EngineReplicatedSummingMergeTree:
+		if len(v.SumColumns) > 0 {
+			return fmt.Sprintf("ReplicatedSummingMergeTree('%s', '%s', (%s))", v.ZooPath, v.ReplicaName, strings.Join(v.SumColumns, ", ")), nil
+		}
+		return fmt.Sprintf("ReplicatedSummingMergeTree('%s', '%s')", v.ZooPath, v.ReplicaName), nil
 	case EngineCollapsingMergeTree:
 		return fmt.Sprintf("CollapsingMergeTree(%s)", v.SignColumn), nil
 	case EngineReplicatedCollapsingMergeTree:

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -604,3 +604,34 @@ func TestSQLGen_Dictionary_DirectLayoutOmitsLifetime(t *testing.T) {
 	assert.NotContains(t, got, "LIFETIME", "direct layout must not emit LIFETIME")
 	assert.Contains(t, got, "LAYOUT(DIRECT())")
 }
+
+func TestSQLGen_Engine_ReplicatedSummingMergeTree(t *testing.T) {
+	t.Run("with sum_columns", func(t *testing.T) {
+		clause, extra := engineSQL(EngineReplicatedSummingMergeTree{
+			ZooPath:     "/clickhouse/tables/{shard}/distinct_id_usage",
+			ReplicaName: "{replica}",
+			SumColumns:  []string{"count"},
+		})
+		assert.Equal(t, "ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/distinct_id_usage', '{replica}', (count))", clause)
+		assert.Nil(t, extra)
+	})
+
+	t.Run("without sum_columns", func(t *testing.T) {
+		clause, extra := engineSQL(EngineReplicatedSummingMergeTree{
+			ZooPath:     "/clickhouse/tables/{shard}/distinct_id_usage",
+			ReplicaName: "{replica}",
+		})
+		assert.Equal(t, "ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/distinct_id_usage', '{replica}')", clause)
+		assert.Nil(t, extra)
+	})
+
+	t.Run("with multiple sum_columns", func(t *testing.T) {
+		clause, extra := engineSQL(EngineReplicatedSummingMergeTree{
+			ZooPath:     "/zk",
+			ReplicaName: "r",
+			SumColumns:  []string{"a", "b"},
+		})
+		assert.Equal(t, "ReplicatedSummingMergeTree('/zk', 'r', (a, b))", clause)
+		assert.Nil(t, extra)
+	})
+}

--- a/internal/loader/hcl/testdata/engines_all_kinds.hcl
+++ b/internal/loader/hcl/testdata/engines_all_kinds.hcl
@@ -35,6 +35,15 @@ database "posthog" {
     }
   }
 
+  table "t_replicated_summing_merge_tree" {
+    column "id" { type = "UUID" }
+    engine "replicated_summing_merge_tree" {
+      zoo_path     = "/clickhouse/tables/{shard}/t_rsmt"
+      replica_name = "{replica}"
+      sum_columns  = ["a", "b"]
+    }
+  }
+
   table "t_collapsing_merge_tree" {
     column "id" { type = "UUID" }
     engine "collapsing_merge_tree" {

--- a/test/introspection_live_test.go
+++ b/test/introspection_live_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/posthog/chschema/gen/chschema_v1"
 	"github.com/posthog/chschema/internal/introspection"
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
 	"github.com/posthog/chschema/internal/sqlgen"
 	"github.com/posthog/chschema/internal/utils"
 	"github.com/posthog/chschema/test/testhelpers"
@@ -422,6 +423,24 @@ func TestLive_Introspection_AllStatements(t *testing.T) {
 							}
 						}
 						require.True(t, found, "Dictionary '%s' should be found after introspection", objectName)
+					case "ReplicatedSummingMergeTree":
+						// Legacy chschema_v1 protobuf path doesn't model this
+						// engine (the proto contract is frozen — see
+						// CLAUDE.md). Verify via the hcl-loader path that
+						// hclexp itself uses.
+						hclState, err := hclload.Introspect(ctx, conn, dbName)
+						require.NoError(t, err, "hcl introspect for ReplicatedSummingMergeTree assertion")
+						var ts *hclload.TableSpec
+						for i := range hclState.Tables {
+							if hclState.Tables[i].Name == objectName {
+								ts = &hclState.Tables[i]
+								break
+							}
+						}
+						require.NotNil(t, ts, "table %q should be in hcl introspection result", objectName)
+						require.NotNil(t, ts.Engine)
+						_, ok := ts.Engine.Decoded.(hclload.EngineReplicatedSummingMergeTree)
+						require.True(t, ok, "expected EngineReplicatedSummingMergeTree, got %T", ts.Engine.Decoded)
 					default:
 						foundObject := chschema_v1.FindTableByName(state.Tables, objectName)
 						require.NotNil(t, foundObject, "Object '%s' should be found after introspection", objectName)

--- a/test/testdata/posthog-create-statements/ReplicatedSummingMergeTree/sharded_distinct_id_usage.sql
+++ b/test/testdata/posthog-create-statements/ReplicatedSummingMergeTree/sharded_distinct_id_usage.sql
@@ -1,0 +1,1 @@
+CREATE TABLE default.sharded_distinct_id_usage (`team_id` Int64, `distinct_id` String, `count` UInt64) ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/{shard}/posthog.distinct_id_usage', '{replica}', count) ORDER BY (team_id, distinct_id) SETTINGS index_granularity = 8192


### PR DESCRIPTION
## Why

`hclexp introspect` against PostHog's production schema fails on one table — `posthog.sharded_distinct_id_usage` — because its `ReplicatedSummingMergeTree` engine is not modelled by hclexp. It's the only missing replicated/non-replicated pair in the MergeTree family: ReplicatedReplacing, ReplicatedCollapsing, ReplicatedAggregating, and `ReplicatedMergeTree` itself are all supported; the Summing variant was overlooked.

## What

Adds full first-class support for `ReplicatedSummingMergeTree`, following the existing one-type-per-engine convention exactly.

### HCL surface

```hcl
table "sharded_distinct_id_usage" {
  order_by = ["team_id", "distinct_id"]

  column "team_id" { type = "Int64" }
  column "distinct_id" { type = "String" }
  column "count" { type = "UInt64" }

  engine "replicated_summing_merge_tree" {
    zoo_path     = "/clickhouse/tables/{shard}/distinct_id_usage"
    replica_name = "{replica}"
    sum_columns  = ["count"]   // optional; omit for the no-argument form
  }
}
```

| HCL attribute | Required | Maps to |
|---|---|---|
| `zoo_path` | yes | first positional arg of `ReplicatedSummingMergeTree(...)` |
| `replica_name` | yes | second positional arg |
| `sum_columns` | no | trailing tuple of column identifiers |

ClickHouse syntax round-trip:

| HCL | DDL |
|---|---|
| no `sum_columns` | `ENGINE = ReplicatedSummingMergeTree('zk', 'replica')` |
| `sum_columns = ["a", "b"]` | `ENGINE = ReplicatedSummingMergeTree('zk', 'replica', (a, b))` |

## Implementation

Six commits (after spec + plan), one per layer touched:

| Layer | File | Commit |
|---|---|---|
| Spec | `docs/superpowers/specs/2026-05-28-replicated-summing-merge-tree.md` | `docs: design spec…` |
| Plan | `docs/superpowers/plans/2026-05-28-replicated-summing-merge-tree.md` | `docs: implementation plan…` |
| Type + HCL decode | `engines.go` | `feat(hcl): EngineReplicatedSummingMergeTree type + HCL decode` |
| Sqlgen | `sqlgen.go` | `feat(hcl): emit ReplicatedSummingMergeTree DDL` |
| Introspect (AST + text) + canonical-HCL dump | `introspect.go`, `dump.go` | `feat(hcl): introspect ReplicatedSummingMergeTree (AST + text-fallback)` |
| Live fixture + integration | `test/testdata/posthog-create-statements/ReplicatedSummingMergeTree/sharded_distinct_id_usage.sql`, `test/introspection_live_test.go` | `test(live): ReplicatedSummingMergeTree fixture` |
| Docs | `docs/README.hcl.md`, `README.md` | `docs: list replicated_summing_merge_tree…` |

The live test verification routes through the **hclload introspector** (not the legacy `chschema_v1` protobuf state) because the protobuf contract is frozen per `CLAUDE.md`'s deprecation note ("the protobuf contracts under `proto/`/`gen/` are deprecated and slated for removal. Do not build new features on those paths."). The View arm I added in #20 set this precedent; ReplicatedSummingMergeTree follows it.

## Verification

- `go test ./internal/... ./config ./cmd/... ./test/...` → **398 pass**.
- `ENABLE_CLICKHOUSE=1 go test ./test/...` → **181 pass** against ClickHouse 26.5, including the new `TestLive_Introspection_AllStatements/ReplicatedSummingMergeTree/sharded_distinct_id_usage`.
- `gofmt -s -l .` clean, `go vet ./...` clean.

## Out of scope

- The other replicated engines could be refactored to share Go types — explicitly NOT done; existing one-type-per-engine convention preserved.
- Modelling `database_atomic_*` / `database_replicated` macros — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
