### PR TITLE
chore: add gofmt + go vet pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Pre-commit hook: gofmt on staged Go files + go vet on the module.
+#
+# Install once per checkout:
+#   just setup-hooks
+#   (or `git config core.hooksPath .githooks`)
+#
+# On violation the hook exits non-zero with a copy-pasteable fix command;
+# nothing is auto-rewritten.
+
+set -e
+
+staged_go=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.go$' || true)
+
+if [ -n "$staged_go" ]; then
+	# shellcheck disable=SC2086
+	unformatted=$(gofmt -l $staged_go)
+	if [ -n "$unformatted" ]; then
+		echo "pre-commit: the following files need gofmt:"
+		printf '  %s\n' $unformatted
+		echo
+		echo "Fix:"
+		# shellcheck disable=SC2086
+		printf '  gofmt -w %s\n' $unformatted
+		echo "Then re-stage and retry the commit."
+		exit 1
+	fi
+fi
+
+if ! go vet ./...; then
+	echo
+	echo "pre-commit: go vet failed (see output above)."
+	exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -633,7 +633,15 @@ just test
 
 # Live ClickHouse integration tests (needs: docker compose up -d)
 just test-live
+
+# Install the repo's pre-commit hook (gofmt + go vet) — one-time per checkout
+just setup-hooks
 ```
+
+The pre-commit hook lives at `.githooks/pre-commit` and is opt-in:
+`just setup-hooks` sets `core.hooksPath` to `.githooks`. It rejects a
+commit whose staged Go files aren't gofmt'd or whose module fails
+`go vet`, and prints the exact command to fix.
 
 See `CLAUDE.md` for repository conventions and `justfile` for the full
 list of recipes.

--- a/justfile
+++ b/justfile
@@ -1,6 +1,11 @@
 update-sql-parser:
     go mod edit -replace github.com/AfterShip/clickhouse-sql-parser=github.com/orian/clickhouse-sql-parser@refactor-visitor && go mod tidy
 
+# Install the repo's pre-commit hook (gofmt + go vet). One-time per checkout.
+setup-hooks:
+    git config core.hooksPath .githooks
+    @echo "pre-commit hook installed (.githooks/pre-commit)."
+
 # Run unit and snapshot tests
 test:
     go test ./internal/... -v


### PR DESCRIPTION
## Summary

Adds a tracked `.githooks/pre-commit` script that prevents the kind of `gofmt` regression CI just caught on PR #23.

The hook:

- Runs `gofmt -l` on staged Go files.
- Runs `go vet ./...` on the module.
- Exits non-zero on either failure, prints the exact `gofmt -w …` command to fix.
- Never auto-rewrites — the commit's content can't change silently behind you.

Opt-in per checkout: `just setup-hooks` sets `core.hooksPath` to `.githooks`. Won't fire on anyone who hasn't installed it (which is why it's a `chore` and not a workflow-level enforcement; CI still catches everything).

## Files

- `.githooks/pre-commit` *(new, executable)* — the hook script.
- `justfile` — new `setup-hooks` target.
- `README.md` — one-paragraph note in the Development section.

## Verification

Tested both fail paths and the happy path locally:

- gofmt violation → hook fails with `gofmt -w <files>` instruction.
- `go vet` violation (Printf `%d` with string arg) → hook fails after vet output.
- Clean diff → hook passes, commit proceeds.

This PR's own commit went through the hook.

## Test plan

- [ ] `just setup-hooks` on a fresh checkout
- [ ] Stage an intentionally unformatted Go file and try to commit — expect failure with copy-pasteable fix
- [ ] Fix, re-stage, retry — expect success
- [ ] CI still catches anything missed by anyone who hasn't installed the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)