### PR TITLE
chore(deps): bump chparser fork; drop CREATE VIEW regex workaround

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,4 +50,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
-replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260528112828-782c78d05142
+replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260528133804-903b1cab88e4

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/orian/clickhouse-sql-parser v0.0.0-20260528112828-782c78d05142 h1:26G2lPD7P74LJy4xQnKBNhtpDKkHDwv7mYuyPDwrgJM=
-github.com/orian/clickhouse-sql-parser v0.0.0-20260528112828-782c78d05142/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
+github.com/orian/clickhouse-sql-parser v0.0.0-20260528133804-903b1cab88e4 h1:vTU1h+xlZlbAv/A2jSto6rtMgcKYY/aYe5IrhcuoDIw=
+github.com/orian/clickhouse-sql-parser v0.0.0-20260528133804-903b1cab88e4/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
 github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -64,15 +64,7 @@ func processIntrospectRows(db *DatabaseSpec, database string, rows rowScanner) e
 		if err := rows.Scan(&name, &createSQL); err != nil {
 			return fmt.Errorf("scan system.tables: %w", err)
 		}
-		// chparser as of the current pin rejects DEFINER / SQL SECURITY /
-		// COMMENT on plain CREATE VIEW (tracked at
-		// https://github.com/orian/clickhouse-sql-parser/issues/6). Pre-
-		// strip those clauses so the rest of the statement parses; we
-		// stitch the captured values back onto the resulting ViewSpec
-		// below.
-		extras, parseSQL := stripViewExtras(createSQL)
-
-		stmt, err := parseCreateStatement(parseSQL)
+		stmt, err := parseCreateStatement(createSQL)
 		if err != nil {
 			return fmt.Errorf("parse create_table_query for %s.%s: %w", database, name, err)
 		}
@@ -99,7 +91,7 @@ func processIntrospectRows(db *DatabaseSpec, database string, rows rowScanner) e
 			d.Name = name
 			db.Dictionaries = append(db.Dictionaries, d)
 		case *chparser.CreateView:
-			v, err := buildViewFromCreateView(s, extras)
+			v, err := buildViewFromCreateView(s)
 			if err != nil {
 				return fmt.Errorf("introspect view %s.%s: %w", database, name, err)
 			}
@@ -217,56 +209,10 @@ func buildMaterializedViewFromCreateSQL(createSQL string) (MaterializedViewSpec,
 // buildMaterializedViewFromCreateMV walks an already-parsed CREATE
 // MATERIALIZED VIEW AST. Only the `TO <table>` form is supported;
 // inner-engine and refreshable MVs are rejected with a clear error.
-// viewExtras carries the clauses that chparser doesn't yet parse on
-// CREATE VIEW (see orian/clickhouse-sql-parser#6). They're captured
-// from the raw SQL by stripViewExtras and merged onto the ViewSpec
-// after the cleaned statement is parsed.
-type viewExtras struct {
-	SQLSecurity *string
-	Definer     *string
-	Comment     *string
-}
-
-var (
-	reCreateViewPrefix = regexp.MustCompile(`(?i)^\s*CREATE\s+(OR\s+REPLACE\s+)?VIEW\b`)
-	reViewDefiner      = regexp.MustCompile(`(?i)\s*DEFINER\s*=\s*([A-Za-z_][A-Za-z0-9_]*|CURRENT_USER)\b`)
-	reViewSQLSecurity  = regexp.MustCompile(`(?i)\s*SQL\s+SECURITY\s+(DEFINER|INVOKER|NONE)\b`)
-	reViewCommentTail  = regexp.MustCompile(`(?is)\s*COMMENT\s+'((?:[^']|'')*)'\s*$`)
-)
-
-// stripViewExtras pulls DEFINER / SQL SECURITY / trailing COMMENT off a
-// CREATE VIEW statement so the remainder parses cleanly with the current
-// chparser. Returns the parsed-out clauses and the cleaned SQL. For
-// non-view statements it's a no-op.
-func stripViewExtras(sql string) (viewExtras, string) {
-	if !reCreateViewPrefix.MatchString(sql) {
-		return viewExtras{}, sql
-	}
-	var ex viewExtras
-	if m := reViewDefiner.FindStringSubmatchIndex(sql); m != nil {
-		d := sql[m[2]:m[3]]
-		ex.Definer = &d
-		sql = sql[:m[0]] + sql[m[1]:]
-	}
-	if m := reViewSQLSecurity.FindStringSubmatchIndex(sql); m != nil {
-		s := strings.ToLower(sql[m[2]:m[3]])
-		ex.SQLSecurity = &s
-		sql = sql[:m[0]] + sql[m[1]:]
-	}
-	if m := reViewCommentTail.FindStringSubmatchIndex(sql); m != nil {
-		raw := sql[m[2]:m[3]]
-		c := strings.ReplaceAll(raw, "''", "'")
-		ex.Comment = &c
-		sql = sql[:m[0]]
-	}
-	return ex, sql
-}
-
 // buildViewFromCreateView walks a parsed CREATE VIEW AST and produces a
-// ViewSpec, merging in the extras captured by stripViewExtras. The
-// SELECT body is rendered back to text via formatNode, matching the way
-// MV bodies are captured.
-func buildViewFromCreateView(cv *chparser.CreateView, extras viewExtras) (ViewSpec, error) {
+// ViewSpec. The SELECT body is rendered back to text via formatNode,
+// matching the way MV bodies are captured.
+func buildViewFromCreateView(cv *chparser.CreateView) (ViewSpec, error) {
 	v := ViewSpec{}
 
 	if cv.SubQuery != nil && cv.SubQuery.Select != nil {
@@ -293,18 +239,16 @@ func buildViewFromCreateView(cv *chparser.CreateView, extras viewExtras) (ViewSp
 		}
 	}
 
-	// Merge the regex-extracted extras. AST-side Comment takes precedence
-	// if chparser ever starts populating it.
 	if cv.Comment != nil {
 		v.Comment = strPtr(unquoteString(cv.Comment.Literal))
-	} else if extras.Comment != nil {
-		v.Comment = extras.Comment
 	}
-	if extras.SQLSecurity != nil {
-		v.SQLSecurity = extras.SQLSecurity
+	if cv.Definer != nil {
+		d := stripBackticks(cv.Definer.Name)
+		v.Definer = &d
 	}
-	if extras.Definer != nil {
-		v.Definer = extras.Definer
+	if cv.SQLSecurity != "" {
+		s := strings.ToLower(cv.SQLSecurity)
+		v.SQLSecurity = &s
 	}
 
 	return v, nil


### PR DESCRIPTION
## Why

All four upstream chparser issues filed during the views + production-dump work are now closed:

| Issue | Workaround | Status |
|---|---|---|
| [#1 EPHEMERAL CAST(...)](https://github.com/orian/clickhouse-sql-parser/issues/1) | none in current code | upstream fix |
| [#2 TTL `<expr>` WHERE `<predicate>`](https://github.com/orian/clickhouse-sql-parser/issues/2) | none in current code | upstream fix |
| [#3 INDEX TYPE text(`name = value`, ...)](https://github.com/orian/clickhouse-sql-parser/issues/3) | none in current code | upstream fix |
| [#6 CREATE VIEW COMMENT / DEFINER / SQL SECURITY](https://github.com/orian/clickhouse-sql-parser/issues/6) | `stripViewExtras` regex pre-strip | **upstream fix → workaround removed in this PR** |

## What

```
- replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260528112828-782c78d05142
+ replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260528133804-903b1cab88e4
```

Plus the cleanup: the new fork pin adds `Definer *Ident`, `SQLSecurity string`, and `Comment *StringLiteral` directly to `chparser.CreateView`. That makes the regex preprocessor I introduced for issue #6 unnecessary.

Removes from `internal/loader/hcl/introspect.go`:
- `viewExtras` struct
- `stripViewExtras` function
- Four CREATE VIEW regex constants (`reCreateViewPrefix`, `reViewDefiner`, `reViewSQLSecurity`, `reViewCommentTail`)
- The `extras` parameter on `buildViewFromCreateView`

Net diff: **+14 / -70** (mostly subtractions).

`buildViewFromCreateView` now reads:
```go
if cv.Comment != nil    { v.Comment = strPtr(unquoteString(cv.Comment.Literal)) }
if cv.Definer != nil    { d := stripBackticks(cv.Definer.Name); v.Definer = &d }
if cv.SQLSecurity != "" { s := strings.ToLower(cv.SQLSecurity); v.SQLSecurity = &s }
```

## Verification

- `go test ./internal/... ./config ./cmd/... ./test/...` → **424 pass**.
- `ENABLE_CLICKHOUSE=1 go test ./test/...` → **181 pass** against ClickHouse 26.5.
- `gofmt -s -l .` clean, `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
