### PR TITLE
feat(hcl): allow MV extend, add engine-aware virtual columns

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -41,6 +41,132 @@ After resolution there are two emitted tables — `events_local` and
 `events_distributed` — each with the three shared columns. `_event_base` is
 dropped.
 
+## How do I share columns across a Kafka source, MV, local table, and Distributed table?
+
+The canonical ingest pipeline: Kafka feeds an MV, which writes to a local
+replicated table, fronted by a Distributed table. The three **tables** share
+the same columns — declare them once on an abstract base and let each table
+`extend` it. The MV, since it's a 1:1 passthrough, doesn't need any column
+list at all: ClickHouse derives the MV's schema from its `SELECT`.
+
+```hcl
+database "default" {
+  cluster = "main"
+
+  table "events_base" {
+    abstract = true
+    column "timestamp" { type = "DateTime64(3)" }
+    column "team_id"   { type = "UInt32" }
+    column "event"     { type = "String" }
+  }
+
+  table "events_kafka" {
+    extend = "events_base"
+    engine "kafka" {
+      broker_list = "kafka:9092"
+      topic_list  = "events"
+      group_name  = "ch_events"
+      format      = "JSONEachRow"
+    }
+  }
+
+  table "events_local" {
+    extend = "events_base"
+    engine "replicated_merge_tree" {
+      zoo_path     = "/clickhouse/tables/{shard}/events"
+      replica_name = "{replica}"
+    }
+    order_by = ["team_id", "timestamp"]
+  }
+
+  table "events_distributed" {
+    extend = "events_base"
+    engine "distributed" {
+      cluster_name    = "main"
+      remote_database = "default"
+      remote_table    = "events_local"
+      sharding_key    = "cityHash64(team_id)"
+    }
+  }
+
+  materialized_view "events_mv" {
+    to_table = "events_local"
+    query    = "SELECT timestamp, team_id, event FROM events_kafka"
+  }
+}
+```
+
+Adding a column to `events_base` adds it to all three tables. The MV picks
+it up automatically the next time you edit the `SELECT` to project it.
+
+## When does it make sense to `extend` on a `materialized_view`?
+
+When the MV is *not* a passthrough — typically an aggregating MV whose
+declared output column types must match its destination table. The
+destination and the MV share the same `AggregateFunction(...)` columns, so
+both should extend the same base. The Kafka source uses raw types and does
+*not* extend this base.
+
+```hcl
+database "default" {
+  cluster = "main"
+
+  table "events_kafka" {
+    column "timestamp" { type = "DateTime64(3)" }
+    column "team_id"   { type = "UInt32" }
+    column "user_id"   { type = "UInt64" }
+    engine "kafka" { broker_list = "kafka:9092"; topic_list = "events"; group_name = "ch_metrics"; format = "JSONEachRow" }
+  }
+
+  # Shared shape: aggregation state columns. The destination table and the
+  # MV both extend this — they MUST agree on the AggregateFunction types.
+  table "team_metrics_base" {
+    abstract = true
+    column "hour"         { type = "DateTime" }
+    column "team_id"      { type = "UInt32" }
+    column "events"       { type = "AggregateFunction(count, UInt64)" }
+    column "unique_users" { type = "AggregateFunction(uniq, UInt64)" }
+  }
+
+  table "team_metrics" {
+    extend = "team_metrics_base"
+    engine "aggregating_merge_tree" {}
+    order_by = ["hour", "team_id"]
+  }
+
+  materialized_view "team_metrics_mv" {
+    extend   = "team_metrics_base"
+    to_table = "team_metrics"
+    query    = <<-SQL
+      SELECT
+        toStartOfHour(timestamp)        AS hour,
+        team_id,
+        countState()                    AS events,
+        uniqState(user_id)              AS unique_users
+      FROM events_kafka
+      GROUP BY hour, team_id
+    SQL
+  }
+}
+```
+
+Why the column list pulls its weight here:
+
+- Pins the `AggregateFunction(...)` types instead of relying on CH to infer
+  them from the SELECT — an ambiguous `sumState(...)` or accidental type
+  drift in the SELECT will fail at MV creation, not silently at query time.
+- Documents the MV's shape at the call site.
+- Catches drift between MV and destination when you change either one — the
+  diff highlights the mismatch immediately.
+
+Rule of thumb: passthrough MVs → no column list, no `extend`. Aggregating /
+transforming MVs whose output shape matches a destination → declare a
+shared base and have both `extend` it.
+
+Note: any change to an MV's declared column list — including one that flows
+in via `extend` — requires recreating the MV. `hclexp diff -sql` flags that
+as `UNSAFE`. Plan column changes accordingly.
+
 ## How do I make a table that's *almost* identical to another, just with a different `order_by`?
 
 `extend` from the table you want to clone, then override the differing

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -171,6 +171,49 @@ table "events_local"       { extend = "_event_base"; engine "merge_tree" {}; ...
 table "events_distributed" { extend = "_event_base"; engine "distributed" { ... } }
 ```
 
+### Inheritance on `materialized_view`
+
+A `materialized_view` may also `extend` an `abstract = true` table. The MV
+inherits the parent's `column` list (and `cluster` / `comment` if it
+hasn't set its own). Engine, `order_by`, etc. are table-only and not
+inherited. Extending a concrete (non-abstract) table or another MV is an
+error.
+
+When to reach for it: an MV that **declares its own output shape** — most
+commonly an aggregating MV whose `AggregateFunction(...)` columns must
+agree with the destination table. The destination and the MV share one
+base, the source table does not.
+
+```hcl
+table "team_metrics_base" {
+  abstract = true
+  column "hour"         { type = "DateTime" }
+  column "team_id"      { type = "UInt32" }
+  column "events"       { type = "AggregateFunction(count, UInt64)" }
+}
+
+table "team_metrics" {
+  extend = "team_metrics_base"
+  engine "aggregating_merge_tree" {}
+  order_by = ["hour", "team_id"]
+}
+
+materialized_view "team_metrics_mv" {
+  extend   = "team_metrics_base"
+  to_table = "team_metrics"
+  query    = "SELECT toStartOfHour(timestamp) AS hour, team_id, countState() AS events FROM events_kafka GROUP BY hour, team_id"
+}
+```
+
+For a passthrough MV that just mirrors columns from source to destination,
+omit both the column list and `extend` — ClickHouse derives the MV's
+schema from the `SELECT`. See the FAQ for the full worked passthrough vs.
+aggregating comparison.
+
+An `abstract = true` materialized_view is accepted for symmetry (it is
+dropped after resolution, like an abstract table), but has no common use
+case — MVs are usually concrete glue.
+
 ## Resolution pipeline
 
 When the loader processes a layered set, this pipeline runs:
@@ -259,6 +302,46 @@ requires drop-and-recreate and is flagged unsafe.
 
 **Not supported.** Live views, refreshable materialized views, and window
 views fail introspection with a clear error.
+
+## Virtual columns
+
+ClickHouse exposes implicit columns on tables of certain engines — names
+like `_part` on MergeTree, `_offset`/`_timestamp` on Kafka, `_shard_num`
+on Distributed. `hclexp` knows about them per engine:
+
+| Engine                | Virtual columns                                                                                       |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
+| MergeTree family      | `_part`, `_part_index`, `_part_uuid`, `_partition_id`, `_partition_value`, `_sample_factor`, `_part_offset` |
+| Kafka                 | `_topic`, `_key`, `_offset`, `_partition`, `_timestamp`, `_timestamp_ms`, `_headers.name`, `_headers.value` (+`_raw_message`, `_error` when `handle_error_mode = "stream"`) |
+| Distributed           | `_shard_num`, **plus the virtuals of its remote table** (transitive; chains and cycles handled)        |
+| Log, all others       | none                                                                                                  |
+
+This awareness shows up in three places:
+
+1. **MV source-column validation** (`hclexp validate`). When a materialized
+   view's `query` has a single resolvable source (no JOIN/UNION/CTE/
+   subquery/`SELECT *`), the validator walks identifier references whose
+   names begin with `_` and flags any that aren't provided by the source —
+   declared columns plus the engine's virtual set. A bare `_offsett` on a
+   Kafka source is flagged; a legitimate `_offset`/`_timestamp` /
+   `_headers.name` passes. Skip per-MV with `-skip-validation=<mv-name>`.
+
+2. **Diff guard** (`hclexp diff`). A column name recognised as virtual on
+   one side is suppressed from ADD/DROP DDL only when the other side has
+   not declared it — preventing CH-illegal `DROP COLUMN _offset` from a
+   stray introspector leak, while still surfacing `MODIFY COLUMN` when
+   both sides explicitly declared the column (the `_key FixedString(8)`
+   case from `kafka_map_virtual_columns_on_write`).
+
+3. **Schema-as-source-of-truth**. A user can declare a column whose name
+   matches a virtual (e.g. `column "_key" { type = "FixedString(8)" }` on
+   a Kafka table) — the declared definition wins over the virtual at
+   every consumer site.
+
+Out of scope in v1: MergeTree's version-gated virtuals (`_block_number`,
+`_block_offset`, `_row_exists`) — these depend on ClickHouse version /
+table settings (lightweight deletes) and would risk false positives on
+older deployments. Declare them explicitly in HCL when you need them.
 
 ## TLS / secure connections
 

--- a/docs/superpowers/plans/2026-05-29-kafka-virtual-columns.md
+++ b/docs/superpowers/plans/2026-05-29-kafka-virtual-columns.md
@@ -1,0 +1,106 @@
+# Kafka Virtual Columns Support
+
+**Goal:** Teach `hclexp` about the implicit/virtual columns ClickHouse exposes on `Kafka`-engine
+tables (`_topic`, `_key`, `_offset`, `_partition`, `_timestamp`, `_timestamp_ms`, `_headers.name`,
+`_headers.value`, plus `_raw_message`/`_error` in `kafka_handle_error_mode = 'stream'`), so that
+(1) materialized views reading those columns from a Kafka source validate cleanly, and (2)
+introspection/diff never treat a virtual column as a managed column (no spurious `ADD`/`DROP`).
+
+**Why:** Virtual columns are not part of a Kafka table's DDL (`create_table_query`), so the
+DDL-parsing introspector never sees them and the rest of the tool has no notion that a Kafka source
+exposes them. Today the only place that knows is a hard-coded `kafkaVirtualColumns` constant in the
+live-test stub builder (`test/integration_live_test.go`) — duplicated, drift-prone, and slightly
+wrong (it includes `_raw_message` unconditionally and omits `_error`). Reference:
+`clickhouse-docs/en/engines/table-engines/integrations/kafka.md` §Virtual columns (lines 264-280).
+
+**Architecture:** A single canonical, engine-setting-aware source of truth in the `hcl` package.
+`KafkaVirtualColumns(EngineKafka)` returns the set (stream-only columns gated on
+`HandleErrorMode`). `IsKafkaVirtualColumn(name)` is the membership predicate. `ColumnsProvidedBy(TableSpec)`
+is the seam both surfaces consume: declared columns, plus the virtual set when the engine is Kafka.
+The live-test constant is replaced by a call into this set.
+
+**Conventions:** Go + `stretchr/testify`. Unit tests: `go test ./internal/... ./cmd/... -v`. Live:
+`-clickhouse` + `docker compose up -d`. Engines are typed structs decoded in `engines.go`
+(`EngineSpec.Decoded.(EngineKafka)`, `Engine.Kind()`). Do **not** add features to the legacy
+`internal/introspection` / `internal/diff` / proto paths (frozen).
+
+---
+
+## Design
+
+### Foundation — `internal/loader/hcl/kafka_virtual.go` (new)
+
+```go
+func KafkaVirtualColumns(e EngineKafka) []DeclaredColumn
+func IsKafkaVirtualColumn(name string) bool
+func ColumnsProvidedBy(t TableSpec) []DeclaredColumn
+```
+
+- Base set (always): `_topic LowCardinality(String)`, `_key String`, `_offset UInt64`,
+  `_partition UInt64`, `_timestamp Nullable(DateTime)`, `_timestamp_ms Nullable(DateTime64(3))`,
+  `_headers.name Array(String)`, `_headers.value Array(String)`.
+- Stream-mode extras (when `e.HandleErrorMode != nil && *e.HandleErrorMode == "stream"`):
+  `_raw_message String`, `_error String`.
+- `IsKafkaVirtualColumn` matches the **full** name set (both modes) plus the `_headers` Nested parent
+  — it is a name guard, mode-independent on purpose.
+- `ColumnsProvidedBy` returns `t.Columns` mapped to `DeclaredColumn`, and if
+  `t.Engine.Decoded` is `EngineKafka`, appends `KafkaVirtualColumns(e)` for names not already declared
+  (a declared `_key`/`_timestamp` via `kafka_map_virtual_columns_on_write` wins — it is a real column).
+
+### Surface 1 — MV column validation (`internal/loader/hcl/validate.go`)
+
+Extend `Validate`. For each non-skipped MV with a **single resolvable source** (exactly one
+distinct source table, which is declared in a loaded DB, and the query is not `SELECT *`):
+- Build the source's provided-column name set via `ColumnsProvidedBy`.
+- Walk the parsed query; collect column identifiers attributable to that single source.
+- Emit a `ValidationError` (new `Kind = "mv_column"`) for any referenced column absent from the set.
+
+**Conservatism (no false positives) is the governing constraint:**
+- Only when there is exactly one source table and no `JOIN`/secondary table refs (so every bare
+  column belongs to that source unambiguously).
+- Skip `SELECT *` / `SELECT t.*`.
+- Ignore identifiers that are function names, aliases introduced in the same query (`AS x`), or CTE
+  columns. When attribution is uncertain, do not flag.
+- Only runs for sources we can resolve to a `TableSpec`; unknown/system sources are skipped (the
+  existing table-level check already reports truly missing sources).
+
+This catches the real case (an MV reading `_offset`/`_timestamp` from a Kafka source now passes;
+a typo'd `_offsett` is flagged) without risking valid complex MVs.
+
+### Surface 2 — Introspect / diff guard (`internal/loader/hcl/diff.go`)
+
+When diffing two tables whose engine is `Kafka`, filter both column lists through
+`IsKafkaVirtualColumn` before comparison, so a virtual column can never become an `ADD COLUMN` /
+`DROP COLUMN`. Note: the **declared-vs-implicit** rule means this only suppresses virtuals that leak
+in from a column-listing path — declared columns named `_key`/`_timestamp` come from the DDL and are
+kept. The active introspector parses `create_table_query` (virtuals never appear), so this is a
+correctness guard for any future `system.columns`/`DESCRIBE`-based path and for hand-written HCL.
+(The legacy `internal/introspection` `system.columns` query is frozen; if ever revived, add
+`AND is_virtual = 0`.)
+
+### Test harness — `test/integration_live_test.go`
+
+Replace the hard-coded `kafkaVirtualColumns` constant with a render of the canonical set
+(`KafkaVirtualColumns` + the existing `_headers Nested(...)` shape for the stub), so the stub builder
+and the production library never drift, and `_error`/stream handling is correct.
+
+---
+
+## Tasks
+
+- [ ] **Foundation** — create `internal/loader/hcl/kafka_virtual.go` with `KafkaVirtualColumns`,
+      `IsKafkaVirtualColumn`, `ColumnsProvidedBy`.
+- [ ] **Foundation tests** — `internal/loader/hcl/kafka_virtual_test.go`: base vs stream set;
+      membership predicate; `ColumnsProvidedBy` for Kafka vs non-Kafka and the declared-wins case.
+- [ ] **Diff guard** — filter Kafka virtual columns in `diff.go` table-column comparison; unit test
+      that a stray `_offset` on a Kafka table yields no column diff while a real column change does.
+- [ ] **MV column validation** — extend `validate.go` (`mv_column` kind, conservative single-source);
+      unit tests: passes a real virtual ref, flags a bogus ref, no false-positive on `SELECT *`/JOIN.
+- [ ] **Test harness** — point `buildStubColList` at the canonical set; run `just test-live`.
+- [ ] **Docs** — note Kafka virtual-column handling in `README.md` / `docs/README.hcl.md`.
+
+## Verification
+
+- `go build ./... && go test ./internal/... ./cmd/... -v` (unit + snapshot).
+- `go test ./test -v -clickhouse` (live) — the existing Kafka-source MV fixtures validate and
+  round-trip with no virtual columns in the dump/diff.

--- a/internal/loader/hcl/diff.go
+++ b/internal/loader/hcl/diff.go
@@ -3,6 +3,7 @@ package hcl
 import (
 	"reflect"
 	"sort"
+	"strings"
 )
 
 // ChangeSet describes the changes required to evolve a `from` schema into a
@@ -200,6 +201,11 @@ func Diff(from, to *Schema) ChangeSet {
 	toIdx := indexDatabases(to.Databases)
 	names := mergedKeys(fromIdx, toIdx)
 
+	// Resolvers built once per side so the virtual-column guard in
+	// diffTable can resolve Distributed → remote-table transitive sets.
+	fromR := NewSchemaResolver(from.Databases)
+	toR := NewSchemaResolver(to.Databases)
+
 	var cs ChangeSet
 	for _, name := range names {
 		f, fOK := fromIdx[name]
@@ -226,7 +232,7 @@ func Diff(from, to *Schema) ChangeSet {
 				dc.DropViews = append(dc.DropViews, v.Name)
 			}
 		default:
-			dc = diffDatabase(name, f, t)
+			dc = diffDatabase(name, f, t, fromR, toR)
 		}
 		if dc.IsEmpty() {
 			continue
@@ -262,7 +268,7 @@ func mergedKeys(a, b map[string]*DatabaseSpec) []string {
 	return out
 }
 
-func diffDatabase(name string, from, to *DatabaseSpec) DatabaseChange {
+func diffDatabase(name string, from, to *DatabaseSpec, fromR, toR TableResolver) DatabaseChange {
 	dc := DatabaseChange{Database: name}
 
 	fromTables := indexTables(from.Tables)
@@ -283,7 +289,7 @@ func diffDatabase(name string, from, to *DatabaseSpec) DatabaseChange {
 		if !ok {
 			continue
 		}
-		td := diffTable(fromTables[n], t)
+		td := diffTable(fromTables[n], t, fromR, toR)
 		if !td.IsEmpty() {
 			dc.AlterTables = append(dc.AlterTables, td)
 		}
@@ -490,11 +496,38 @@ func sortedKeys[V any](m map[string]V) []string {
 	return out
 }
 
-func diffTable(from, to *TableSpec) TableDiff {
+func diffTable(from, to *TableSpec, fromR, toR TableResolver) TableDiff {
 	td := TableDiff{Table: to.Name}
 
 	fromCols := indexColumns(from.Columns)
 	toCols := indexColumns(to.Columns)
+
+	// Asymmetric virtual-column guard. A column name recognised as
+	// virtual by an engine is dropped from that side only when the
+	// OTHER side has not declared it — that suppresses would-be
+	// ADD/DROP DDL on a virtual (CH rejects DROP COLUMN of a virtual
+	// and a stray "_offset" leak from a future system.columns-based
+	// introspector would otherwise generate one). When both sides
+	// declare the column (e.g. real `_key FixedString(8)` on both),
+	// it stays and a type change still surfaces normally.
+	fromVirtuals := virtualNameSet(engineOf(*from), fromR)
+	toVirtuals := virtualNameSet(engineOf(*to), toR)
+	for n := range fromCols {
+		if !fromVirtuals[n] {
+			continue
+		}
+		if _, declaredOnOther := toCols[n]; !declaredOnOther {
+			delete(fromCols, n)
+		}
+	}
+	for n := range toCols {
+		if !toVirtuals[n] {
+			continue
+		}
+		if _, declaredOnOther := fromCols[n]; !declaredOnOther {
+			delete(toCols, n)
+		}
+	}
 
 	// Resolve renamed_from directives: a rename applies only when the old
 	// name exists in `from` AND the new name does not. This makes stale
@@ -684,4 +717,31 @@ func sortDatabaseChange(dc *DatabaseChange) {
 	sort.Slice(dc.AddViews, func(i, j int) bool { return dc.AddViews[i].Name < dc.AddViews[j].Name })
 	sort.Strings(dc.DropViews)
 	sort.Slice(dc.AlterViews, func(i, j int) bool { return dc.AlterViews[i].Name < dc.AlterViews[j].Name })
+}
+
+// virtualNameSet returns the names recognised as virtual on engine e in
+// the context of resolver r. Includes the bare Nested parent for any
+// dot-access name (e.g. "_headers" when "_headers.name" is present), so
+// a stray declared parent is recognised even though Virtuals() only
+// reports the dot-access form.
+func virtualNameSet(e Engine, r TableResolver) map[string]bool {
+	if e == nil {
+		return nil
+	}
+	cols := VirtualColumnsFor(e, r)
+	if len(cols) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(cols)+1)
+	hasHeadersDotted := false
+	for _, c := range cols {
+		out[c.Name] = true
+		if !hasHeadersDotted && strings.HasPrefix(c.Name, "_headers.") {
+			hasHeadersDotted = true
+		}
+	}
+	if hasHeadersDotted {
+		out["_headers"] = true
+	}
+	return out
 }

--- a/internal/loader/hcl/diff_test.go
+++ b/internal/loader/hcl/diff_test.go
@@ -765,3 +765,125 @@ func TestDiff_NamedCollections_HIDDEN_OnTargetSide(t *testing.T) {
 	assert.Empty(t, cs.NamedCollections[0].SetParams)
 	assert.Equal(t, []string{"k"}, cs.NamedCollections[0].SkippedRedactedParams)
 }
+
+// --- Virtual-column diff guard -----------------------------------------
+
+// kafkaTable builds a Kafka-engined TableSpec for the virtual-column tests.
+func kafkaTable(name string, cols ...ColumnSpec) TableSpec {
+	return TableSpec{
+		Name:    name,
+		Columns: cols,
+		Engine:  &EngineSpec{Kind: "kafka", Decoded: EngineKafka{}},
+	}
+}
+
+func TestDiff_VirtualColumnGuard_LeakedVirtualOnFrom_SuppressedDrop(t *testing.T) {
+	// from has _offset (leaked from a future system.columns-based introspector).
+	// to has only real columns. Naive diff would emit DROP COLUMN _offset,
+	// which CH rejects. Guard suppresses it.
+	from := &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{kafkaTable("ev",
+			ColumnSpec{Name: "team_id", Type: "UInt32"},
+			ColumnSpec{Name: "_offset", Type: "UInt64"}, // leaked
+		)},
+	}}}
+	to := &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{kafkaTable("ev",
+			ColumnSpec{Name: "team_id", Type: "UInt32"},
+		)},
+	}}}
+	cs := Diff(from, to)
+	assert.True(t, cs.IsEmpty(), "virtual leak should not surface as a DROP")
+}
+
+func TestDiff_VirtualColumnGuard_DeclaredOnBothSides_TypeChangeStillSurfaces(t *testing.T) {
+	// User legitimately declared _key on both sides (e.g. via
+	// kafka_map_virtual_columns_on_write). A type change must still
+	// produce a MODIFY COLUMN — the guard must NOT silence declared-vs-
+	// declared diffs.
+	from := &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{kafkaTable("ev",
+			ColumnSpec{Name: "_key", Type: "String"},
+		)},
+	}}}
+	to := &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{kafkaTable("ev",
+			ColumnSpec{Name: "_key", Type: "FixedString(8)"},
+		)},
+	}}}
+	cs := Diff(from, to)
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterTables, 1)
+	require.Len(t, cs.Databases[0].AlterTables[0].ModifyColumns, 1)
+	mc := cs.Databases[0].AlterTables[0].ModifyColumns[0]
+	assert.Equal(t, "_key", mc.Name)
+	assert.Equal(t, "String", mc.OldType)
+	assert.Equal(t, "FixedString(8)", mc.NewType)
+}
+
+func TestDiff_VirtualColumnGuard_NonVirtualNamesUnaffected(t *testing.T) {
+	// A real column drop on a Kafka table must still surface — the guard
+	// only filters names that match the engine's virtual set.
+	from := &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{kafkaTable("ev",
+			ColumnSpec{Name: "team_id", Type: "UInt32"},
+			ColumnSpec{Name: "event", Type: "String"},
+		)},
+	}}}
+	to := &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{kafkaTable("ev",
+			ColumnSpec{Name: "team_id", Type: "UInt32"},
+		)},
+	}}}
+	cs := Diff(from, to)
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterTables, 1)
+	assert.Equal(t, []string{"event"}, cs.Databases[0].AlterTables[0].DropColumns)
+}
+
+func TestDiff_VirtualColumnGuard_DistributedTransitive(t *testing.T) {
+	// _part is virtual on a Distributed-over-MergeTree (transitive). A
+	// stray declared _part on `from` only must not surface as a DROP.
+	mt := func(name string) TableSpec {
+		return TableSpec{
+			Name:   name,
+			Engine: &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}},
+		}
+	}
+	dist := func(name string, cols ...ColumnSpec) TableSpec {
+		return TableSpec{
+			Name:    name,
+			Columns: cols,
+			Engine: &EngineSpec{Kind: "distributed", Decoded: EngineDistributed{
+				RemoteDatabase: "default", RemoteTable: "ev_local",
+			}},
+		}
+	}
+	from := &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{
+			mt("ev_local"),
+			dist("ev_dist",
+				ColumnSpec{Name: "team_id", Type: "UInt32"},
+				ColumnSpec{Name: "_part", Type: "String"}, // leaked transitive
+			),
+		},
+	}}}
+	to := &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{
+			mt("ev_local"),
+			dist("ev_dist",
+				ColumnSpec{Name: "team_id", Type: "UInt32"},
+			),
+		},
+	}}}
+	cs := Diff(from, to)
+	assert.True(t, cs.IsEmpty(), "transitive virtual leak should not surface as a DROP on Distributed")
+}

--- a/internal/loader/hcl/engines.go
+++ b/internal/loader/hcl/engines.go
@@ -141,6 +141,135 @@ type EngineKafka struct {
 
 func (EngineKafka) Kind() string { return "kafka" }
 
+// mergeTreeFamilyVirtuals is the stable virtual-column set every
+// MergeTree-family engine exposes. Version-gated names (_block_number,
+// _block_offset on CH 24.x+, _row_exists with lightweight deletes) are
+// deliberately omitted from v1 — adding them risks false positives on
+// older deployments. Revisit when a real schema needs them.
+var mergeTreeFamilyVirtuals = []DeclaredColumn{
+	{Name: "_part", Type: "String"},
+	{Name: "_part_index", Type: "UInt64"},
+	{Name: "_part_uuid", Type: "UUID"},
+	{Name: "_partition_id", Type: "String"},
+	{Name: "_partition_value", Type: "Tuple"},
+	{Name: "_sample_factor", Type: "Float64"},
+	{Name: "_part_offset", Type: "UInt64"},
+}
+
+func (EngineMergeTree) Virtuals() []DeclaredColumn { return mergeTreeFamilyVirtuals }
+func (EngineReplicatedMergeTree) Virtuals() []DeclaredColumn {
+	return mergeTreeFamilyVirtuals
+}
+func (EngineReplacingMergeTree) Virtuals() []DeclaredColumn { return mergeTreeFamilyVirtuals }
+func (EngineReplicatedReplacingMergeTree) Virtuals() []DeclaredColumn {
+	return mergeTreeFamilyVirtuals
+}
+func (EngineSummingMergeTree) Virtuals() []DeclaredColumn { return mergeTreeFamilyVirtuals }
+func (EngineReplicatedSummingMergeTree) Virtuals() []DeclaredColumn {
+	return mergeTreeFamilyVirtuals
+}
+func (EngineCollapsingMergeTree) Virtuals() []DeclaredColumn {
+	return mergeTreeFamilyVirtuals
+}
+func (EngineReplicatedCollapsingMergeTree) Virtuals() []DeclaredColumn {
+	return mergeTreeFamilyVirtuals
+}
+func (EngineAggregatingMergeTree) Virtuals() []DeclaredColumn {
+	return mergeTreeFamilyVirtuals
+}
+func (EngineReplicatedAggregatingMergeTree) Virtuals() []DeclaredColumn {
+	return mergeTreeFamilyVirtuals
+}
+
+// kafkaBaseVirtuals is the always-on Kafka virtual set. `_headers` is
+// modelled in its dot-access form (`_headers.name`, `_headers.value`)
+// matching how MV queries reference it; the bare Nested parent
+// "_headers" is added by IsVirtualColumn for membership tests and by
+// the live-test stub builder for CREATE statements.
+var kafkaBaseVirtuals = []DeclaredColumn{
+	{Name: "_topic", Type: "LowCardinality(String)"},
+	{Name: "_key", Type: "String"},
+	{Name: "_offset", Type: "UInt64"},
+	{Name: "_partition", Type: "UInt64"},
+	{Name: "_timestamp", Type: "Nullable(DateTime)"},
+	{Name: "_timestamp_ms", Type: "Nullable(DateTime64(3))"},
+	{Name: "_headers.name", Type: "Array(String)"},
+	{Name: "_headers.value", Type: "Array(String)"},
+}
+
+// kafkaStreamVirtuals are the additional virtuals exposed only when
+// HandleErrorMode = "stream".
+var kafkaStreamVirtuals = []DeclaredColumn{
+	{Name: "_raw_message", Type: "String"},
+	{Name: "_error", Type: "String"},
+}
+
+func (e EngineKafka) Virtuals() []DeclaredColumn {
+	if e.HandleErrorMode != nil && *e.HandleErrorMode == "stream" {
+		out := make([]DeclaredColumn, 0, len(kafkaBaseVirtuals)+len(kafkaStreamVirtuals))
+		out = append(out, kafkaBaseVirtuals...)
+		out = append(out, kafkaStreamVirtuals...)
+		return out
+	}
+	return kafkaBaseVirtuals
+}
+
+var distributedSelfVirtuals = []DeclaredColumn{
+	{Name: "_shard_num", Type: "UInt32"},
+}
+
+// Virtuals returns only the Distributed-local virtuals — used as the
+// static fallback when no TableResolver is available. With a resolver,
+// DynamicVirtuals returns the transitive set.
+func (EngineDistributed) Virtuals() []DeclaredColumn { return distributedSelfVirtuals }
+
+// DynamicVirtuals returns _shard_num plus the virtuals of the remote
+// table, recursing through chained Distributed tables. Cycles are
+// broken by a visited set. With r == nil or the remote not modelled in
+// the schema, only _shard_num is returned.
+func (e EngineDistributed) DynamicVirtuals(r TableResolver) []DeclaredColumn {
+	return distributedVirtuals(e, r, map[string]bool{})
+}
+
+func distributedVirtuals(e EngineDistributed, r TableResolver, seen map[string]bool) []DeclaredColumn {
+	out := append([]DeclaredColumn(nil), distributedSelfVirtuals...)
+	if r == nil {
+		return out
+	}
+	key := e.RemoteDatabase + "." + e.RemoteTable
+	if seen[key] {
+		return out
+	}
+	seen[key] = true
+
+	remote, ok := r.LookupTable(e.RemoteDatabase, e.RemoteTable)
+	if !ok || remote.Engine == nil {
+		return out
+	}
+
+	var inherited []DeclaredColumn
+	switch inner := remote.Engine.Decoded.(type) {
+	case EngineDistributed:
+		inherited = distributedVirtuals(inner, r, seen)
+	default:
+		if v, ok := remote.Engine.Decoded.(EngineWithVirtuals); ok {
+			inherited = v.Virtuals()
+		}
+	}
+
+	have := map[string]bool{}
+	for _, c := range out {
+		have[c.Name] = true
+	}
+	for _, c := range inherited {
+		if !have[c.Name] {
+			out = append(out, c)
+			have[c.Name] = true
+		}
+	}
+	return out
+}
+
 // DecodeEngine dispatches on spec.Kind and decodes the body into a kind-specific
 // struct. Returns (nil, nil) when spec is nil.
 func DecodeEngine(spec *EngineSpec) (Engine, error) {

--- a/internal/loader/hcl/resolver.go
+++ b/internal/loader/hcl/resolver.go
@@ -212,6 +212,23 @@ func resolveDatabase(db *DatabaseSpec) error {
 		}
 	}
 
+	// MV resolution must happen BEFORE the abstract-table drop below, so
+	// abstract parents are still present in db.Tables / indexByName when
+	// each extending MV looks them up.
+	mvIndex := make(map[string]bool, len(db.MaterializedViews))
+	for i := range db.MaterializedViews {
+		name := db.MaterializedViews[i].Name
+		if mvIndex[name] {
+			return fmt.Errorf("%s: duplicate materialized_view %q", db.Name, name)
+		}
+		mvIndex[name] = true
+	}
+	for i := range db.MaterializedViews {
+		if err := resolveMaterializedView(db, i, indexByName, mvIndex); err != nil {
+			return err
+		}
+	}
+
 	kept := db.Tables[:0]
 	for _, t := range db.Tables {
 		if !t.Abstract {
@@ -220,14 +237,28 @@ func resolveDatabase(db *DatabaseSpec) error {
 	}
 	db.Tables = kept
 
-	// Cascade the database-level cluster default into each table that
-	// hasn't set its own. Done after abstracts are dropped so we never
-	// touch tables that won't be emitted.
+	keptMVs := db.MaterializedViews[:0]
+	for _, mv := range db.MaterializedViews {
+		if !mv.Abstract {
+			keptMVs = append(keptMVs, mv)
+		}
+	}
+	db.MaterializedViews = keptMVs
+
+	// Cascade the database-level cluster default into each table and MV
+	// that hasn't set its own. Done after abstracts are dropped so we
+	// never touch objects that won't be emitted.
 	if db.Cluster != nil {
 		for i := range db.Tables {
 			if db.Tables[i].Cluster == nil {
 				v := *db.Cluster
 				db.Tables[i].Cluster = &v
+			}
+		}
+		for i := range db.MaterializedViews {
+			if db.MaterializedViews[i].Cluster == nil {
+				v := *db.Cluster
+				db.MaterializedViews[i].Cluster = &v
 			}
 		}
 	}
@@ -241,6 +272,14 @@ func resolveDatabase(db *DatabaseSpec) error {
 		}
 		if err := validateConstraints(db.Name, t); err != nil {
 			return err
+		}
+	}
+	for _, mv := range db.MaterializedViews {
+		if mv.ToTable == "" {
+			return fmt.Errorf("%s.%s: materialized_view requires to_table", db.Name, mv.Name)
+		}
+		if mv.Query == "" {
+			return fmt.Errorf("%s.%s: materialized_view requires query", db.Name, mv.Name)
 		}
 	}
 	return nil
@@ -321,6 +360,56 @@ func resolveTable(db *DatabaseSpec, idx int, indexByName map[string]int, resolve
 	}
 	t.Extend = nil
 	resolved[t.Name] = true
+	return nil
+}
+
+// resolveMaterializedView merges an MV's `extend` parent (an abstract
+// table) into the MV. Only column/cluster/comment flow from the parent;
+// engine, order_by, etc. are table-only concepts. Must run before
+// abstract tables are dropped from db.Tables.
+func resolveMaterializedView(db *DatabaseSpec, idx int, tableIndex map[string]int, mvIndex map[string]bool) error {
+	mv := &db.MaterializedViews[idx]
+	if mv.Extend == nil {
+		return nil
+	}
+	parentName := *mv.Extend
+	if mvIndex[parentName] {
+		return fmt.Errorf("%s.%s: materialized_view cannot extend another materialized_view %q (extend an abstract table instead)", db.Name, mv.Name, parentName)
+	}
+	parentIdx, ok := tableIndex[parentName]
+	if !ok {
+		return fmt.Errorf("%s.%s: extend references unknown table %q", db.Name, mv.Name, parentName)
+	}
+	parent := &db.Tables[parentIdx]
+	if !parent.Abstract {
+		return fmt.Errorf("%s.%s: extend target %q must be an abstract table", db.Name, mv.Name, parentName)
+	}
+
+	if len(parent.Columns) > 0 || len(mv.Columns) > 0 {
+		merged := make([]ColumnSpec, 0, len(parent.Columns)+len(mv.Columns))
+		seen := make(map[string]bool, len(parent.Columns)+len(mv.Columns))
+		for _, c := range parent.Columns {
+			seen[c.Name] = true
+			merged = append(merged, c)
+		}
+		for _, c := range mv.Columns {
+			if seen[c.Name] {
+				return fmt.Errorf("%s.%s: column %q collides with inherited column", db.Name, mv.Name, c.Name)
+			}
+			seen[c.Name] = true
+			merged = append(merged, c)
+		}
+		mv.Columns = merged
+	}
+	if mv.Cluster == nil && parent.Cluster != nil {
+		v := *parent.Cluster
+		mv.Cluster = &v
+	}
+	if mv.Comment == nil && parent.Comment != nil {
+		v := *parent.Comment
+		mv.Comment = &v
+	}
+	mv.Extend = nil
 	return nil
 }
 

--- a/internal/loader/hcl/resolver_test.go
+++ b/internal/loader/hcl/resolver_test.go
@@ -299,6 +299,165 @@ func TestResolve_KafkaEngine_XOR(t *testing.T) {
 	}
 }
 
+// mvExtendBase returns the canonical four-tier schema used by the MV-extend
+// tests: an abstract base table, three concrete tables (Kafka/local/Distributed)
+// extending it, and an MV that also extends it. Built in memory so individual
+// tests can mutate single fields to exercise edge cases without copy-paste.
+func mvExtendBase() *Schema {
+	cols := []ColumnSpec{
+		{Name: "timestamp", Type: "DateTime64(3)"},
+		{Name: "team_id", Type: "UInt32"},
+		{Name: "event", Type: "String"},
+	}
+	return &Schema{Databases: []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{
+			{Name: "events_base", Abstract: true, Columns: cols},
+			{
+				Name:    "events_local",
+				Extend:  ptr("events_base"),
+				OrderBy: []string{"team_id", "timestamp"},
+				Engine: &EngineSpec{
+					Kind: "replicated_merge_tree",
+					Decoded: EngineReplicatedMergeTree{
+						ZooPath:     "/clickhouse/tables/{shard}/events",
+						ReplicaName: "{replica}",
+					},
+				},
+			},
+		},
+		MaterializedViews: []MaterializedViewSpec{{
+			Name:    "events_mv",
+			Extend:  ptr("events_base"),
+			ToTable: "events_local",
+			Query:   "SELECT timestamp, team_id, event FROM events_kafka",
+		}},
+	}}}
+}
+
+func TestResolve_MVExtendsAbstractTable(t *testing.T) {
+	schema, err := ParseFile(filepath.Join("testdata", "resolve_mv_extend.hcl"))
+	require.NoError(t, err)
+	require.NoError(t, Resolve(schema))
+
+	require.Len(t, schema.Databases, 1)
+	db := schema.Databases[0]
+
+	// Abstract base is dropped; three concrete tables remain.
+	assert.Equal(t, []string{"events_kafka", "events_local", "events_distributed"},
+		[]string{db.Tables[0].Name, db.Tables[1].Name, db.Tables[2].Name})
+	require.Len(t, db.MaterializedViews, 1)
+	mv := db.MaterializedViews[0]
+	assert.Equal(t, "events_mv", mv.Name)
+	assert.Nil(t, mv.Extend, "extend should be cleared after resolution")
+	assert.Equal(t, []ColumnSpec{
+		{Name: "timestamp", Type: "DateTime64(3)"},
+		{Name: "team_id", Type: "UInt32"},
+		{Name: "event", Type: "String"},
+		{Name: "properties", Type: "String", Codec: ptr("ZSTD(3)")},
+	}, mv.Columns)
+	// db.Cluster cascades into the MV.
+	require.NotNil(t, mv.Cluster)
+	assert.Equal(t, "main", *mv.Cluster)
+}
+
+func TestResolve_MVExtendsAbstract_WithExtraColumns(t *testing.T) {
+	s := mvExtendBase()
+	mv := &s.Databases[0].MaterializedViews[0]
+	mv.Columns = []ColumnSpec{{Name: "extra", Type: "UInt8"}}
+	require.NoError(t, Resolve(s))
+	assert.Equal(t, []ColumnSpec{
+		{Name: "timestamp", Type: "DateTime64(3)"},
+		{Name: "team_id", Type: "UInt32"},
+		{Name: "event", Type: "String"},
+		{Name: "extra", Type: "UInt8"},
+	}, s.Databases[0].MaterializedViews[0].Columns)
+}
+
+func TestResolve_MVExtendsAbstract_ColumnCollision(t *testing.T) {
+	s := mvExtendBase()
+	mv := &s.Databases[0].MaterializedViews[0]
+	mv.Columns = []ColumnSpec{{Name: "team_id", Type: "UInt64"}}
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "team_id")
+	assert.Contains(t, err.Error(), "collides")
+}
+
+func TestResolve_MVExtendsConcreteTable_Rejected(t *testing.T) {
+	s := mvExtendBase()
+	mv := &s.Databases[0].MaterializedViews[0]
+	mv.Extend = ptr("events_local")
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be an abstract table")
+}
+
+func TestResolve_MVExtendsUnknownName(t *testing.T) {
+	s := mvExtendBase()
+	mv := &s.Databases[0].MaterializedViews[0]
+	mv.Extend = ptr("does_not_exist")
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does_not_exist")
+}
+
+func TestResolve_MVExtendsMV_Rejected(t *testing.T) {
+	s := mvExtendBase()
+	db := &s.Databases[0]
+	db.MaterializedViews = append(db.MaterializedViews, MaterializedViewSpec{
+		Name:    "events_mv_2",
+		Extend:  ptr("events_mv"),
+		ToTable: "events_local",
+		Query:   "SELECT * FROM events_kafka",
+	})
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot extend another materialized_view")
+}
+
+func TestResolve_AbstractMV_Dropped(t *testing.T) {
+	s := mvExtendBase()
+	db := &s.Databases[0]
+	db.MaterializedViews[0] = MaterializedViewSpec{
+		Name:     "events_mv_template",
+		Abstract: true,
+		Columns:  []ColumnSpec{{Name: "x", Type: "UInt8"}},
+	}
+	require.NoError(t, Resolve(s))
+	assert.Empty(t, s.Databases[0].MaterializedViews, "abstract MV should be dropped")
+}
+
+func TestResolve_NonAbstractMV_RequiresToTable(t *testing.T) {
+	s := mvExtendBase()
+	mv := &s.Databases[0].MaterializedViews[0]
+	mv.ToTable = ""
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires to_table")
+}
+
+func TestResolve_NonAbstractMV_RequiresQuery(t *testing.T) {
+	s := mvExtendBase()
+	mv := &s.Databases[0].MaterializedViews[0]
+	mv.Query = ""
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires query")
+}
+
+func TestResolve_DatabaseClusterCascadesToMV(t *testing.T) {
+	s := mvExtendBase()
+	s.Databases[0].Cluster = ptr("posthog")
+	// MV does not extend, does not set its own cluster.
+	s.Databases[0].MaterializedViews[0].Extend = nil
+	s.Databases[0].MaterializedViews[0].Cluster = nil
+	require.NoError(t, Resolve(s))
+	mv := s.Databases[0].MaterializedViews[0]
+	require.NotNil(t, mv.Cluster)
+	assert.Equal(t, "posthog", *mv.Cluster)
+}
+
 func TestResolve_KafkaCollectionReference(t *testing.T) {
 	s := &Schema{Databases: []DatabaseSpec{{
 		Name: "db",

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -1,6 +1,7 @@
 package hcl
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -267,6 +268,49 @@ func TestSQLGen_DropView(t *testing.T) {
 		{Database: "posthog", DropMaterializedViews: []string{"metrics_mv"}},
 	}})
 	assert.Equal(t, []string{"DROP VIEW posthog.metrics_mv"}, out.Statements)
+}
+
+// TestSQLGen_FourTierMVExtend exercises the Kafka -> MV -> local -> Distributed
+// pipeline where all four objects share columns via one abstract base. It is
+// the end-to-end check that `extend` on materialized_view emits the inherited
+// column list in the generated DDL.
+func TestSQLGen_FourTierMVExtend(t *testing.T) {
+	schema, err := ParseFile(filepath.Join("testdata", "resolve_mv_extend.hcl"))
+	require.NoError(t, err)
+	require.NoError(t, Resolve(schema))
+
+	out := GenerateSQL(Diff(nil, schema))
+	require.Empty(t, out.Unsafe)
+	require.Len(t, out.Statements, 4)
+	joined := strings.Join(out.Statements, "\n")
+
+	assert.Contains(t, joined, "CREATE TABLE default.events_kafka")
+	assert.Contains(t, joined, "CREATE TABLE default.events_local")
+	assert.Contains(t, joined, "CREATE TABLE default.events_distributed")
+	assert.Contains(t, joined, "CREATE MATERIALIZED VIEW default.events_mv")
+
+	// Every inherited column appears on all four objects (3 tables emit
+	// multi-line CREATE column lists, MV emits inline; assert per-column
+	// count = 4 against the joined output).
+	for _, col := range []string{"timestamp DateTime64(3)", "team_id UInt32", "event String", "properties String CODEC(ZSTD(3))"} {
+		assert.Equal(t, 4, strings.Count(joined, col), "column fragment %q should appear once per object", col)
+	}
+
+	// MV emits the column list inline between TO <table> and AS.
+	assert.Contains(t, joined, "TO events_local (timestamp DateTime64(3), team_id UInt32, event String, properties String CODEC(ZSTD(3))) AS SELECT")
+
+	// db.Cluster cascades to ON CLUSTER on every emitted object.
+	assert.Equal(t, 4, strings.Count(joined, "ON CLUSTER main"))
+
+	// Distributed table is created after the local table it points at;
+	// MV is created after both source (Kafka) and destination (local).
+	localIdx := strings.Index(joined, "CREATE TABLE default.events_local")
+	distIdx := strings.Index(joined, "CREATE TABLE default.events_distributed")
+	mvIdx := strings.Index(joined, "CREATE MATERIALIZED VIEW default.events_mv")
+	kafkaIdx := strings.Index(joined, "CREATE TABLE default.events_kafka")
+	assert.Less(t, localIdx, distIdx, "local must precede Distributed")
+	assert.Less(t, localIdx, mvIdx, "local (MV destination) must precede MV")
+	assert.Less(t, kafkaIdx, mvIdx, "kafka (MV source) must precede MV")
 }
 
 func TestSQLGen_MaterializedViewRecreateUnsafe(t *testing.T) {

--- a/internal/loader/hcl/testdata/resolve_mv_extend.hcl
+++ b/internal/loader/hcl/testdata/resolve_mv_extend.hcl
@@ -1,0 +1,50 @@
+database "default" {
+  cluster = "main"
+
+  table "events_base" {
+    abstract = true
+    column "timestamp"  { type = "DateTime64(3)" }
+    column "team_id"    { type = "UInt32" }
+    column "event"      { type = "String" }
+    column "properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+  }
+
+  table "events_kafka" {
+    extend = "events_base"
+    engine "kafka" {
+      broker_list = "kafka:9092"
+      topic_list  = "events"
+      group_name  = "ch_events"
+      format      = "JSONEachRow"
+    }
+  }
+
+  table "events_local" {
+    extend = "events_base"
+    engine "replicated_merge_tree" {
+      zoo_path     = "/clickhouse/tables/{shard}/events"
+      replica_name = "{replica}"
+    }
+    order_by     = ["team_id", "timestamp"]
+    partition_by = "toYYYYMM(timestamp)"
+  }
+
+  table "events_distributed" {
+    extend = "events_base"
+    engine "distributed" {
+      cluster_name    = "main"
+      remote_database = "default"
+      remote_table    = "events_local"
+      sharding_key    = "cityHash64(team_id)"
+    }
+  }
+
+  materialized_view "events_mv" {
+    extend   = "events_base"
+    to_table = "events_local"
+    query    = "SELECT timestamp, team_id, event, properties FROM events_kafka"
+  }
+}

--- a/internal/loader/hcl/types.go
+++ b/internal/loader/hcl/types.go
@@ -15,8 +15,9 @@ type DatabaseSpec struct {
 	Patches []PatchTableSpec `hcl:"patch_table,block" diff:"-"`
 
 	// MaterializedViews are a sibling collection to Tables, not a flavored
-	// TableSpec. MVs do not participate in the table inheritance system
-	// (extend / abstract / patch_table).
+	// TableSpec. They may `extend` an `abstract = true` table to inherit
+	// its column list (and optionally cluster/comment); `patch_table` does
+	// not apply to MVs.
 	MaterializedViews []MaterializedViewSpec `hcl:"materialized_view,block"`
 
 	// Dictionaries are a third sibling collection. Like MVs, they do not
@@ -35,11 +36,19 @@ type DatabaseSpec struct {
 // (ENGINE = ...), refreshable MVs (REFRESH ...), and window views are not
 // supported and are rejected with a clear error during introspection.
 type MaterializedViewSpec struct {
-	Name    string       `hcl:"name,label"`
-	ToTable string       `hcl:"to_table"`         // TO <db.>table target (required)
-	Columns []ColumnSpec `hcl:"column,block"`     // explicit column list (may be empty)
-	Query   string       `hcl:"query"`            // the AS SELECT ... body
-	Cluster *string      `hcl:"cluster,optional"` // ON CLUSTER
+	Name string `hcl:"name,label"`
+
+	// Inheritance fields. Consumed during resolution; not part of the
+	// schema for diff purposes. Extend names an abstract table whose
+	// columns (and optionally cluster/comment) are merged into this MV.
+	// Abstract MVs are dropped before diff, like abstract tables.
+	Extend   *string `hcl:"extend,optional"   diff:"-"`
+	Abstract bool    `hcl:"abstract,optional" diff:"-"`
+
+	ToTable string       `hcl:"to_table,optional"` // TO <db.>table target (required when not abstract)
+	Columns []ColumnSpec `hcl:"column,block"`      // explicit column list (may be empty; merged with parent on extend)
+	Query   string       `hcl:"query,optional"`    // the AS SELECT ... body (required when not abstract)
+	Cluster *string      `hcl:"cluster,optional"`  // ON CLUSTER
 	Comment *string      `hcl:"comment,optional"`
 }
 

--- a/internal/loader/hcl/validate.go
+++ b/internal/loader/hcl/validate.go
@@ -14,6 +14,13 @@ const (
 	DepMVDest            = "mv_dest"            // a materialized view writes into this table
 	DepDistributedRemote = "distributed_remote" // a Distributed table forwards to this table
 	DepViewSource        = "view_source"        // a plain view reads from this table
+
+	// KindMVColumn flags a materialized view that references a column its
+	// single source table does not provide (declared columns plus the
+	// engine's virtual columns). This is a heuristic check, restricted to
+	// virtual-prefixed names (those starting with `_`) and to MVs with a
+	// single resolvable source and no JOIN/CTE/UNION/subquery/SELECT *.
+	KindMVColumn = "mv_column"
 )
 
 // ObjectRef identifies a schema object (table or materialized view) by its
@@ -459,6 +466,25 @@ func Validate(dbs []DatabaseSpec, skip SkipSet) []ValidationError {
 		}
 	}
 
+	// MV column validation (heuristic, virtual-prefixed names only).
+	// Runs in addition to the dependency check above. Same skip rules.
+	resolver := NewSchemaResolver(dbs)
+	tablesByRef := map[ObjectRef]TableSpec{}
+	for _, db := range dbs {
+		for _, t := range db.Tables {
+			tablesByRef[ObjectRef{Database: db.Name, Name: t.Name}] = t
+		}
+	}
+	for _, db := range dbs {
+		for _, mv := range db.MaterializedViews {
+			from := ObjectRef{Database: db.Name, Name: mv.Name}
+			if skip.Skips(from) {
+				continue
+			}
+			errs = append(errs, validateMVColumns(from, mv, db.Name, tablesByRef, resolver)...)
+		}
+	}
+
 	sort.Slice(errs, func(i, j int) bool {
 		if errs[i].Object != errs[j].Object {
 			return errs[i].Object.String() < errs[j].Object.String()
@@ -466,6 +492,238 @@ func Validate(dbs []DatabaseSpec, skip SkipSet) []ValidationError {
 		return errs[i].Missing.String() < errs[j].Missing.String()
 	})
 	return errs
+}
+
+// validateMVColumns runs the heuristic virtual-column reference check on
+// a single MV. Returns an empty slice when the query is too complex to
+// attribute, when the source can't be resolved to a known TableSpec, or
+// when no virtual-prefixed refs are unknown.
+func validateMVColumns(from ObjectRef, mv MaterializedViewSpec, defaultDB string, tables map[ObjectRef]TableSpec, r TableResolver) []ValidationError {
+	sources, err := extractSourceTables(mv.Query)
+	if err != nil || len(sources) != 1 {
+		return nil
+	}
+	src := sources[0]
+	if src.Database == "" {
+		src.Database = defaultDB
+	}
+	srcSpec, ok := tables[src]
+	if !ok {
+		return nil
+	}
+	refs, ok := mvVirtualPrefixedRefs(mv.Query)
+	if !ok {
+		return nil
+	}
+	provided := ColumnsProvidedBy(srcSpec, r)
+	providedNames := make(map[string]bool, len(provided))
+	hasHeadersDotted := false
+	for _, c := range provided {
+		providedNames[c.Name] = true
+		if !hasHeadersDotted && strings.HasPrefix(c.Name, "_headers.") {
+			hasHeadersDotted = true
+		}
+	}
+	if hasHeadersDotted {
+		providedNames["_headers"] = true // accept the bare Nested parent too
+	}
+
+	// Sort refs for deterministic errors.
+	names := make([]string, 0, len(refs))
+	for n := range refs {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var errs []ValidationError
+	for _, ref := range names {
+		if providedNames[ref] {
+			continue
+		}
+		errs = append(errs, ValidationError{
+			Object:  from,
+			Missing: ObjectRef{Database: src.Database, Name: ref},
+			Kind:    KindMVColumn,
+			Reason: fmt.Sprintf("materialized view references column %q which is not provided by source table %q (declared columns or %s virtual columns)",
+				ref, src, sourceEngineKind(srcSpec)),
+		})
+	}
+	return errs
+}
+
+// sourceEngineKind returns the engine kind name for the error message, or
+// "(no engine)" when the source has none (shouldn't happen post-resolve).
+func sourceEngineKind(t TableSpec) string {
+	if t.Engine != nil && t.Engine.Decoded != nil {
+		return t.Engine.Decoded.Kind()
+	}
+	return "(no engine)"
+}
+
+// mvVirtualPrefixedRefs parses an MV query and returns the set of
+// underscore-prefixed identifier names it references. ok=false signals
+// the caller should skip the check (query has JOIN, UNION, CTE, subquery
+// in FROM, or SELECT *).
+//
+// The leading-underscore heuristic deliberately scopes the check to
+// virtual-column-like names so the bare-Ident walk can't false-positive
+// on regular columns we couldn't attribute precisely.
+func mvVirtualPrefixedRefs(query string) (map[string]bool, bool) {
+	stmts, err := chparser.NewParser(query).ParseStmts()
+	if err != nil || len(stmts) == 0 {
+		return nil, false
+	}
+	var sel *chparser.SelectQuery
+	for _, n := range chparser.FindAll(stmts[0], isSelectQuery) {
+		sel = n.(*chparser.SelectQuery)
+		break
+	}
+	if sel == nil {
+		return nil, false
+	}
+	// Bail on structural complexity.
+	if sel.UnionAll != nil || sel.UnionDistinct != nil || sel.Except != nil {
+		return nil, false
+	}
+	if sel.With != nil && len(sel.With.CTEs) > 0 {
+		return nil, false
+	}
+	if !isSimpleFrom(sel.From) {
+		return nil, false
+	}
+	if hasStarSelectItem(sel) {
+		return nil, false
+	}
+
+	// Collect alias names introduced by SELECT items so they don't
+	// surface as refs.
+	aliasNames := map[string]bool{}
+	for _, item := range sel.SelectItems {
+		if item.Alias != nil {
+			aliasNames[stripBackticks(item.Alias.Name)] = true
+		}
+	}
+
+	// Collect Idents we must NOT treat as column refs: function names,
+	// table-qualifier Idents, alias-target Idents. Compared by pointer
+	// identity since FindAll returns shared nodes.
+	skip := map[*chparser.Ident]bool{}
+	for _, n := range chparser.FindAll(sel, func(e chparser.Expr) bool {
+		_, ok := e.(*chparser.FunctionExpr)
+		return ok
+	}) {
+		f := n.(*chparser.FunctionExpr)
+		if f.Name != nil {
+			skip[f.Name] = true
+		}
+	}
+	for _, n := range chparser.FindAll(sel, isTableIdentifier) {
+		t := n.(*chparser.TableIdentifier)
+		if t.Database != nil {
+			skip[t.Database] = true
+		}
+		if t.Table != nil {
+			skip[t.Table] = true
+		}
+	}
+	for _, n := range chparser.FindAll(sel, func(e chparser.Expr) bool {
+		_, ok := e.(*chparser.Path)
+		return ok
+	}) {
+		p := n.(*chparser.Path)
+		// Path qualifier idents (db, table) are not column refs; only
+		// the final Ident is. Skip every Ident except the last.
+		if len(p.Fields) > 1 {
+			for i := 0; i < len(p.Fields)-1; i++ {
+				skip[p.Fields[i]] = true
+			}
+		}
+	}
+	for _, item := range sel.SelectItems {
+		if item.Alias != nil {
+			skip[item.Alias] = true
+		}
+	}
+
+	refs := map[string]bool{}
+	for _, n := range chparser.FindAll(sel, func(e chparser.Expr) bool {
+		_, ok := e.(*chparser.Ident)
+		return ok
+	}) {
+		id := n.(*chparser.Ident)
+		if skip[id] {
+			continue
+		}
+		name := stripBackticks(id.Name)
+		if !strings.HasPrefix(name, "_") {
+			continue
+		}
+		if aliasNames[name] {
+			continue
+		}
+		refs[name] = true
+	}
+	for _, n := range chparser.FindAll(sel, func(e chparser.Expr) bool {
+		_, ok := e.(*chparser.NestedIdentifier)
+		return ok
+	}) {
+		ni := n.(*chparser.NestedIdentifier)
+		if ni.Ident == nil || ni.DotIdent == nil {
+			continue
+		}
+		name := stripBackticks(ni.Ident.Name) + "." + stripBackticks(ni.DotIdent.Name)
+		if !strings.HasPrefix(name, "_") {
+			continue
+		}
+		if aliasNames[name] {
+			continue
+		}
+		refs[name] = true
+	}
+	return refs, true
+}
+
+// isSimpleFrom reports whether the FROM clause is a single, plain
+// TableIdentifier — no JOIN, no subquery, no table-function call. The
+// parser wraps every FROM in JoinTableExpr → TableExpr → inner; the inner
+// must be a TableIdentifier or bare Ident. JoinExpr at the top means a
+// real JOIN; SubQuery at the inner means a FROM-subquery. Both bail.
+func isSimpleFrom(f *chparser.FromClause) bool {
+	if f == nil {
+		return false
+	}
+	jte, ok := f.Expr.(*chparser.JoinTableExpr)
+	if !ok {
+		return false
+	}
+	if jte.Table == nil {
+		return false
+	}
+	switch jte.Table.Expr.(type) {
+	case *chparser.TableIdentifier, *chparser.Ident:
+		return true
+	default:
+		return false
+	}
+}
+
+// hasStarSelectItem reports whether any SELECT item is a `*` or `t.*`.
+// Detected by walking the SelectItem expressions for any Ident whose
+// name is "*" — the chparser models the star as such.
+func hasStarSelectItem(sel *chparser.SelectQuery) bool {
+	for _, item := range sel.SelectItems {
+		if item == nil || item.Expr == nil {
+			continue
+		}
+		for _, n := range chparser.FindAll(item.Expr, func(e chparser.Expr) bool {
+			id, ok := e.(*chparser.Ident)
+			return ok && id != nil && id.Name == "*"
+		}) {
+			_ = n
+			return true
+		}
+	}
+	return false
 }
 
 func depPhrase(kind string) string {

--- a/internal/loader/hcl/validate_test.go
+++ b/internal/loader/hcl/validate_test.go
@@ -326,3 +326,136 @@ func TestExtractDeclaredColumns(t *testing.T) {
 		})
 	}
 }
+
+// --- MV column validation (heuristic) ----------------------------------
+
+// mvKafkaFixture builds a single-DB schema with a Kafka source table and
+// an MV writing to a (non-existent in v1 fixtures) destination — the
+// destination's existence is checked by the dependency pass, not the
+// column pass, so we declare a stub destination too.
+func mvKafkaFixture(query string, sourceCols ...ColumnSpec) []DatabaseSpec {
+	dest := TableSpec{
+		Name:    "events_local",
+		Columns: sourceCols,
+		Engine:  &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}},
+	}
+	src := TableSpec{
+		Name:    "events_kafka",
+		Columns: sourceCols,
+		Engine: &EngineSpec{Kind: "kafka", Decoded: EngineKafka{
+			BrokerList: ptr("k:9092"), TopicList: ptr("ev"),
+			GroupName: ptr("g"), Format: ptr("JSONEachRow"),
+		}},
+	}
+	mv := MaterializedViewSpec{
+		Name:    "events_mv",
+		ToTable: "events_local",
+		Query:   query,
+	}
+	return []DatabaseSpec{{
+		Name:              "default",
+		Tables:            []TableSpec{src, dest},
+		MaterializedViews: []MaterializedViewSpec{mv},
+	}}
+}
+
+func TestValidate_MVColumn_VirtualRefAccepted(t *testing.T) {
+	dbs := mvKafkaFixture(
+		"SELECT _offset, team_id FROM events_kafka",
+		ColumnSpec{Name: "team_id", Type: "UInt32"},
+	)
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, KindMVColumn, e.Kind, "real Kafka virtual must not be flagged: %s", e.Reason)
+	}
+}
+
+func TestValidate_MVColumn_BogusVirtualRefFlagged(t *testing.T) {
+	dbs := mvKafkaFixture(
+		"SELECT _offsett, team_id FROM events_kafka",
+		ColumnSpec{Name: "team_id", Type: "UInt32"},
+	)
+	errs := Validate(dbs, SkipSet{})
+	var mvErr *ValidationError
+	for i := range errs {
+		if errs[i].Kind == KindMVColumn {
+			mvErr = &errs[i]
+		}
+	}
+	require.NotNil(t, mvErr, "typo'd virtual should be flagged")
+	assert.Contains(t, mvErr.Reason, "_offsett")
+	assert.Equal(t, "events_mv", mvErr.Object.Name)
+}
+
+func TestValidate_MVColumn_HeadersDottedRefAccepted(t *testing.T) {
+	dbs := mvKafkaFixture(
+		"SELECT _headers.name, team_id FROM events_kafka",
+		ColumnSpec{Name: "team_id", Type: "UInt32"},
+	)
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, KindMVColumn, e.Kind, "_headers.name is a real Kafka virtual: %s", e.Reason)
+	}
+}
+
+func TestValidate_MVColumn_DeclaredColumnNotFlagged(t *testing.T) {
+	// _meta is declared on the source — should pass even though it starts
+	// with `_` and is not a Kafka virtual.
+	dbs := mvKafkaFixture(
+		"SELECT _meta, team_id FROM events_kafka",
+		ColumnSpec{Name: "team_id", Type: "UInt32"},
+		ColumnSpec{Name: "_meta", Type: "String"},
+	)
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, KindMVColumn, e.Kind, "declared column must not be flagged: %s", e.Reason)
+	}
+}
+
+func TestValidate_MVColumn_SelectStarSkipped(t *testing.T) {
+	dbs := mvKafkaFixture(
+		"SELECT * FROM events_kafka",
+		ColumnSpec{Name: "team_id", Type: "UInt32"},
+	)
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, KindMVColumn, e.Kind, "SELECT * must skip the column check: %s", e.Reason)
+	}
+}
+
+func TestValidate_MVColumn_JoinSkipped(t *testing.T) {
+	// JOIN with second source ⇒ attribution ambiguous ⇒ bail.
+	dbs := mvKafkaFixture(
+		"SELECT _offsett, team_id FROM events_kafka JOIN events_local USING team_id",
+		ColumnSpec{Name: "team_id", Type: "UInt32"},
+	)
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, KindMVColumn, e.Kind, "JOIN must skip the column check: %s", e.Reason)
+	}
+}
+
+func TestValidate_MVColumn_AliasNotFlagged(t *testing.T) {
+	// An aliased projection like `countState() AS _agg_count` introduces
+	// the name `_agg_count` — it's an output binding, not a source ref.
+	dbs := mvKafkaFixture(
+		"SELECT countState() AS _agg_count, team_id FROM events_kafka GROUP BY team_id",
+		ColumnSpec{Name: "team_id", Type: "UInt32"},
+	)
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, KindMVColumn, e.Kind, "alias name must not be flagged as a source ref: %s", e.Reason)
+	}
+}
+
+func TestValidate_MVColumn_SkipSetWorks(t *testing.T) {
+	dbs := mvKafkaFixture(
+		"SELECT _offsett, team_id FROM events_kafka",
+		ColumnSpec{Name: "team_id", Type: "UInt32"},
+	)
+	skip := ParseSkipSet("events_mv")
+	errs := Validate(dbs, skip)
+	for _, e := range errs {
+		assert.NotEqual(t, KindMVColumn, e.Kind, "skip should suppress mv_column: %s", e.Reason)
+	}
+}

--- a/internal/loader/hcl/virtual_columns.go
+++ b/internal/loader/hcl/virtual_columns.go
@@ -1,0 +1,159 @@
+package hcl
+
+// EngineWithVirtuals is the optional interface an Engine implements when
+// ClickHouse exposes implicit columns on tables of that kind. The returned
+// set is static — derived from the engine's settings only, not from other
+// tables in the schema. Engines with no virtuals (e.g. Log) simply don't
+// implement it.
+type EngineWithVirtuals interface {
+	Engine
+	Virtuals() []DeclaredColumn
+}
+
+// EngineWithDynamicVirtuals is implemented by engines whose implicit
+// column set depends on other tables in the schema — for example,
+// Distributed, which exposes _shard_num plus the virtuals of its remote
+// table. When an engine implements both interfaces, the dynamic form is
+// authoritative.
+type EngineWithDynamicVirtuals interface {
+	Engine
+	DynamicVirtuals(r TableResolver) []DeclaredColumn
+}
+
+// TableResolver is the minimum lookup surface dynamic-virtuals engines
+// need. Pass nil when no schema context is available — dynamic engines
+// must degrade gracefully (Distributed returns just _shard_num).
+type TableResolver interface {
+	LookupTable(db, name string) (TableSpec, bool)
+}
+
+// VirtualColumnsFor returns the engine-defined implicit columns for e,
+// or nil if the engine has none / e is nil. Dispatch is by interface
+// assertion, not by Kind() switch — adding a new engine with virtuals
+// only requires implementing one of the optional interfaces.
+func VirtualColumnsFor(e Engine, r TableResolver) []DeclaredColumn {
+	if e == nil {
+		return nil
+	}
+	if d, ok := e.(EngineWithDynamicVirtuals); ok {
+		return d.DynamicVirtuals(r)
+	}
+	if v, ok := e.(EngineWithVirtuals); ok {
+		return v.Virtuals()
+	}
+	return nil
+}
+
+// IsVirtualColumn reports whether name is one of the implicit columns the
+// engine contributes. Used as a name guard in the diff path; mode- and
+// settings-independent on purpose — Kafka's stream-mode extras are
+// included in the membership test so a column never silently shifts
+// status when a setting changes.
+//
+// The bare Nested parent (e.g. "_headers" for Kafka) is also recognised
+// in addition to the dot-access form ("_headers.name").
+func IsVirtualColumn(e Engine, name string) bool {
+	for _, c := range allVirtualNames(e) {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ColumnsProvidedBy returns every column readable from t: declared
+// columns first (in declaration order), then engine-contributed virtual
+// columns the user has not shadowed by declaring a same-named column.
+//
+// Declared wins: a user-written `column "_key" { ... }` on a Kafka table
+// (e.g. via kafka_map_virtual_columns_on_write) appears in the output
+// and the virtual is suppressed.
+func ColumnsProvidedBy(t TableSpec, r TableResolver) []DeclaredColumn {
+	out := make([]DeclaredColumn, 0, len(t.Columns))
+	declared := make(map[string]bool, len(t.Columns))
+	for _, c := range t.Columns {
+		declared[c.Name] = true
+		out = append(out, DeclaredColumn{Name: c.Name, Type: c.Type})
+	}
+	if t.Engine == nil {
+		return out
+	}
+	for _, v := range VirtualColumnsFor(t.Engine.Decoded, r) {
+		if !declared[v.Name] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// schemaResolver is the standard TableResolver, indexing every table in a
+// flat slice of DatabaseSpec by "db.name". Pass the post-Resolve()
+// databases — abstract bases are dropped and Engine.Decoded is populated.
+type schemaResolver struct {
+	byKey map[string]TableSpec
+}
+
+// NewSchemaResolver builds a resolver over the loaded databases. Safe to
+// call with an empty slice; the resolver returns ok=false for every
+// lookup. Tables collide on (db, name); the last entry wins (Resolve
+// already errors on duplicates within a single db, so collisions only
+// happen across multiple DatabaseSpec entries for the same db name —
+// rare, and the legacy multi-layer loader already merged them).
+func NewSchemaResolver(dbs []DatabaseSpec) TableResolver {
+	r := &schemaResolver{byKey: make(map[string]TableSpec)}
+	for _, db := range dbs {
+		for _, t := range db.Tables {
+			r.byKey[db.Name+"."+t.Name] = t
+		}
+	}
+	return r
+}
+
+func (r *schemaResolver) LookupTable(db, name string) (TableSpec, bool) {
+	t, ok := r.byKey[db+"."+name]
+	return t, ok
+}
+
+// allVirtualNames returns the full name set IsVirtualColumn considers
+// virtual: the engine's normal static/dynamic virtuals plus any extra
+// well-known forms (e.g. the bare Nested parent for Kafka's "_headers").
+// Mode-independent: stream-mode names are always present so the predicate
+// is stable across setting changes.
+func allVirtualNames(e Engine) []string {
+	if e == nil {
+		return nil
+	}
+	// For the membership predicate we want the *superset* of names that
+	// might be virtual on this engine kind, independent of current
+	// settings. Build it from a settings-maximal probe.
+	var cols []DeclaredColumn
+	switch typed := e.(type) {
+	case EngineKafka:
+		// Force stream mode for the predicate so _raw_message / _error
+		// are recognised regardless of HandleErrorMode.
+		stream := "stream"
+		typed.HandleErrorMode = &stream
+		cols = typed.Virtuals()
+	case EngineDistributed:
+		// Static fallback only — the membership predicate doesn't recurse
+		// into remote tables. Diff/validate sites call VirtualColumnsFor
+		// directly with a resolver when they need the transitive set.
+		cols = typed.Virtuals()
+	default:
+		if v, ok := e.(EngineWithVirtuals); ok {
+			cols = v.Virtuals()
+		}
+	}
+	names := make([]string, 0, len(cols)+1)
+	hasHeaders := false
+	for _, c := range cols {
+		names = append(names, c.Name)
+		if !hasHeaders && len(c.Name) > len("_headers.") && c.Name[:len("_headers.")] == "_headers." {
+			hasHeaders = true
+		}
+	}
+	if hasHeaders {
+		names = append(names, "_headers")
+	}
+	return names
+}

--- a/internal/loader/hcl/virtual_columns_test.go
+++ b/internal/loader/hcl/virtual_columns_test.go
@@ -1,0 +1,254 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVirtualColumnsFor_NoEngine(t *testing.T) {
+	assert.Nil(t, VirtualColumnsFor(nil, nil))
+	assert.Nil(t, VirtualColumnsFor(EngineLog{}, nil), "Log engine has no virtuals")
+}
+
+func TestVirtualColumnsFor_MergeTreeFamilyStableSet(t *testing.T) {
+	for _, e := range []Engine{
+		EngineMergeTree{},
+		EngineReplicatedMergeTree{},
+		EngineReplacingMergeTree{},
+		EngineReplicatedReplacingMergeTree{},
+		EngineSummingMergeTree{},
+		EngineReplicatedSummingMergeTree{},
+		EngineCollapsingMergeTree{},
+		EngineReplicatedCollapsingMergeTree{},
+		EngineAggregatingMergeTree{},
+		EngineReplicatedAggregatingMergeTree{},
+	} {
+		t.Run(e.Kind(), func(t *testing.T) {
+			cols := VirtualColumnsFor(e, nil)
+			require.Len(t, cols, 7)
+			names := columnNames(cols)
+			assert.Equal(t, []string{
+				"_part", "_part_index", "_part_uuid",
+				"_partition_id", "_partition_value",
+				"_sample_factor", "_part_offset",
+			}, names)
+		})
+	}
+}
+
+func TestVirtualColumnsFor_Kafka_BaseSet(t *testing.T) {
+	cols := VirtualColumnsFor(EngineKafka{}, nil)
+	names := columnNames(cols)
+	assert.Equal(t, []string{
+		"_topic", "_key", "_offset", "_partition",
+		"_timestamp", "_timestamp_ms",
+		"_headers.name", "_headers.value",
+	}, names)
+	// Type spot-check: _topic should be LowCardinality(String), not bare String.
+	for _, c := range cols {
+		if c.Name == "_topic" {
+			assert.Equal(t, "LowCardinality(String)", c.Type)
+		}
+	}
+}
+
+func TestVirtualColumnsFor_Kafka_StreamModeAddsExtras(t *testing.T) {
+	stream := "stream"
+	cols := VirtualColumnsFor(EngineKafka{HandleErrorMode: &stream}, nil)
+	names := columnNames(cols)
+	assert.Contains(t, names, "_raw_message")
+	assert.Contains(t, names, "_error")
+}
+
+func TestVirtualColumnsFor_Kafka_DefaultModeOmitsStreamExtras(t *testing.T) {
+	defaultMode := "default"
+	cols := VirtualColumnsFor(EngineKafka{HandleErrorMode: &defaultMode}, nil)
+	names := columnNames(cols)
+	assert.NotContains(t, names, "_raw_message")
+	assert.NotContains(t, names, "_error")
+}
+
+func TestIsVirtualColumn_Kafka_RecognisesStreamNamesRegardlessOfMode(t *testing.T) {
+	// IsVirtualColumn is mode-independent: _raw_message/_error are
+	// virtual on Kafka in every mode for membership-test purposes.
+	assert.True(t, IsVirtualColumn(EngineKafka{}, "_raw_message"))
+	assert.True(t, IsVirtualColumn(EngineKafka{}, "_error"))
+}
+
+func TestIsVirtualColumn_Kafka_RecognisesHeadersNestedParent(t *testing.T) {
+	assert.True(t, IsVirtualColumn(EngineKafka{}, "_headers"))
+	assert.True(t, IsVirtualColumn(EngineKafka{}, "_headers.name"))
+	assert.True(t, IsVirtualColumn(EngineKafka{}, "_headers.value"))
+}
+
+func TestIsVirtualColumn_NonKafka_HasNoHeaders(t *testing.T) {
+	assert.False(t, IsVirtualColumn(EngineMergeTree{}, "_headers"))
+}
+
+func TestIsVirtualColumn_MissAndUnknownEngine(t *testing.T) {
+	assert.False(t, IsVirtualColumn(EngineMergeTree{}, "_offset"), "_offset is Kafka-only")
+	assert.False(t, IsVirtualColumn(EngineLog{}, "_part"), "Log engine has no virtuals")
+	assert.False(t, IsVirtualColumn(nil, "_part"))
+}
+
+func TestColumnsProvidedBy_DeclaredOnlyWhenNoEngine(t *testing.T) {
+	t1 := TableSpec{Columns: []ColumnSpec{{Name: "id", Type: "UInt64"}}}
+	cols := ColumnsProvidedBy(t1, nil)
+	assert.Equal(t, []DeclaredColumn{{Name: "id", Type: "UInt64"}}, cols)
+}
+
+func TestColumnsProvidedBy_KafkaAppendsVirtuals(t *testing.T) {
+	t1 := TableSpec{
+		Columns: []ColumnSpec{{Name: "team_id", Type: "UInt32"}},
+		Engine:  &EngineSpec{Kind: "kafka", Decoded: EngineKafka{}},
+	}
+	cols := ColumnsProvidedBy(t1, nil)
+	names := columnNames(cols)
+	// Declared first, virtuals appended.
+	assert.Equal(t, "team_id", names[0])
+	assert.Contains(t, names, "_topic")
+	assert.Contains(t, names, "_offset")
+}
+
+func TestColumnsProvidedBy_DeclaredWinsOverVirtual(t *testing.T) {
+	// User declares _key as a real column (e.g. via
+	// kafka_map_virtual_columns_on_write). The declared form must win
+	// — appear once, with the user's type, and the virtual must not
+	// be appended again.
+	t1 := TableSpec{
+		Columns: []ColumnSpec{{Name: "_key", Type: "FixedString(8)"}},
+		Engine:  &EngineSpec{Kind: "kafka", Decoded: EngineKafka{}},
+	}
+	cols := ColumnsProvidedBy(t1, nil)
+	var keyCount int
+	for _, c := range cols {
+		if c.Name == "_key" {
+			keyCount++
+			assert.Equal(t, "FixedString(8)", c.Type, "declared type must win")
+		}
+	}
+	assert.Equal(t, 1, keyCount, "_key must appear exactly once")
+}
+
+func TestVirtualColumnsFor_DistributedNoResolver_FallbackToShardNum(t *testing.T) {
+	cols := VirtualColumnsFor(EngineDistributed{RemoteDatabase: "default", RemoteTable: "t_local"}, nil)
+	assert.Equal(t, []DeclaredColumn{{Name: "_shard_num", Type: "UInt32"}}, cols)
+}
+
+func TestVirtualColumnsFor_DistributedOverMergeTree_InheritsVirtuals(t *testing.T) {
+	dbs := []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{{
+			Name:   "events_local",
+			Engine: &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}},
+		}},
+	}}
+	r := NewSchemaResolver(dbs)
+	cols := VirtualColumnsFor(
+		EngineDistributed{RemoteDatabase: "default", RemoteTable: "events_local"},
+		r,
+	)
+	names := columnNames(cols)
+	assert.Equal(t, "_shard_num", names[0], "_shard_num always first")
+	assert.Contains(t, names, "_part")
+	assert.Contains(t, names, "_partition_id")
+	assert.NotContains(t, names, "_topic", "should not include Kafka virtuals")
+}
+
+func TestVirtualColumnsFor_DistributedOverDistributed_RecursesAndDeduplicates(t *testing.T) {
+	dbs := []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{
+			{
+				Name:   "events_inner_local",
+				Engine: &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}},
+			},
+			{
+				Name: "events_inner_dist",
+				Engine: &EngineSpec{Kind: "distributed", Decoded: EngineDistributed{
+					RemoteDatabase: "default", RemoteTable: "events_inner_local",
+				}},
+			},
+		},
+	}}
+	r := NewSchemaResolver(dbs)
+	cols := VirtualColumnsFor(
+		EngineDistributed{RemoteDatabase: "default", RemoteTable: "events_inner_dist"},
+		r,
+	)
+	names := columnNames(cols)
+	// _shard_num appears once even though both layers contribute it.
+	var shardCount int
+	for _, n := range names {
+		if n == "_shard_num" {
+			shardCount++
+		}
+	}
+	assert.Equal(t, 1, shardCount, "_shard_num must be deduplicated across chained Distributeds")
+	assert.Contains(t, names, "_part", "MergeTree virtuals propagated through both layers")
+}
+
+func TestVirtualColumnsFor_DistributedCycle_NoInfiniteLoop(t *testing.T) {
+	// A pathological Distributed -> Distributed -> Distributed cycle.
+	// We must terminate and return at least _shard_num.
+	dbs := []DatabaseSpec{{
+		Name: "default",
+		Tables: []TableSpec{
+			{
+				Name: "a",
+				Engine: &EngineSpec{Kind: "distributed", Decoded: EngineDistributed{
+					RemoteDatabase: "default", RemoteTable: "b",
+				}},
+			},
+			{
+				Name: "b",
+				Engine: &EngineSpec{Kind: "distributed", Decoded: EngineDistributed{
+					RemoteDatabase: "default", RemoteTable: "a",
+				}},
+			},
+		},
+	}}
+	r := NewSchemaResolver(dbs)
+	cols := VirtualColumnsFor(
+		EngineDistributed{RemoteDatabase: "default", RemoteTable: "a"},
+		r,
+	)
+	require.NotEmpty(t, cols)
+	assert.Equal(t, "_shard_num", cols[0].Name)
+}
+
+func TestVirtualColumnsFor_DistributedMissingRemote_FallbackToShardNum(t *testing.T) {
+	r := NewSchemaResolver(nil)
+	cols := VirtualColumnsFor(
+		EngineDistributed{RemoteDatabase: "other_db", RemoteTable: "nope"},
+		r,
+	)
+	assert.Equal(t, []DeclaredColumn{{Name: "_shard_num", Type: "UInt32"}}, cols)
+}
+
+func TestSchemaResolver_LookupByQualifiedName(t *testing.T) {
+	dbs := []DatabaseSpec{{
+		Name: "posthog",
+		Tables: []TableSpec{
+			{Name: "events", Engine: &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}}},
+		},
+	}}
+	r := NewSchemaResolver(dbs)
+	got, ok := r.LookupTable("posthog", "events")
+	require.True(t, ok)
+	assert.Equal(t, "events", got.Name)
+	_, ok = r.LookupTable("posthog", "missing")
+	assert.False(t, ok)
+	_, ok = r.LookupTable("other", "events")
+	assert.False(t, ok)
+}
+
+func columnNames(cols []DeclaredColumn) []string {
+	out := make([]string, len(cols))
+	for i, c := range cols {
+		out[i] = c.Name
+	}
+	return out
+}

--- a/test/integration_live_test.go
+++ b/test/integration_live_test.go
@@ -295,14 +295,41 @@ func dropDependentDictionaries(t *testing.T, conn driver.Conn, dbName, stubsDB s
 	}
 }
 
-// kafkaVirtualColumns is the column set ClickHouse's Kafka engine
-// auto-injects on every Kafka-engine table. Stubbed sources need these
-// declared explicitly so MVs that reference `_topic`, `_partition`,
-// `_offset`, `_timestamp`, `_headers.name`, etc. pass CREATE-time
-// validation. `_headers` uses the Nested form so `_headers.name` and
-// `_headers.value` are reachable via the dot-suffix Array syntax that
-// ClickHouse exposes on real Kafka tables.
-const kafkaVirtualColumns = "`_topic` String, `_partition` UInt64, `_offset` UInt64, `_timestamp` Nullable(DateTime), `_timestamp_ms` Nullable(DateTime64(3)), `_headers` Nested(name String, value String), `_raw_message` String, `_key` String"
+// renderVirtualsForCreate emits a CREATE-statement column-list fragment
+// for the engine's virtual columns. Folds `_headers.name`/`_headers.value`
+// (the dot-access form the loader models) back into a single
+// `_headers Nested(name String, value String)` declaration so the CREATE
+// statement parses against real ClickHouse. Returns "" when the engine
+// contributes no virtuals.
+func renderVirtualsForCreate(e hclload.Engine) string {
+	cols := hclload.VirtualColumnsFor(e, nil)
+	if len(cols) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(cols))
+	var headersInner []string
+	for _, c := range cols {
+		if rest, ok := strings.CutPrefix(c.Name, "_headers."); ok {
+			headersInner = append(headersInner, fmt.Sprintf("%s %s", rest, stripArrayWrapper(c.Type)))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("`%s` %s", c.Name, c.Type))
+	}
+	if len(headersInner) > 0 {
+		parts = append(parts, fmt.Sprintf("`_headers` Nested(%s)", strings.Join(headersInner, ", ")))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// stripArrayWrapper turns "Array(String)" into "String"; ClickHouse's
+// Nested columns implicitly wrap each field in Array, so the dot-access
+// type the loader emits (Array(X)) must be unwrapped for the Nested form.
+func stripArrayWrapper(t string) string {
+	if rest, ok := strings.CutPrefix(t, "Array("); ok && strings.HasSuffix(rest, ")") {
+		return rest[:len(rest)-1]
+	}
+	return t
+}
 
 // findSourceFixture searches the testdata corpus for the original CREATE
 // statement of a referenced source table. The corpus is laid out as
@@ -332,7 +359,13 @@ func buildStubColList(cols []hclload.DeclaredColumn, isKafka bool) string {
 		parts = append(parts, fmt.Sprintf("`%s` %s", c.Name, c.Type))
 	}
 	if isKafka {
-		parts = append(parts, kafkaVirtualColumns)
+		// Stub source: emit the maximal Kafka virtual set (stream mode)
+		// so MVs referencing _raw_message / _error parse against the
+		// stub regardless of the real source's handle_error_mode.
+		stream := "stream"
+		if v := renderVirtualsForCreate(hclload.EngineKafka{HandleErrorMode: &stream}); v != "" {
+			parts = append(parts, v)
+		}
 	}
 	if len(parts) == 0 {
 		return "_dummy String"


### PR DESCRIPTION
## Summary

Two related additions that close the column-duplication gap for the PostHog-style Kafka → MV → local → Distributed pipeline.

### 1) `materialized_view` can `extend` an `abstract = true` table

The MV inherits the parent's column list (and `cluster` / `comment` if it hasn't set its own). Engine, `order_by`, and other table-only fields are not inherited. Extending a concrete table or another MV is rejected. The surrounding `database`'s `cluster` now cascades into MVs the same way it does into tables.

Useful where the MV declares its own output shape (aggregating MVs). Passthrough MVs that mirror their destination should still omit both `column` blocks and `extend` — ClickHouse derives the shape from the SELECT.

Worked example added to both `docs/FAQ.md` and `docs/README.hcl.md`.

### 2) Engine-aware virtual columns

A new optional interface pair on `Engine`:

- `EngineWithVirtuals` — static virtual set
- `EngineWithDynamicVirtuals` — schema-aware virtual set (used by `Distributed`, which transitively inherits its remote table's virtuals; cycle break + dedupe)

V1 coverage:

| Engine                | Virtual columns                                                                                       |
| --------------------- | ----------------------------------------------------------------------------------------------------- |
| MergeTree family      | `_part`, `_part_index`, `_part_uuid`, `_partition_id`, `_partition_value`, `_sample_factor`, `_part_offset` |
| Kafka                 | `_topic`, `_key`, `_offset`, `_partition`, `_timestamp`, `_timestamp_ms`, `_headers.name`, `_headers.value` (+`_raw_message`, `_error` when `handle_error_mode = "stream"`) |
| Distributed           | `_shard_num`, plus the virtuals of its remote table (transitive)                                       |
| Log, others           | none                                                                                                  |

Out of scope in v1: MergeTree's version-gated virtuals (`_block_number`, `_block_offset`, `_row_exists`).

Three consumer sites pick up the awareness, all engine-agnostic — none name "kafka":

- **MV column validation** (`hclexp validate`): heuristic walker restricted to underscore-prefixed identifier refs. Bails on JOIN/UNION/CTE/subquery/`SELECT *` and multi-source MVs. Catches typo'd `_offsett` on a Kafka source; passes legitimate `_offset` / `_timestamp` / `_headers.name`. New `ValidationError.Kind = "mv_column"`. Skip via `-skip-validation=<mv-name>`.
- **Diff guard** (`hclexp diff`): asymmetric filter inside `diffTable`. A virtual-named column is suppressed from one side only when the other side has not declared it — preventing CH-illegal `DROP COLUMN _offset` from a leaked introspector column, while still surfacing `MODIFY COLUMN` on a user-declared `_key FixedString(N)`.
- **Live-test stub builder**: replaces the hard-coded Kafka virtual constant with `renderVirtualsForCreate(EngineKafka{...stream})` plus a `_headers.name`/`_headers.value` → Nested fold. Fixes two latent stub bugs: `_topic` is now `LowCardinality(String)` (was `String`) and `_error` is included for stream mode.

### Design notes worth flagging

- **TableResolver param threaded through `VirtualColumnsFor` / `ColumnsProvidedBy`.** Pay the call-site tax now to avoid breaking the signature when Distributed transitive inheritance lands later — done in v1.
- **Adding a new engine with virtuals later** is one method: `func (E) Virtuals() []DeclaredColumn { ... }`. No changes to the foundation, the diff guard, or the validate path.
- **`_headers` is modeled as `_headers.name`/`_headers.value`** (matches how MVs reference it); the stub builder folds them back to `Nested(name String, value String)` for CREATE syntax. `IsVirtualColumn` also accepts the bare `_headers` for completeness.

### Plan document

`docs/superpowers/plans/2026-05-29-kafka-virtual-columns.md` captures the design walkthrough that landed at the current shape (deferred items, alternative designs considered, etc.).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 442/442 non-live pass
- [x] `go test ./... -clickhouse` — 566/566 live pass (179 in `./test` + 387 in `./internal/...`), confirms no snapshot drift from the `_topic` / `_error` corrections
- [ ] CI runs the same suites
- [ ] Reviewer eyeballs: MV-extend semantics for aggregating-MV / passthrough-MV split; the asymmetric diff-guard rule; the leading-underscore heuristic in MV column validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)