### PR TITLE
feat(hcl): TimeSeries engine support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: chschema
 
 services:
   keeper:
-    image: clickhouse/clickhouse-keeper:latest
+    image: clickhouse/clickhouse-keeper:26.3.12.3
     environment:
       - KEEPER_SERVER_ID=1
     volumes:
@@ -18,7 +18,7 @@ services:
     restart: unless-stopped
 
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.3.12.3
     depends_on:
       - keeper
     ports:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -308,3 +308,36 @@ The pipeline mutates the parsed `[]DatabaseSpec` in place. After
 fields filled in, engines decoded into their typed structs, abstracts
 dropped, and `extend` cleared. That value is what the diff engine and SQL
 generator consume.
+## How do I model a Prometheus TimeSeries table?
+
+Use the `time_series` engine. The common production shape is the
+external-target form, where three target tables already exist (declared
+elsewhere in the schema) and the TimeSeries wraps them:
+
+```hcl
+table "prom_metrics" {
+  column "metric_name" { type = "LowCardinality(String)" }
+  # ... outer columns ...
+
+  engine "time_series" {
+    samples { target = "default.prom_metrics_data" }
+    tags    { target = "default.prom_metrics_tags" }
+    metrics { target = "default.prom_metrics_metrics" }
+  }
+}
+```
+
+`hclexp validate` will refuse to resolve until each target table is
+declared somewhere in the loaded schema (a new dependency kind
+`ts_target`). If you don't manage them via hclexp, declare them with
+`engine "merge_tree" {}` (or whichever they actually use) so the
+dependency check passes.
+
+Two settings are `ALTER`-able (`id_generator`,
+`filter_by_min_time_and_max_time`); every other change is a recreate
+and shows up as `-- UNSAFE` in the diff output. The `DATA` alias for
+`SAMPLES` is preserved on the dump side via a hidden `KeywordHint` —
+HCL authors always write `samples`.
+
+See the `time_series` reference in `README.hcl.md` for the full
+attribute list and the inner-target form.

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -117,9 +117,54 @@ attributes depend on the kind.
 | `distributed`                         | `cluster_name`, `remote_database`, `remote_table`  | `sharding_key`         |
 | `log`                                 | —                                                  | —                      |
 | `kafka`                               | `broker_list = [...]`, `topic`, `consumer_group`, `format` | —              |
+| `time_series` (experimental)          | —                                                  | `settings`, `tags_to_columns`, nested `samples`/`tags`/`metrics` blocks |
 
 Unknown kinds and missing required attributes are rejected at parse time
 with file/line positions.
+
+### `time_series` engine
+
+Models ClickHouse's [TimeSeries](https://clickhouse.com/docs/en/engines/table-engines/special/time_series) engine for Prometheus-style metrics. Three sibling target tables (samples/tags/metrics) are declared via nested sub-blocks; each takes either an external `target = "db.table"` reference or an inline `inner {}` block with column list + nested engine.
+
+```hcl
+table "prom_metrics" {
+  column "metric_name" { type = "LowCardinality(String)" }
+  # ... outer columns ...
+
+  engine "time_series" {
+    settings = {
+      id_generator = "sipHash64(metric_name, all_tags)"
+    }
+    tags_to_columns = {
+      instance = "instance"
+      job      = "job"
+    }
+    samples { target = "default.prom_metrics_data" }
+    tags    { target = "default.prom_metrics_tags" }
+    metrics { target = "default.prom_metrics_metrics" }
+  }
+}
+```
+
+- Each target sub-block is optional. Omitted = CH default inner targets (CH auto-generates them).
+- Exactly one of `target` or `inner` per sub-block.
+- Inner-form engines restricted to MergeTree-family kinds.
+- ALTER-able settings: `id_generator`, `filter_by_min_time_and_max_time`. Every other setting and every target change requires recreating the table (flagged `-- UNSAFE`).
+- HCL authors always write `samples`; the `DATA` alias CH supports is preserved on dump-side only via a `KeywordHint` round-trip.
+
+Inner form for a single target:
+
+```hcl
+samples {
+  inner {
+    column "id"        { type = "UUID" }
+    column "timestamp" { type = "DateTime64(3)" }
+    column "value"     { type = "Float64" }
+    engine "merge_tree" {}
+    order_by = ["id", "timestamp"]
+  }
+}
+```
 
 ## `patch_table`
 

--- a/docs/superpowers/plans/2026-06-01-timeseries-engine-support.md
+++ b/docs/superpowers/plans/2026-06-01-timeseries-engine-support.md
@@ -1,0 +1,1394 @@
+# TimeSeries Engine Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PostHog's `posthog.prom_metrics` (and any other CH TimeSeries-engine table) round-trips end-to-end through `hclexp introspect` / `hclexp diff` / `hclexp validate`.
+
+**Architecture:** New `EngineTimeSeries` value type holding optional `samples`/`tags`/`metrics` sub-blocks (each either an external table ref or an inline `INNER COLUMNS`+`INNER ENGINE` body), promoted `tags_to_columns` map, free-form `settings` map. Wired into the existing engine-decode → resolve → introspect → sqlgen → diff → validate pipeline at the same hook points every other engine uses. Inner-form target engines reuse the MergeTree-family struct types we already have.
+
+**Tech Stack:** Go 1.26, `hashicorp/hcl/v2` (gohcl), `orian/clickhouse-sql-parser` (chparser), `ClickHouse/clickhouse-go/v2` driver.
+
+**Spec:** [`docs/superpowers/specs/2026-06-01-timeseries-engine-support.md`](../specs/2026-06-01-timeseries-engine-support.md)
+
+**Upstream chparser change:** [orian/clickhouse-sql-parser#8](https://github.com/orian/clickhouse-sql-parser/issues/8) — landed as commit `47aa1ff` on `refactor-visitor`. AST: `CreateTable.TimeSeriesTargets []*TimeSeriesTargetClause`, each with `Kind` (lowercase normalised), `Keyword` (verbatim), `External *TableIdentifier`, `InnerColumns *TableSchemaClause`, `InnerEngine *EngineExpr`. Pin is already bumped on this branch (`go.mod` replace points at `v0.0.0-20260601104648-4521cd37e69b`).
+
+**File Map:**
+
+| File | What changes |
+|---|---|
+| `internal/loader/hcl/engines.go` | `EngineTimeSeries`, `TimeSeriesTarget`, `TimeSeriesInnerTable` types + `Kind()`; `DecodeEngine` case; `Virtuals()` returns nil. |
+| `internal/loader/hcl/engines_test.go` | HCL-decode round-trip tests for external, inner, mixed, settings, tags_to_columns. |
+| `internal/loader/hcl/resolver.go` | `resolveTimeSeriesEngine` helper invoked by the existing engine pass; enforces both-or-neither per target, restricts inner engines to MergeTree-family. |
+| `internal/loader/hcl/resolver_test.go` | Resolver rule tests. |
+| `internal/loader/hcl/introspect.go` | `buildTimeSeriesFromCreateTable`; dispatch from `processIntrospectRows`; populate `KeywordHint`. |
+| `internal/loader/hcl/introspect_test.go` | Introspect round-trip from CREATE strings (4 fixtures). |
+| `internal/loader/hcl/sqlgen.go` | `createTimeSeriesEngineSQL`; tail-clause emission in `createTableSQL`. |
+| `internal/loader/hcl/sqlgen_test.go` | Emission tests including KeywordHint behaviour. |
+| `internal/loader/hcl/diff.go` | `TimeSeriesDiff`; ALTER-vs-recreate split; folded into `TableDiff`. |
+| `internal/loader/hcl/diff_test.go` | Diff bucket tests. |
+| `internal/loader/hcl/validate.go` | `DepTimeSeriesTarget = "ts_target"`; `CollectDependencies` extended. |
+| `internal/loader/hcl/validate_test.go` | External-form dependency check; inner-form has none. |
+| `test/testdata/posthog-create-statements/TimeSeries/prom_metrics_external.sql` | Real production CREATE. |
+| `test/testdata/posthog-create-statements/TimeSeries/prom_metrics_inner.sql` | Doc-default inner form (all 3 INNER COLUMNS + INNER ENGINE). |
+| `test/testdata/posthog-create-statements/TimeSeries/prom_metrics_minimal.sql` | Bare `ENGINE = TimeSeries`. |
+| `docs/README.hcl.md` | New "TimeSeries" engine entry under Engine kinds. |
+| `docs/FAQ.md` | "How do I model a Prometheus TimeSeries table?" |
+
+---
+
+### Task 1: Engine types + HCL decode
+
+**Files:**
+- Modify: `internal/loader/hcl/engines.go` (insert after `EngineKafka`)
+- Modify: `internal/loader/hcl/engines_test.go`
+
+- [ ] **Step 1: Add the types**
+
+After `func (EngineKafka) Kind() string { return "kafka" }` in `engines.go`, add:
+
+```go
+// EngineTimeSeries models the (experimental) ClickHouse TimeSeries engine.
+// It stores Prometheus-style time series across three sibling target tables
+// (samples/tags/metrics), each either a reference to an external CH table or
+// an inline declaration with INNER COLUMNS + INNER ENGINE.
+//
+// Virtual columns: none; TimeSeries exposes no engine-virtual columns. Outer
+// table columns are real declared columns.
+type EngineTimeSeries struct {
+	// Settings declared via `engine "time_series" { settings = {...} }`.
+	// Free-form for forward compatibility; only two are ALTER-able
+	// (id_generator, filter_by_min_time_and_max_time) — the rest are baked
+	// into the CREATE.
+	Settings map[string]string `hcl:"settings,optional"`
+
+	// TagsToColumns shapes the inner tags-target table by promoting specific
+	// label keys into their own columns. CH treats this as a setting at the
+	// SQL level; promoted here for HCL clarity. sqlgen folds it back into
+	// the SETTINGS clause at emit time.
+	TagsToColumns map[string]string `hcl:"tags_to_columns,optional"`
+
+	// Sub-block per target kind. Nil = CH default applies (auto-generate the
+	// inner target).
+	Samples *TimeSeriesTarget `hcl:"samples,block"`
+	Tags    *TimeSeriesTarget `hcl:"tags,block"`
+	Metrics *TimeSeriesTarget `hcl:"metrics,block"`
+
+	// KeywordHint preserves whether the samples target's source SQL used
+	// SAMPLES or DATA. Populated by the introspector; sqlgen reads it to
+	// round-trip the same word. HCL authors never set this.
+	KeywordHint string `hcl:"-" diff:"-"`
+}
+
+func (EngineTimeSeries) Kind() string { return "time_series" }
+
+func (EngineTimeSeries) Virtuals() []DeclaredColumn { return nil }
+
+// TimeSeriesTarget is one of {samples, tags, metrics}. Exactly one of
+// Target or Inner must be set; both/neither is a resolve-time error.
+type TimeSeriesTarget struct {
+	Target *string                `hcl:"target,optional"`
+	Inner  *TimeSeriesInnerTable  `hcl:"inner,block"`
+}
+
+// TimeSeriesInnerTable mirrors a small slice of TableSpec — only the fields
+// CH actually emits inside INNER COLUMNS / INNER ENGINE. No
+// abstract/extend/cluster: those are outer-table concerns.
+type TimeSeriesInnerTable struct {
+	Columns     []ColumnSpec      `hcl:"column,block"`
+	Engine      *EngineSpec       `hcl:"engine,block"`
+	PrimaryKey  []string          `hcl:"primary_key,optional"`
+	OrderBy     []string          `hcl:"order_by,optional"`
+	PartitionBy *string           `hcl:"partition_by,optional"`
+	Settings    map[string]string `hcl:"settings,optional"`
+}
+```
+
+- [ ] **Step 2: Wire into `DecodeEngine`**
+
+In the `switch spec.Kind` block in `DecodeEngine` (same file, around line 191 where `"kafka"` lives), add:
+
+```go
+case "time_series":
+	var e EngineTimeSeries
+	diags = gohcl.DecodeBody(spec.Body, nil, &e)
+	if diags.HasErrors() {
+		break
+	}
+	// Recursively decode inner engines so resolver/sqlgen see typed values.
+	for _, t := range []*TimeSeriesTarget{e.Samples, e.Tags, e.Metrics} {
+		if t == nil || t.Inner == nil || t.Inner.Engine == nil {
+			continue
+		}
+		inner, err := DecodeEngine(t.Inner.Engine)
+		if err != nil {
+			return nil, fmt.Errorf("time_series inner engine: %w", err)
+		}
+		t.Inner.Engine.Decoded = inner
+	}
+	target = e
+```
+
+- [ ] **Step 3: Write decode tests**
+
+Add to `engines_test.go` (after the Kafka tests). Use the same `decodeTableEngine` helper as the other engine tests (it's already there).
+
+```go
+func TestDecodeEngine_TimeSeries_External(t *testing.T) {
+	e := decodeTableEngine(t, `
+table "m" {
+  engine "time_series" {
+    settings = { id_generator = "sipHash64(metric_name, all_tags)" }
+    samples { target = "db.m_data" }
+    tags    { target = "db.m_tags" }
+    metrics { target = "db.m_metrics" }
+  }
+}`)
+	got, ok := e.(EngineTimeSeries)
+	require.True(t, ok)
+	assert.Equal(t, "time_series", got.Kind())
+	assert.Equal(t, "sipHash64(metric_name, all_tags)", got.Settings["id_generator"])
+	require.NotNil(t, got.Samples)
+	require.NotNil(t, got.Samples.Target)
+	assert.Equal(t, "db.m_data", *got.Samples.Target)
+	assert.Nil(t, got.Samples.Inner)
+}
+
+func TestDecodeEngine_TimeSeries_Inner(t *testing.T) {
+	e := decodeTableEngine(t, `
+table "m" {
+  engine "time_series" {
+    samples {
+      inner {
+        column "id"        { type = "UUID" }
+        column "timestamp" { type = "DateTime64(3)" }
+        column "value"     { type = "Float64" }
+        engine "merge_tree" {}
+        order_by = ["id", "timestamp"]
+      }
+    }
+  }
+}`)
+	got := e.(EngineTimeSeries)
+	require.NotNil(t, got.Samples)
+	require.NotNil(t, got.Samples.Inner)
+	assert.Nil(t, got.Samples.Target)
+	require.NotNil(t, got.Samples.Inner.Engine)
+	_, ok := got.Samples.Inner.Engine.Decoded.(EngineMergeTree)
+	assert.True(t, ok, "inner engine should be decoded recursively")
+	assert.Equal(t, []string{"id", "timestamp"}, got.Samples.Inner.OrderBy)
+	require.Len(t, got.Samples.Inner.Columns, 3)
+}
+
+func TestDecodeEngine_TimeSeries_TagsToColumns(t *testing.T) {
+	e := decodeTableEngine(t, `
+table "m" {
+  engine "time_series" {
+    tags_to_columns = { instance = "instance", job = "job" }
+  }
+}`)
+	got := e.(EngineTimeSeries)
+	assert.Equal(t, map[string]string{"instance": "instance", "job": "job"}, got.TagsToColumns)
+}
+
+func TestDecodeEngine_TimeSeries_BareEmpty(t *testing.T) {
+	e := decodeTableEngine(t, `
+table "m" {
+  engine "time_series" {}
+}`)
+	got := e.(EngineTimeSeries)
+	assert.Nil(t, got.Samples)
+	assert.Nil(t, got.Tags)
+	assert.Nil(t, got.Metrics)
+}
+```
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+go test ./internal/loader/hcl/ -run TestDecodeEngine_TimeSeries -v
+git add internal/loader/hcl/engines.go internal/loader/hcl/engines_test.go
+git commit -m "feat(hcl): EngineTimeSeries type + DecodeEngine wiring"
+```
+
+---
+
+### Task 2: Resolver — both-or-neither + inner-engine restriction
+
+**Files:**
+- Modify: `internal/loader/hcl/resolver.go`
+- Modify: `internal/loader/hcl/resolver_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+In `resolver_test.go`, add:
+
+```go
+func TestResolve_TimeSeries_BothExternalAndInnerOnSameTarget_Rejected(t *testing.T) {
+	tgt := "db.x"
+	e := EngineTimeSeries{Samples: &TimeSeriesTarget{
+		Target: &tgt,
+		Inner:  &TimeSeriesInnerTable{Engine: &EngineSpec{Decoded: EngineMergeTree{}}},
+	}}
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine:  &EngineSpec{Kind: "time_series", Decoded: e},
+		}},
+	}}}
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "samples")
+	assert.Contains(t, err.Error(), "either")
+}
+
+func TestResolve_TimeSeries_NeitherForm_Rejected(t *testing.T) {
+	e := EngineTimeSeries{Samples: &TimeSeriesTarget{}}
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine:  &EngineSpec{Kind: "time_series", Decoded: e},
+		}},
+	}}}
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "samples")
+}
+
+func TestResolve_TimeSeries_InnerEngineRestrictedToMergeTreeFamily(t *testing.T) {
+	// Kafka as inner engine on samples — should be rejected.
+	e := EngineTimeSeries{Samples: &TimeSeriesTarget{
+		Inner: &TimeSeriesInnerTable{Engine: &EngineSpec{Decoded: EngineKafka{}}},
+	}}
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine:  &EngineSpec{Kind: "time_series", Decoded: e},
+		}},
+	}}}
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inner engine")
+	assert.Contains(t, err.Error(), "MergeTree")
+}
+
+func TestResolve_TimeSeries_AllValidForms_OK(t *testing.T) {
+	tgt := "db.m_data"
+	e := EngineTimeSeries{
+		Samples: &TimeSeriesTarget{Target: &tgt},
+		Tags: &TimeSeriesTarget{Inner: &TimeSeriesInnerTable{
+			Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+			Engine:  &EngineSpec{Decoded: EngineAggregatingMergeTree{}},
+		}},
+	}
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine:  &EngineSpec{Kind: "time_series", Decoded: e},
+		}},
+	}}}
+	require.NoError(t, Resolve(s))
+}
+```
+
+- [ ] **Step 2: Implement the resolver hook**
+
+In `resolver.go`, add a new helper and call it from the existing per-table validation loop in `resolveDatabase` (just before the `for _, t := range db.Tables` block that validates engine + columns):
+
+```go
+// validateTimeSeriesEngine enforces the engine-specific resolve rules for
+// EngineTimeSeries: each target sub-block must have exactly one of Target
+// or Inner; inner engines must be MergeTree-family kinds.
+func validateTimeSeriesEngine(dbName, tableName string, e EngineTimeSeries) error {
+	for _, kv := range []struct {
+		kind string
+		t    *TimeSeriesTarget
+	}{
+		{"samples", e.Samples},
+		{"tags", e.Tags},
+		{"metrics", e.Metrics},
+	} {
+		if kv.t == nil {
+			continue
+		}
+		hasExternal := kv.t.Target != nil
+		hasInner := kv.t.Inner != nil
+		switch {
+		case hasExternal && hasInner:
+			return fmt.Errorf("%s.%s: time_series %s target: set either target or inner, not both",
+				dbName, tableName, kv.kind)
+		case !hasExternal && !hasInner:
+			return fmt.Errorf("%s.%s: time_series %s target: must set target or inner",
+				dbName, tableName, kv.kind)
+		}
+		if hasInner && kv.t.Inner.Engine != nil && kv.t.Inner.Engine.Decoded != nil {
+			if !isMergeTreeFamily(kv.t.Inner.Engine.Decoded) {
+				return fmt.Errorf("%s.%s: time_series %s inner engine %q: only MergeTree-family engines are allowed",
+					dbName, tableName, kv.kind, kv.t.Inner.Engine.Decoded.Kind())
+			}
+		}
+	}
+	return nil
+}
+
+func isMergeTreeFamily(e Engine) bool {
+	switch e.(type) {
+	case EngineMergeTree,
+		EngineReplicatedMergeTree,
+		EngineReplacingMergeTree,
+		EngineReplicatedReplacingMergeTree,
+		EngineSummingMergeTree,
+		EngineReplicatedSummingMergeTree,
+		EngineCollapsingMergeTree,
+		EngineReplicatedCollapsingMergeTree,
+		EngineAggregatingMergeTree,
+		EngineReplicatedAggregatingMergeTree:
+		return true
+	}
+	return false
+}
+```
+
+Then, in `resolveDatabase`'s per-table validation loop (the one that checks engine+columns+constraints, around line 208 of the current file), call into the new helper:
+
+```go
+for _, t := range db.Tables {
+	if t.Engine == nil || t.Engine.Decoded == nil {
+		return fmt.Errorf("%s.%s: non-abstract table requires an engine", db.Name, t.Name)
+	}
+	if ts, ok := t.Engine.Decoded.(EngineTimeSeries); ok {
+		if err := validateTimeSeriesEngine(db.Name, t.Name, ts); err != nil {
+			return err
+		}
+	}
+	if err := validateColumns(db.Name, t); err != nil {
+		return err
+	}
+	if err := validateConstraints(db.Name, t); err != nil {
+		return err
+	}
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+go test ./internal/loader/hcl/ -run TestResolve_TimeSeries -v
+git add internal/loader/hcl/resolver.go internal/loader/hcl/resolver_test.go
+git commit -m "feat(hcl): resolve-time validation for TimeSeries engine targets"
+```
+
+---
+
+### Task 3: Introspection — buildTimeSeriesFromCreateTable
+
+**Files:**
+- Modify: `internal/loader/hcl/introspect.go`
+- Modify: `internal/loader/hcl/introspect_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestIntrospect_TimeSeries_External(t *testing.T) {
+	sql := "CREATE TABLE db.m (`id` UUID, `timestamp` DateTime64(3), `value` Float64, " +
+		"`metric_name` LowCardinality(String)) " +
+		"ENGINE = TimeSeries DATA db.m_data TAGS db.m_tags METRICS db.m_metrics"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &stringRows{rows: [][2]string{{"m", sql}}}))
+	require.Len(t, db.Tables, 1)
+	tbl := db.Tables[0]
+	assert.Equal(t, "m", tbl.Name)
+	assert.Equal(t, 4, len(tbl.Columns))
+	e, ok := tbl.Engine.Decoded.(EngineTimeSeries)
+	require.True(t, ok)
+	assert.Equal(t, "DATA", e.KeywordHint)
+	require.NotNil(t, e.Samples)
+	require.NotNil(t, e.Samples.Target)
+	assert.Equal(t, "db.m_data", *e.Samples.Target)
+	require.NotNil(t, e.Tags)
+	assert.Equal(t, "db.m_tags", *e.Tags.Target)
+	require.NotNil(t, e.Metrics)
+	assert.Equal(t, "db.m_metrics", *e.Metrics.Target)
+}
+
+func TestIntrospect_TimeSeries_Inner(t *testing.T) {
+	sql := "CREATE TABLE db.m () ENGINE = TimeSeries " +
+		"SAMPLES INNER COLUMNS (`id` UUID, `timestamp` DateTime64(3), `value` Float64) " +
+		"SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &stringRows{rows: [][2]string{{"m", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
+	assert.Equal(t, "SAMPLES", e.KeywordHint)
+	require.NotNil(t, e.Samples)
+	require.NotNil(t, e.Samples.Inner)
+	assert.Nil(t, e.Samples.Target)
+	require.Len(t, e.Samples.Inner.Columns, 3)
+	_, ok := e.Samples.Inner.Engine.Decoded.(EngineMergeTree)
+	assert.True(t, ok)
+	assert.Equal(t, []string{"id", "timestamp"}, e.Samples.Inner.OrderBy)
+}
+
+func TestIntrospect_TimeSeries_Bare(t *testing.T) {
+	sql := "CREATE TABLE db.m () ENGINE = TimeSeries"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &stringRows{rows: [][2]string{{"m", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
+	assert.Nil(t, e.Samples)
+	assert.Nil(t, e.Tags)
+	assert.Nil(t, e.Metrics)
+}
+
+func TestIntrospect_TimeSeries_Settings(t *testing.T) {
+	sql := "CREATE TABLE db.m () ENGINE = TimeSeries " +
+		"SETTINGS id_generator = 'sipHash64(metric_name, all_tags)', tags_to_columns = {'instance':'instance','job':'job'}"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &stringRows{rows: [][2]string{{"m", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
+	assert.Equal(t, "sipHash64(metric_name, all_tags)", e.Settings["id_generator"])
+	assert.Equal(t, map[string]string{"instance": "instance", "job": "job"}, e.TagsToColumns)
+}
+```
+
+(`stringRows` is the existing test helper — search `introspect_test.go` for it.)
+
+- [ ] **Step 2: Implement the builder**
+
+Add to `introspect.go`:
+
+```go
+// buildTimeSeriesFromCreateTable handles a CreateTable whose Engine.Name is
+// "TimeSeries". Outer columns flow through the standard path; the engine
+// becomes an EngineTimeSeries with its target sub-blocks populated from
+// the chparser TimeSeriesTargetClause list.
+func buildTimeSeriesFromCreateTable(ct *chparser.CreateTable) (TableSpec, error) {
+	ts, err := buildTableFromCreateTable(ct)
+	if err != nil {
+		return TableSpec{}, err
+	}
+	// buildTableFromCreateTable already populated Columns/Settings/etc on the
+	// outer table. We replace ts.Engine with an EngineTimeSeries, lifting
+	// id_generator/tags_to_columns out of the engine SETTINGS the parser
+	// returned and folding them into the typed engine struct.
+	e := EngineTimeSeries{}
+
+	// Engine-level SETTINGS the parser captured.
+	if ct.Engine.Settings != nil {
+		for _, item := range ct.Engine.Settings.Items {
+			key := stripBackticks(identName(item.Name))
+			val := settingValueString(item.Expr)
+			switch key {
+			case "tags_to_columns":
+				m, err := parseTagsToColumnsMap(val)
+				if err != nil {
+					return TableSpec{}, fmt.Errorf("tags_to_columns: %w", err)
+				}
+				e.TagsToColumns = m
+			default:
+				if e.Settings == nil {
+					e.Settings = map[string]string{}
+				}
+				e.Settings[key] = val
+			}
+		}
+	}
+
+	// Target clauses.
+	for _, tc := range ct.TimeSeriesTargets {
+		target, err := buildTimeSeriesTarget(tc)
+		if err != nil {
+			return TableSpec{}, fmt.Errorf("%s target: %w", tc.Kind, err)
+		}
+		switch tc.Kind {
+		case "samples":
+			e.Samples = target
+			e.KeywordHint = tc.Keyword // SAMPLES or DATA
+		case "tags":
+			e.Tags = target
+		case "metrics":
+			e.Metrics = target
+		default:
+			return TableSpec{}, fmt.Errorf("unknown TimeSeries target kind: %q", tc.Kind)
+		}
+	}
+
+	ts.Engine = &EngineSpec{Kind: "time_series", Decoded: e}
+	return ts, nil
+}
+
+func buildTimeSeriesTarget(tc *chparser.TimeSeriesTargetClause) (*TimeSeriesTarget, error) {
+	switch {
+	case tc.External != nil:
+		ref := tc.External.String()
+		return &TimeSeriesTarget{Target: &ref}, nil
+	case tc.InnerColumns != nil:
+		cols := columnsFromTableSchema(tc.InnerColumns)
+		inner := &TimeSeriesInnerTable{
+			Columns: make([]ColumnSpec, len(cols)),
+		}
+		for i, c := range cols {
+			inner.Columns[i] = ColumnSpec{Name: c.Name, Type: c.Type}
+		}
+		if tc.InnerEngine != nil {
+			eng, _, err := engineFromAST(tc.InnerEngine)
+			if err != nil {
+				return nil, fmt.Errorf("inner engine: %w", err)
+			}
+			inner.Engine = &EngineSpec{
+				Kind:    canonicalKindOf(eng),
+				Decoded: eng,
+			}
+			if tc.InnerEngine.OrderBy != nil {
+				inner.OrderBy = extractOrderBy(tc.InnerEngine.OrderBy)
+			}
+			if tc.InnerEngine.PrimaryKey != nil {
+				inner.PrimaryKey = extractPrimaryKey(tc.InnerEngine.PrimaryKey)
+			}
+			if tc.InnerEngine.PartitionBy != nil {
+				pb := tc.InnerEngine.PartitionBy.String()
+				inner.PartitionBy = &pb
+			}
+		}
+		return &TimeSeriesTarget{Inner: inner}, nil
+	}
+	return nil, errors.New("clause has neither external table nor inner columns")
+}
+
+// canonicalKindOf maps a decoded Engine back to its "kind" label used in HCL.
+// E.g. EngineMergeTree -> "merge_tree", EngineAggregatingMergeTree ->
+// "aggregating_merge_tree". Reuses the Kind() method on the typed value.
+func canonicalKindOf(e Engine) string {
+	if e == nil {
+		return ""
+	}
+	return e.Kind()
+}
+
+// parseTagsToColumnsMap parses the `{'tag1':'col1','tag2':'col2',...}` map
+// literal CH emits in SETTINGS.
+func parseTagsToColumnsMap(s string) (map[string]string, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{") || !strings.HasSuffix(s, "}") {
+		return nil, fmt.Errorf("expected map literal, got %q", s)
+	}
+	s = strings.TrimSpace(s[1 : len(s)-1])
+	if s == "" {
+		return map[string]string{}, nil
+	}
+	out := map[string]string{}
+	for _, pair := range splitTopLevel(s, ',') {
+		kv := splitTopLevel(strings.TrimSpace(pair), ':')
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("expected `key:value`, got %q", pair)
+		}
+		k := unquoteString(strings.TrimSpace(kv[0]))
+		v := unquoteString(strings.TrimSpace(kv[1]))
+		out[k] = v
+	}
+	return out, nil
+}
+
+// splitTopLevel splits s on sep, respecting matched quotes. Tiny helper —
+// the parsed maps are flat strings only, so we don't need full SQL-aware
+// splitting.
+func splitTopLevel(s string, sep byte) []string {
+	var parts []string
+	var current strings.Builder
+	inSingle := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\'' && (i == 0 || s[i-1] != '\\') {
+			inSingle = !inSingle
+		}
+		if c == sep && !inSingle {
+			parts = append(parts, current.String())
+			current.Reset()
+			continue
+		}
+		current.WriteByte(c)
+	}
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	return parts
+}
+
+func unquoteString(s string) string {
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+```
+
+The helpers `extractOrderBy` / `extractPrimaryKey` / `settingValueString` / `identName` should already exist in `introspect.go` — search for them and reuse. If `settingValueString` doesn't exist, see how the Kafka path handles `Engine.Settings.Items[i].Expr` and mirror it.
+
+- [ ] **Step 3: Dispatch from `processIntrospectRows`**
+
+Modify the `case *chparser.CreateTable:` branch in `processIntrospectRows` (around `introspect.go:71`):
+
+```go
+case *chparser.CreateTable:
+	var ts TableSpec
+	var err error
+	if s.Engine != nil && s.Engine.Name == "TimeSeries" {
+		ts, err = buildTimeSeriesFromCreateTable(s)
+	} else {
+		ts, err = buildTableFromCreateTable(s)
+	}
+	if err != nil {
+		return fmt.Errorf("introspect table %s.%s: %w", database, name, err)
+	}
+	ts.Name = name
+	db.Tables = append(db.Tables, ts)
+```
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+go test ./internal/loader/hcl/ -run TestIntrospect_TimeSeries -v
+git add internal/loader/hcl/introspect.go internal/loader/hcl/introspect_test.go
+git commit -m "feat(hcl): introspect TimeSeries-engine tables"
+```
+
+---
+
+### Task 4: SQL generation — engine clause + tail emission
+
+**Files:**
+- Modify: `internal/loader/hcl/sqlgen.go`
+- Modify: `internal/loader/hcl/sqlgen_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestSQLGen_TimeSeries_External_DataAlias(t *testing.T) {
+	tgtData := "default.m_data"
+	tgtTags := "default.m_tags"
+	tgtMetrics := "default.m_metrics"
+	ts := TableSpec{Name: "m",
+		Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+		Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+			Samples:     &TimeSeriesTarget{Target: &tgtData},
+			Tags:        &TimeSeriesTarget{Target: &tgtTags},
+			Metrics:     &TimeSeriesTarget{Target: &tgtMetrics},
+			KeywordHint: "DATA",
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	require.Len(t, out.Statements, 1)
+	stmt := out.Statements[0]
+	assert.Contains(t, stmt, "ENGINE = TimeSeries")
+	assert.Contains(t, stmt, "DATA default.m_data")
+	assert.Contains(t, stmt, "TAGS default.m_tags")
+	assert.Contains(t, stmt, "METRICS default.m_metrics")
+	assert.NotContains(t, stmt, "SAMPLES")
+}
+
+func TestSQLGen_TimeSeries_External_DefaultsToSamplesKeyword(t *testing.T) {
+	tgt := "default.m_data"
+	ts := TableSpec{Name: "m",
+		Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+		Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+			Samples: &TimeSeriesTarget{Target: &tgt},
+			// no KeywordHint -> canonical SAMPLES
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	stmt := out.Statements[0]
+	assert.Contains(t, stmt, "SAMPLES default.m_data")
+	assert.NotContains(t, stmt, "DATA default.m_data")
+}
+
+func TestSQLGen_TimeSeries_Inner(t *testing.T) {
+	inner := &TimeSeriesInnerTable{
+		Columns: []ColumnSpec{
+			{Name: "id", Type: "UUID"},
+			{Name: "timestamp", Type: "DateTime64(3)"},
+			{Name: "value", Type: "Float64"},
+		},
+		Engine:  &EngineSpec{Decoded: EngineMergeTree{}},
+		OrderBy: []string{"id", "timestamp"},
+	}
+	ts := TableSpec{Name: "m",
+		Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+		Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+			Samples: &TimeSeriesTarget{Inner: inner},
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	stmt := out.Statements[0]
+	assert.Contains(t, stmt, "SAMPLES INNER COLUMNS (id UUID, timestamp DateTime64(3), value Float64)")
+	assert.Contains(t, stmt, "SAMPLES INNER ENGINE = MergeTree")
+	assert.Contains(t, stmt, "ORDER BY (id, timestamp)")
+}
+
+func TestSQLGen_TimeSeries_TagsToColumnsFolded(t *testing.T) {
+	ts := TableSpec{Name: "m",
+		Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+		Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+			TagsToColumns: map[string]string{"instance": "instance", "job": "job"},
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	stmt := out.Statements[0]
+	assert.Contains(t, stmt, "tags_to_columns = {'instance':'instance', 'job':'job'}")
+}
+```
+
+- [ ] **Step 2: Implement engine emission**
+
+In `sqlgen.go`'s `engineSQL` switch, add:
+
+```go
+case EngineTimeSeries:
+	clause, extra := createTimeSeriesEngineSQL(e)
+	return clause, extra
+```
+
+(Mirror the Kafka shape that already returns `(clause string, extra map[string]string)`.)
+
+Then add:
+
+```go
+func createTimeSeriesEngineSQL(e EngineTimeSeries) (string, map[string]string) {
+	settings := map[string]string{}
+	for k, v := range e.Settings {
+		settings[k] = v
+	}
+	if len(e.TagsToColumns) > 0 {
+		settings["tags_to_columns"] = renderTagsToColumnsMap(e.TagsToColumns)
+	}
+	var b strings.Builder
+	b.WriteString("TimeSeries")
+	emitTimeSeriesTarget(&b, e.Samples, samplesKeyword(e.KeywordHint))
+	emitTimeSeriesTarget(&b, e.Tags, "TAGS")
+	emitTimeSeriesTarget(&b, e.Metrics, "METRICS")
+	return b.String(), settings
+}
+
+func samplesKeyword(hint string) string {
+	if hint == "DATA" {
+		return "DATA"
+	}
+	return "SAMPLES"
+}
+
+func emitTimeSeriesTarget(b *strings.Builder, t *TimeSeriesTarget, keyword string) {
+	if t == nil {
+		return
+	}
+	if t.Target != nil {
+		fmt.Fprintf(b, " %s %s", keyword, *t.Target)
+		return
+	}
+	if t.Inner == nil {
+		return
+	}
+	parts := make([]string, len(t.Inner.Columns))
+	for i, c := range t.Inner.Columns {
+		parts[i] = columnDefSQL(c)
+	}
+	fmt.Fprintf(b, " %s INNER COLUMNS (%s)", keyword, strings.Join(parts, ", "))
+	if t.Inner.Engine != nil && t.Inner.Engine.Decoded != nil {
+		inner, _ := engineSQL(t.Inner.Engine.Decoded)
+		fmt.Fprintf(b, " %s INNER ENGINE = %s", keyword, inner)
+	}
+	if len(t.Inner.PrimaryKey) > 0 {
+		fmt.Fprintf(b, " PRIMARY KEY (%s)", strings.Join(t.Inner.PrimaryKey, ", "))
+	}
+	if len(t.Inner.OrderBy) > 0 {
+		fmt.Fprintf(b, " ORDER BY (%s)", strings.Join(t.Inner.OrderBy, ", "))
+	}
+	if t.Inner.PartitionBy != nil {
+		fmt.Fprintf(b, " PARTITION BY %s", *t.Inner.PartitionBy)
+	}
+	if len(t.Inner.Settings) > 0 {
+		keys := make([]string, 0, len(t.Inner.Settings))
+		for k := range t.Inner.Settings {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var s strings.Builder
+		for i, k := range keys {
+			if i > 0 {
+				s.WriteString(", ")
+			}
+			fmt.Fprintf(&s, "%s = %s", k, formatSettingValue(t.Inner.Settings[k]))
+		}
+		fmt.Fprintf(b, " SETTINGS %s", s.String())
+	}
+}
+
+func renderTagsToColumnsMap(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("'%s':'%s'", k, m[k])
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+```
+
+`formatSettingValue` already exists for the Kafka path; reuse it. If `columnDefSQL` doesn't exist, look for `func columnDefSQL` in `sqlgen.go` — it's the one that emits `name Type [DEFAULT ...] [CODEC(...)]`. Reuse it.
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+go test ./internal/loader/hcl/ -run TestSQLGen_TimeSeries -v
+git add internal/loader/hcl/sqlgen.go internal/loader/hcl/sqlgen_test.go
+git commit -m "feat(hcl): sqlgen for TimeSeries engine (external + inner targets)"
+```
+
+---
+
+### Task 5: Diff + ALTER policy
+
+**Files:**
+- Modify: `internal/loader/hcl/diff.go`
+- Modify: `internal/loader/hcl/diff_test.go`
+- Modify: `internal/loader/hcl/sqlgen.go` (ALTER emission for the two ALTER-able settings)
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestDiff_TimeSeries_IdGeneratorChange_ALTERed(t *testing.T) {
+	mk := func(idGen string) *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					Settings: map[string]string{"id_generator": idGen},
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk("sipHash64(metric_name)"), mk("sipHash64(metric_name, all_tags)"))
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterTables, 1)
+	td := cs.Databases[0].AlterTables[0]
+	assert.Len(t, td.SettingsChanged, 1)
+	assert.Equal(t, "id_generator", td.SettingsChanged[0].Key)
+	assert.False(t, td.IsUnsafe(), "id_generator change is in-place")
+}
+
+func TestDiff_TimeSeries_BakedSettingChange_Recreate(t *testing.T) {
+	mk := func(val string) *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					Settings: map[string]string{"store_min_time_and_max_time": val},
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk("0"), mk("1"))
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterTables, 1)
+	td := cs.Databases[0].AlterTables[0]
+	assert.True(t, td.IsUnsafe(), "non-alterable setting change should be recreate")
+}
+
+func TestDiff_TimeSeries_TargetChange_Recreate(t *testing.T) {
+	mk := func(target string) *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					Samples: &TimeSeriesTarget{Target: &target},
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk("db.old"), mk("db.new"))
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterTables, 1)
+	assert.True(t, cs.Databases[0].AlterTables[0].IsUnsafe())
+}
+
+func TestDiff_TimeSeries_TagsToColumnsChange_Recreate(t *testing.T) {
+	mk := func(m map[string]string) *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					TagsToColumns: m,
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk(map[string]string{"instance": "instance"}), mk(map[string]string{"instance": "instance", "job": "job"}))
+	td := cs.Databases[0].AlterTables[0]
+	assert.True(t, td.IsUnsafe())
+}
+```
+
+- [ ] **Step 2: Implement diff logic**
+
+Extend `diffTable` so when both sides' engines are `EngineTimeSeries`, it splits the changes into ALTER-able-settings vs everything-else:
+
+```go
+// Inside diffTable, before the generic engine comparison:
+if fromTS, fromOK := engineOf(*from).(EngineTimeSeries); fromOK {
+	if toTS, toOK := engineOf(*to).(EngineTimeSeries); toOK {
+		diffTimeSeries(&td, fromTS, toTS)
+		// Skip the generic engine-change path; we've handled it.
+		// (Other table-level fields like ordering still need normal diff —
+		// continue past this block, just skip the EngineChange step.)
+	}
+}
+```
+
+```go
+// timeSeriesAlterableSettings names the SETTINGS keys CH supports via
+// ALTER TABLE ... MODIFY SETTING on a TimeSeries table.
+var timeSeriesAlterableSettings = map[string]bool{
+	"id_generator":                    true,
+	"filter_by_min_time_and_max_time": true,
+}
+
+// diffTimeSeries fills td.SettingsAdded/Removed/Changed for the two
+// alterable keys and marks the rest of the engine diff as recreate.
+func diffTimeSeries(td *TableDiff, from, to EngineTimeSeries) {
+	// Settings: split into alterable vs baked.
+	bakedDiffers := false
+	for k, vNew := range to.Settings {
+		vOld, ok := from.Settings[k]
+		if !ok {
+			if timeSeriesAlterableSettings[k] {
+				if td.SettingsAdded == nil {
+					td.SettingsAdded = map[string]string{}
+				}
+				td.SettingsAdded[k] = vNew
+			} else {
+				bakedDiffers = true
+			}
+			continue
+		}
+		if vOld != vNew {
+			if timeSeriesAlterableSettings[k] {
+				td.SettingsChanged = append(td.SettingsChanged, SettingChange{Key: k, OldValue: vOld, NewValue: vNew})
+			} else {
+				bakedDiffers = true
+			}
+		}
+	}
+	for k, vOld := range from.Settings {
+		if _, ok := to.Settings[k]; ok {
+			continue
+		}
+		if timeSeriesAlterableSettings[k] {
+			td.SettingsRemoved = append(td.SettingsRemoved, k)
+			_ = vOld
+		} else {
+			bakedDiffers = true
+		}
+	}
+
+	// TagsToColumns is baked.
+	if !reflect.DeepEqual(from.TagsToColumns, to.TagsToColumns) {
+		bakedDiffers = true
+	}
+	// Any change to targets is a recreate.
+	if !reflect.DeepEqual(from.Samples, to.Samples) ||
+		!reflect.DeepEqual(from.Tags, to.Tags) ||
+		!reflect.DeepEqual(from.Metrics, to.Metrics) {
+		bakedDiffers = true
+	}
+
+	if bakedDiffers {
+		td.EngineChange = &EngineChange{Old: from, New: to}
+	}
+}
+```
+
+The existing `td.IsUnsafe()` already returns true when `EngineChange != nil`, so we get the recreate signal for free.
+
+- [ ] **Step 3: ALTER SETTING emission**
+
+In `sqlgen.go`'s table-alter loop, add (or extend the existing settings-change path so it works for TimeSeries too — the keys are already engine-agnostic):
+
+Look for the existing block that handles `SettingsChanged` / `SettingsAdded` / `SettingsRemoved` for tables. Confirm it emits `ALTER TABLE ... MODIFY SETTING k = v`. If it doesn't already exist, add it:
+
+```go
+for _, sc := range td.SettingsChanged {
+	out.Statements = append(out.Statements,
+		fmt.Sprintf("ALTER TABLE %s.%s MODIFY SETTING %s = %s",
+			dc.Database, td.Table, sc.Key, formatSettingValue(sc.NewValue)))
+}
+for k, v := range td.SettingsAdded {
+	out.Statements = append(out.Statements,
+		fmt.Sprintf("ALTER TABLE %s.%s MODIFY SETTING %s = %s",
+			dc.Database, td.Table, k, formatSettingValue(v)))
+}
+for _, k := range td.SettingsRemoved {
+	out.Statements = append(out.Statements,
+		fmt.Sprintf("ALTER TABLE %s.%s RESET SETTING %s", dc.Database, td.Table, k))
+}
+```
+
+If this block already exists for the MergeTree-family settings flow, no change needed.
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+go test ./internal/loader/hcl/ -run TestDiff_TimeSeries -v
+git add internal/loader/hcl/diff.go internal/loader/hcl/diff_test.go internal/loader/hcl/sqlgen.go
+git commit -m "feat(hcl): TimeSeries diff with ALTER-able settings split"
+```
+
+---
+
+### Task 6: Dependency validation
+
+**Files:**
+- Modify: `internal/loader/hcl/validate.go`
+- Modify: `internal/loader/hcl/validate_test.go`
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestValidate_TimeSeries_ExternalTargetMustExist(t *testing.T) {
+	tgt := "db.samples_does_not_exist"
+	dbs := []DatabaseSpec{{Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+				Samples: &TimeSeriesTarget{Target: &tgt},
+			}},
+		}},
+	}}
+	errs := Validate(dbs, SkipSet{})
+	var ferr *ValidationError
+	for i := range errs {
+		if errs[i].Kind == DepTimeSeriesTarget {
+			ferr = &errs[i]
+			break
+		}
+	}
+	require.NotNil(t, ferr, "external TimeSeries target should be flagged")
+	assert.Equal(t, "db.samples_does_not_exist", ferr.Missing.String())
+}
+
+func TestValidate_TimeSeries_InnerTargetNoDependency(t *testing.T) {
+	dbs := []DatabaseSpec{{Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+				Samples: &TimeSeriesTarget{Inner: &TimeSeriesInnerTable{
+					Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+					Engine:  &EngineSpec{Decoded: EngineMergeTree{}},
+				}},
+			}},
+		}},
+	}}
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, DepTimeSeriesTarget, e.Kind, "inner-form target should create no dep")
+	}
+}
+```
+
+- [ ] **Step 2: Implement**
+
+In `validate.go`'s constants block, add:
+
+```go
+DepTimeSeriesTarget = "ts_target" // a TimeSeries table references an external samples/tags/metrics target
+```
+
+Extend `CollectDependencies` (after the existing Distributed dep loop, before the materialized_view block):
+
+```go
+for _, t := range db.Tables {
+	if t.Engine == nil {
+		continue
+	}
+	ts, ok := t.Engine.Decoded.(EngineTimeSeries)
+	if !ok {
+		continue
+	}
+	from := ObjectRef{Database: db.Name, Name: t.Name}
+	for _, kv := range []*TimeSeriesTarget{ts.Samples, ts.Tags, ts.Metrics} {
+		if kv == nil || kv.Target == nil {
+			continue
+		}
+		deps = append(deps, Dependency{
+			From: from,
+			To:   splitQualified(*kv.Target, db.Name),
+			Kind: DepTimeSeriesTarget,
+		})
+	}
+}
+```
+
+Extend `depPhrase`:
+
+```go
+case DepTimeSeriesTarget:
+	return "TimeSeries target table"
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+go test ./internal/loader/hcl/ -run TestValidate_TimeSeries -v
+git add internal/loader/hcl/validate.go internal/loader/hcl/validate_test.go
+git commit -m "feat(hcl): validate TimeSeries external-form target dependencies"
+```
+
+---
+
+### Task 7: Live fixtures + introspect_live_test
+
+**Files:**
+- Create: `test/testdata/posthog-create-statements/TimeSeries/prom_metrics_external.sql`
+- Create: `test/testdata/posthog-create-statements/TimeSeries/prom_metrics_inner.sql`
+- Create: `test/testdata/posthog-create-statements/TimeSeries/prom_metrics_minimal.sql`
+
+- [ ] **Step 1: Write fixtures**
+
+`prom_metrics_external.sql` — the actual production statement (already in our log; reuse it verbatim).
+
+```sql
+CREATE TABLE default.prom_metrics
+(
+    `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
+    `timestamp` DateTime64(3),
+    `value` Float64,
+    `metric_name` LowCardinality(String),
+    `tags` Map(LowCardinality(String), String),
+    `all_tags` Map(String, String),
+    `min_time` Nullable(DateTime64(3)),
+    `max_time` Nullable(DateTime64(3)),
+    `metric_family_name` String,
+    `type` String,
+    `unit` String,
+    `help` String
+)
+ENGINE = TimeSeries
+DATA default.prom_metrics_data
+TAGS default.prom_metrics_tags
+METRICS default.prom_metrics_metrics
+```
+
+`prom_metrics_minimal.sql`:
+
+```sql
+CREATE TABLE default.prom_metrics_minimal () ENGINE = TimeSeries
+```
+
+`prom_metrics_inner.sql` — the doc's "Creation" section example (all three inner forms):
+
+```sql
+CREATE TABLE default.prom_metrics_inner
+(
+    `metric_name` String,
+    `tags` Map(String, String),
+    `time_series` Array(Tuple(DateTime64(3), Float64)),
+    `metric_family` String,
+    `type` String,
+    `unit` String,
+    `help` String
+)
+ENGINE = TimeSeries
+SAMPLES INNER COLUMNS
+(
+    `id` UUID,
+    `timestamp` DateTime64(3),
+    `value` Float64
+)
+SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
+TAGS INNER COLUMNS
+(
+    `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
+    `metric_name` LowCardinality(String),
+    `tags` Map(LowCardinality(String), String),
+    `all_tags` Map(String, String) EPHEMERAL,
+    `min_time` SimpleAggregateFunction(min, Nullable(DateTime64(3))),
+    `max_time` SimpleAggregateFunction(max, Nullable(DateTime64(3)))
+)
+TAGS INNER ENGINE = AggregatingMergeTree PRIMARY KEY metric_name ORDER BY (metric_name, id)
+METRICS INNER COLUMNS
+(
+    `metric_family_name` String,
+    `type` LowCardinality(String),
+    `unit` LowCardinality(String),
+    `help` String
+)
+METRICS INNER ENGINE = ReplacingMergeTree ORDER BY metric_family_name
+```
+
+- [ ] **Step 2: Verify the existing live loop picks them up**
+
+`hcl_introspect_live_test.go` already loops fixtures grouped by directory name. Run:
+
+```bash
+ENABLE_CLICKHOUSE=1 go test ./test -run TestLive_Introspection_AllStatements/TimeSeries -v
+```
+
+Expected: all three load against CH (need `SET allow_experimental_time_series_table = 1`; the test harness should set this — if it doesn't, add it to `setUpDB` in `test/testhelpers`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/testdata/posthog-create-statements/TimeSeries/
+git commit -m "test: live-test fixtures for TimeSeries engine"
+```
+
+---
+
+### Task 8: Docs
+
+**Files:**
+- Modify: `docs/README.hcl.md`
+- Modify: `docs/FAQ.md`
+
+- [ ] **Step 1: README.hcl.md — engine entry**
+
+In the "Engine kinds" section, after `kafka`, add:
+
+```markdown
+### `time_series` (experimental)
+
+Models ClickHouse's [TimeSeries](https://clickhouse.com/docs/en/engines/table-engines/special/time_series) engine for Prometheus-style metrics. Three sibling target tables (samples/tags/metrics) are declared via nested sub-blocks; each takes either an external `target = "db.table"` reference or an inline `inner {}` block with column list + nested engine.
+
+\`\`\`hcl
+table "prom_metrics" {
+  column "metric_name" { type = "LowCardinality(String)" }
+  # ... outer columns ...
+
+  engine "time_series" {
+    settings = {
+      id_generator = "sipHash64(metric_name, all_tags)"
+    }
+    tags_to_columns = {
+      instance = "instance"
+      job      = "job"
+    }
+    samples { target = "default.prom_metrics_data" }
+    tags    { target = "default.prom_metrics_tags" }
+    metrics { target = "default.prom_metrics_metrics" }
+  }
+}
+\`\`\`
+
+- Each target sub-block is optional. Omitted = CH default inner targets.
+- Exactly one of `target` or `inner` per sub-block.
+- Inner-form engines restricted to MergeTree-family kinds.
+- ALTER-able settings: `id_generator`, `filter_by_min_time_and_max_time`. Every other setting and every target change requires recreating the table.
+- HCL authors always write `samples`; the `DATA` alias CH supports is preserved on dump-side only.
+```
+
+- [ ] **Step 2: FAQ.md — worked example**
+
+Append:
+
+```markdown
+## How do I model a Prometheus TimeSeries table?
+
+Use the `time_series` engine. For the common case of three pre-existing external target tables:
+
+\`\`\`hcl
+table "prom_metrics" {
+  column "metric_name" { type = "LowCardinality(String)" }
+  # ... outer columns ...
+
+  engine "time_series" {
+    samples { target = "default.prom_metrics_data" }
+    tags    { target = "default.prom_metrics_tags" }
+    metrics { target = "default.prom_metrics_metrics" }
+  }
+}
+\`\`\`
+
+`hclexp validate` will refuse to resolve until each target table is declared somewhere in the loaded schema. If you don't manage them via hclexp, declare them with `engine "merge_tree" {}` (or whichever they actually use) so the dependency check passes.
+
+See the `time_series` reference in `README.hcl.md` for the full attribute list.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/README.hcl.md docs/FAQ.md
+git commit -m "docs: TimeSeries engine reference + FAQ entry"
+```
+
+---
+
+### Task 9: Final sweep + PR
+
+- [ ] **Step 1: Build + vet + unit tests**
+
+```bash
+go build ./...
+go vet ./...
+go test ./... -count=1
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Live tests**
+
+```bash
+docker compose up -d
+ENABLE_CLICKHOUSE=1 go test ./... -count=1
+```
+
+Expected: all green. The TimeSeries live fixtures join the existing engine-grouped loop.
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feat/timeseries-engine
+gh pr create --title "feat(hcl): TimeSeries engine support" --body-file <(cat <<'EOF'
+## Summary
+
+Adds first-class support for ClickHouse's experimental `TimeSeries` engine. PostHog's `posthog.prom_metrics` now round-trips end-to-end through `hclexp introspect` / `hclexp diff` / `hclexp validate`.
+
+- New `EngineTimeSeries` value type with optional `samples`/`tags`/`metrics` sub-blocks (external or inline-`inner`), promoted `tags_to_columns`, free-form `settings`.
+- Inner-form target engines restricted to MergeTree-family.
+- `DATA` ↔ `SAMPLES` keyword round-trip via `KeywordHint` (diff-skipped, dump-side only).
+- Two ALTER-able settings (`id_generator`, `filter_by_min_time_and_max_time`) → in-place `MODIFY SETTING`. Everything else baked → recreate + UNSAFE.
+- New `DepTimeSeriesTarget` validation dependency for external-form targets.
+
+Depends on chparser fork commit [`47aa1ff`](https://github.com/orian/clickhouse-sql-parser/commit/47aa1ff) (fixes [#8](https://github.com/orian/clickhouse-sql-parser/issues/8)), already pinned via `go.mod` replace.
+
+## Test plan
+
+- [x] `go build ./...`
+- [x] `go vet ./...`
+- [x] `go test ./... -count=1`
+- [x] `ENABLE_CLICKHOUSE=1 go test ./... -count=1` (with docker compose up)
+- [x] PostHog prom_metrics CREATE statement round-trips through introspect → sqlgen → introspect with no diff
+- [ ] CI runs the same matrices
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)
+```
+
+- [ ] **Step 4: Watch CI**
+
+```bash
+gh pr checks
+```

--- a/docs/superpowers/specs/2026-06-01-timeseries-engine-support.md
+++ b/docs/superpowers/specs/2026-06-01-timeseries-engine-support.md
@@ -1,0 +1,185 @@
+# TimeSeries Engine Support in hclexp — Design Spec
+
+**Date:** 2026-06-01
+**Status:** Approved, ready for implementation
+**Reference docs:** `clickhouse-docs/en/engines/table-engines/integrations/time-series.md` (full file; in particular the *Syntax*, *Target tables*, *Creation*, and *Settings* sections)
+
+## Motivation
+
+`hclexp introspect` against PostHog production fails the entire database dump on the first table whose engine the chparser cannot tokenize. The reported case:
+
+```
+parse create_table_query for posthog.prom_metrics:
+  parser: line 0:431 <EOF> or ';' was expected, but got: "DATA"
+CREATE TABLE posthog.prom_metrics (...) ENGINE = TimeSeries
+  DATA posthog.prom_metrics_data
+  TAGS posthog.prom_metrics_tags
+  METRICS posthog.prom_metrics_metrics
+```
+
+`TimeSeries` is an experimental ClickHouse engine for storing Prometheus-style time series. It declares three sibling target tables (`samples`/`tags`/`metrics`) either as external table references or via inline `INNER COLUMNS` + `INNER ENGINE` clauses. The chparser fork has no handling for this grammar; the introspector has no handling for the engine kind. We need both.
+
+The companion need ("be able to keep dumping when some engines aren't supported") is split off into a separate spec on skip mechanics.
+
+## Surface (HCL)
+
+A new engine kind `time_series` available inside `table` blocks, with three optional repeatable-style sub-blocks (one per target kind).
+
+```hcl
+table "prom_metrics" {
+  # Outer columns (CH may auto-generate them; explicit declaration also allowed).
+  column "id"          { type = "UUID" }
+  column "timestamp"   { type = "DateTime64(3)" }
+  column "value"       { type = "Float64" }
+  column "metric_name" { type = "LowCardinality(String)" }
+  # ... other CH-auto outer columns ...
+
+  engine "time_series" {
+    settings = {
+      id_generator                    = "sipHash64(metric_name, all_tags)"
+      store_min_time_and_max_time     = "1"
+      filter_by_min_time_and_max_time = "1"
+    }
+    tags_to_columns = {
+      instance = "instance"
+      job      = "job"
+    }
+
+    samples {                              # AKA "data" (alias retained on dump-side for round-trip)
+      target = "posthog.prom_metrics_data"
+    }
+
+    tags {
+      inner {
+        column "id"          { type = "UUID" }
+        column "metric_name" { type = "LowCardinality(String)" }
+        column "tags"        { type = "Map(LowCardinality(String), String)" }
+        column "min_time"    { type = "SimpleAggregateFunction(min, Nullable(DateTime64(3)))" }
+        column "max_time"    { type = "SimpleAggregateFunction(max, Nullable(DateTime64(3)))" }
+
+        engine "aggregating_merge_tree" {}
+        primary_key = ["metric_name"]
+        order_by    = ["metric_name", "id"]
+      }
+    }
+
+    metrics {
+      target = "posthog.prom_metrics_metrics"
+    }
+  }
+}
+```
+
+Field-by-field on `engine "time_series"`:
+
+| HCL attribute      | Go type                | Mapped to                                                              |
+| ------------------ | ---------------------- | ---------------------------------------------------------------------- |
+| `settings`         | `map[string]string`    | `SETTINGS k = 'v', …` clause on the CREATE                             |
+| `tags_to_columns`  | `map[string]string`    | `SETTINGS tags_to_columns = {'tag1': 'col1', …}` — promoted for clarity |
+| `samples` block    | `*TimeSeriesTarget`    | `SAMPLES <ref>` or `SAMPLES INNER COLUMNS (…) [SAMPLES INNER ENGINE = …]` |
+| `tags` block       | `*TimeSeriesTarget`    | `TAGS <ref>` or `TAGS INNER COLUMNS (…) [TAGS INNER ENGINE = …]`         |
+| `metrics` block    | `*TimeSeriesTarget`    | `METRICS <ref>` or `METRICS INNER COLUMNS (…) [METRICS INNER ENGINE = …]` |
+
+Each `TimeSeriesTarget` has:
+
+| HCL attribute  | Go type                  | Mapped to                                |
+| -------------- | ------------------------ | ---------------------------------------- |
+| `target`       | `*string`                | external `<db>.<table>` reference        |
+| `inner` block  | `*TimeSeriesInnerTable`  | inline `INNER COLUMNS` + `INNER ENGINE`  |
+
+Each `TimeSeriesInnerTable` is a small slice of `TableSpec` covering only the fields CH emits inside an `INNER COLUMNS`/`INNER ENGINE` block:
+
+| HCL attribute  | Go type             | Mapped to                          |
+| -------------- | ------------------- | ---------------------------------- |
+| `column`       | `[]ColumnSpec`      | inner-target column list           |
+| `engine`       | `*EngineSpec`       | inner-target engine (MergeTree-family only) |
+| `primary_key`  | `[]string`          | `PRIMARY KEY` on the inner target  |
+| `order_by`     | `[]string`          | `ORDER BY`                         |
+| `partition_by` | `*string`           | `PARTITION BY`                     |
+| `settings`     | `map[string]string` | `SETTINGS` on the inner target     |
+
+### Rules
+
+- **Exactly one** of `target` or `inner` per sub-block. Both → resolve-time error. Neither → resolve-time error.
+- All three sub-blocks are optional. `engine "time_series" {}` is the simplest valid form (CH auto-generates inner targets for the missing kinds, matching the docs' "Creation" section).
+- The inner-target engine must be one of the MergeTree-family kinds the resolver already knows. Reject `kafka`/`distributed`/etc. with a clear error — CH itself rejects these and we surface it earlier.
+- `tags_to_columns` is modelled as a separate top-level attribute rather than nested inside `settings`. Rationale: CH treats it as a *schema-shaping* setting (declaring tags-target columns), distinct from runtime tuning. Promoting it makes the HCL self-documenting; sqlgen folds it back into the `SETTINGS` clause at emit time.
+- `DATA` (the documented alias for `SAMPLES`) is **dump-side only**: introspection captures the source keyword; sqlgen round-trips it. HCL authors always write the canonical `samples`.
+
+### Out of scope (rejected during introspection with a clear error)
+
+- Any future TimeSeries syntax extension (e.g., new settings, new clause kinds) not modelled here. Introspection fails with `unknown TimeSeries clause: %s` so the user is forced to upgrade hclexp rather than silently losing the clause.
+- Validation that the external target's schema matches CH's required column shape (the docs constrain inner targets' columns, but enforcing that would duplicate CH's own CREATE-time check; we leave it to CH).
+
+## Architecture
+
+Work spans two repositories. The chparser change must land first because the engine implementation here consumes the new AST node.
+
+### chparser fork (`../clickhouse-sql-parser`, repo `orian/clickhouse-sql-parser`)
+
+1. **Lexer.** New keywords: `SAMPLES`, `DATA`, `TAGS`, `METRICS`, `INNER`. Tokenised contextually (engine-tail position only) to avoid colliding with user identifiers.
+2. **AST.** New node `TimeSeriesTargetClause`:
+   ```go
+   type TimeSeriesTargetClause struct {
+       Kind        string             // "samples" | "tags" | "metrics"
+       Keyword     string             // verbatim source keyword: "SAMPLES" | "DATA" | "TAGS" | "METRICS"
+       External    *TableIdentifier   // external form
+       InnerCols   *TableSchemaClause // inner form
+       InnerEngine *EngineExpr        // inner form
+   }
+   ```
+   `CreateTable` gains `TimeSeriesTargets []*TimeSeriesTargetClause` (nil when engine != TimeSeries).
+3. **Parser.** New production for the engine-tail clause list, parsed only when `Engine.Name == "TimeSeries"`. Each clause: `(SAMPLES | DATA | TAGS | METRICS) (table_identifier | INNER COLUMNS '(' column_list ')' [(SAMPLES|DATA|TAGS|METRICS) INNER ENGINE '=' engine_expr])`.
+4. **PrintVisitor.** Round-trip rendering of the new clauses.
+5. **Tests.** Parser-level fixtures: PostHog's prom_metrics, the doc's "fully generated" inner form, a minimal `ENGINE = TimeSeries`, the `tags_to_columns` form, the `id_generator` form.
+6. **Issue + PR:** File issue at `github.com/orian/clickhouse-sql-parser` referencing this spec; PR with the changes above; upstream PR to `AfterShip/clickhouse-sql-parser` as a follow-up (out of scope here).
+
+After the chparser change is merged, bump the replace directive in this repo's `go.mod`.
+
+### chschema (this repo) — files touched
+
+1. **`internal/loader/hcl/types.go`** — no change (TimeSeries is engine-internal; the outer table is a regular `TableSpec`).
+2. **`internal/loader/hcl/engines.go`** — new `EngineTimeSeries`, `TimeSeriesTarget`, `TimeSeriesInnerTable` structs; new `DecodeEngine` case; `Virtuals()` returns nil (TimeSeries exposes no engine-virtual columns — its outer columns are real declared columns).
+3. **`internal/loader/hcl/resolver.go`** — validate per-target both-or-neither rule; restrict inner engine to MergeTree-family kinds; resolve unqualified target names against the surrounding database.
+4. **`internal/loader/hcl/introspect.go`** — when the chparser returns a `CreateTable` whose engine is `TimeSeries`, dispatch to a new `buildTimeSeriesFromCreateTable` that walks the `TimeSeriesTargetClause` list, populates `EngineTimeSeries`, and stamps `KeywordHint` from the source `Keyword`.
+5. **`internal/loader/hcl/sqlgen.go`** — new `createTimeSeriesEngineSQL(e EngineTimeSeries) (string, map[string]string)` invoked from `engineSQL`; promotes `TagsToColumns` into the `SETTINGS` map before rendering; emits one tail-clause line per non-nil sub-block in `samples`/`tags`/`metrics` order; chooses `SAMPLES`/`DATA` based on `KeywordHint` (default `SAMPLES`).
+6. **`internal/loader/hcl/diff.go`** — new `TimeSeriesDiff` (covering target swaps, inner-target column/engine/settings changes, tags_to_columns changes, and settings changes split into ALTER-able vs recreate buckets); folded into the existing `TableDiff` so the rest of the dispatch logic stays intact.
+7. **`internal/loader/hcl/validate.go`** — new dependency kind `DepTimeSeriesTarget = "ts_target"`. `CollectDependencies` walks every table; for each `EngineTimeSeries` with an external-form target, emit a dependency on `db.table`. Inner-form targets create no dependency.
+8. **`internal/loader/hcl/sqlgen.go`** (diff path) — ALTER emission: `id_generator` and `filter_by_min_time_and_max_time` changes → `ALTER TABLE … MODIFY SETTING k = v`. Every other change → mark `Recreate = true` + add `UnsafeChange`.
+9. **`docs/README.hcl.md`** — new section under "Engine kinds" describing the `time_series` engine; cross-reference to the upstream TimeSeries docs.
+10. **`docs/FAQ.md`** — short Q&A: "How do I model a Prometheus TimeSeries table?"
+
+### Tests
+
+- **Unit:** `engines_test.go` (decode), `introspect_test.go` (round-trip from hand-written CREATE strings), `sqlgen_test.go` (emit including keyword hint), `diff_test.go` (ALTER-able vs recreate buckets), `validate_test.go` (`ts_target` dependency), `resolver_test.go` (both-or-neither, inner-engine restriction). Add a top-level round-trip test asserting `parse → build → sqlgen → parse → build` is a fixed point.
+- **Live:** extend `test/hcl_introspect_live_test.go` with two TimeSeries variants (external + inner forms). Apply-and-diff smoke test.
+- **Fixtures:** three SQL files under `test/testdata/posthog-create-statements/TimeSeries/` (the production CREATE, the doc-default inner form, the minimal form). Picked up automatically by the existing engine-grouped loop.
+- **chparser fork:** parser_test entries for each fixture asserting the AST shape.
+
+## Implementation order
+
+1. **chparser fork:** open issue, implement lexer + AST + parser + PrintVisitor + tests, open PR, merge.
+2. **chschema:** bump go.mod replace to the new chparser SHA.
+3. **chschema:** `EngineTimeSeries` struct + `DecodeEngine` case + `Virtuals()`.
+4. **chschema:** resolver rules + tests.
+5. **chschema:** introspect path + tests + fixtures.
+6. **chschema:** sqlgen + tests.
+7. **chschema:** diff path + tests.
+8. **chschema:** validate path + tests.
+9. **chschema:** live tests.
+10. **chschema:** docs.
+
+Each step ends green. Each PR-sized chunk: chparser change (1–2), then chschema-side work as either one feature PR (3–10) or split if review-time is tight.
+
+## Out of scope
+
+- Skip-tables / skip-engines flag on introspect (separate spec).
+- TimeSeries dependency *type* validation (CH-style "external samples table needs columns id/timestamp/value"). CH itself rejects mismatches at CREATE.
+- `ALTER ... MODIFY SETTING` for `tags_to_columns` and other non-ALTER-able settings. CH itself rejects them — sqlgen marks recreate + unsafe.
+- `CREATE TABLE x AS y` semantics for TimeSeries (docs' "Creating a table AS existing table" section). The existing `hclexp` model doesn't model AS-based creation; nothing changes here.
+
+## Future work
+
+- Skip-tables / skip-engines on introspect (separate spec, drafted next).
+- `ALTER … MODIFY SETTING id_generator` only matters once HCL adopters need it; reuse the same diff infrastructure if other engines also gain ALTER-able settings later.
+- Upstream the chparser PR to `AfterShip/clickhouse-sql-parser` so the fork can eventually shrink.

--- a/go.mod
+++ b/go.mod
@@ -47,4 +47,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260528133804-903b1cab88e4
+replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260601104648-4521cd37e69b

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/orian/clickhouse-sql-parser v0.0.0-20260528133804-903b1cab88e4 h1:vTU1h+xlZlbAv/A2jSto6rtMgcKYY/aYe5IrhcuoDIw=
-github.com/orian/clickhouse-sql-parser v0.0.0-20260528133804-903b1cab88e4/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
+github.com/orian/clickhouse-sql-parser v0.0.0-20260601104648-4521cd37e69b h1:EpAXD/zgcZFpBP+9jnfi/vrKJUe0aASf/fU/iFlfBR0=
+github.com/orian/clickhouse-sql-parser v0.0.0-20260601104648-4521cd37e69b/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
 github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=

--- a/internal/loader/hcl/diff.go
+++ b/internal/loader/hcl/diff.go
@@ -608,6 +608,34 @@ func diffTable(from, to *TableSpec, fromR, toR TableResolver) TableDiff {
 		}
 	}
 
+	// TimeSeries gets a smarter engine-diff path: changes to two specific
+	// SETTINGS (id_generator, filter_by_min_time_and_max_time) are
+	// ALTER-able in CH; everything else (other settings, target swaps,
+	// tags_to_columns) is a recreate. This split lets the user evolve the
+	// two alterable settings without losing the table.
+	if fromTS, fromOK := engineOf(*from).(EngineTimeSeries); fromOK {
+		if toTS, toOK := engineOf(*to).(EngineTimeSeries); toOK {
+			diffTimeSeries(&td, from.Engine, to.Engine, fromTS, toTS)
+			td.OrderByChange = diffStringSlice(from.OrderBy, to.OrderBy)
+			td.PartitionByChange = diffStringPtr(from.PartitionBy, to.PartitionBy)
+			td.SampleByChange = diffStringPtr(from.SampleBy, to.SampleBy)
+			td.TTLChange = diffStringPtr(from.TTL, to.TTL)
+			// Merge in table-level Settings (independent of engine settings
+			// on TimeSeries). We append rather than overwrite so the engine
+			// settings populated by diffTimeSeries above aren't dropped.
+			added, removed, changed := diffSettings(from.Settings, to.Settings)
+			for k, v := range added {
+				if td.SettingsAdded == nil {
+					td.SettingsAdded = map[string]string{}
+				}
+				td.SettingsAdded[k] = v
+			}
+			td.SettingsRemoved = append(td.SettingsRemoved, removed...)
+			td.SettingsChanged = append(td.SettingsChanged, changed...)
+			return td
+		}
+	}
+
 	td.EngineChange = diffEngine(from.Engine, to.Engine)
 	td.OrderByChange = diffStringSlice(from.OrderBy, to.OrderBy)
 	td.PartitionByChange = diffStringPtr(from.PartitionBy, to.PartitionBy)
@@ -620,6 +648,64 @@ func diffTable(from, to *TableSpec, fromR, toR TableResolver) TableDiff {
 	td.SettingsChanged = changed
 
 	return td
+}
+
+// timeSeriesAlterableSettings names the SETTINGS keys CH supports via
+// ALTER TABLE ... MODIFY SETTING on a TimeSeries table.
+var timeSeriesAlterableSettings = map[string]bool{
+	"id_generator":                    true,
+	"filter_by_min_time_and_max_time": true,
+}
+
+// diffTimeSeries fills td.SettingsAdded/Removed/Changed for the two
+// ALTER-able TimeSeries settings, and marks the rest of the engine diff
+// as a recreate via EngineChange.
+func diffTimeSeries(td *TableDiff, fromSpec, toSpec *EngineSpec, from, to EngineTimeSeries) {
+	bakedDiffers := false
+	for k, vNew := range to.Settings {
+		vOld, ok := from.Settings[k]
+		if !ok {
+			if timeSeriesAlterableSettings[k] {
+				if td.SettingsAdded == nil {
+					td.SettingsAdded = map[string]string{}
+				}
+				td.SettingsAdded[k] = vNew
+			} else {
+				bakedDiffers = true
+			}
+			continue
+		}
+		if vOld != vNew {
+			if timeSeriesAlterableSettings[k] {
+				td.SettingsChanged = append(td.SettingsChanged, SettingChange{Key: k, OldValue: vOld, NewValue: vNew})
+			} else {
+				bakedDiffers = true
+			}
+		}
+	}
+	for k := range from.Settings {
+		if _, ok := to.Settings[k]; ok {
+			continue
+		}
+		if timeSeriesAlterableSettings[k] {
+			td.SettingsRemoved = append(td.SettingsRemoved, k)
+		} else {
+			bakedDiffers = true
+		}
+	}
+
+	if !reflect.DeepEqual(from.TagsToColumns, to.TagsToColumns) {
+		bakedDiffers = true
+	}
+	if !reflect.DeepEqual(from.Samples, to.Samples) ||
+		!reflect.DeepEqual(from.Tags, to.Tags) ||
+		!reflect.DeepEqual(from.Metrics, to.Metrics) {
+		bakedDiffers = true
+	}
+
+	if bakedDiffers {
+		td.EngineChange = &EngineChange{Old: from, New: to}
+	}
 }
 
 func indexColumns(cols []ColumnSpec) map[string]*ColumnSpec {

--- a/internal/loader/hcl/diff_test.go
+++ b/internal/loader/hcl/diff_test.go
@@ -887,3 +887,95 @@ func TestDiff_VirtualColumnGuard_DistributedTransitive(t *testing.T) {
 	cs := Diff(from, to)
 	assert.True(t, cs.IsEmpty(), "transitive virtual leak should not surface as a DROP on Distributed")
 }
+
+func TestDiff_TimeSeries_IdGeneratorChange_ALTERed(t *testing.T) {
+	mk := func(idGen string) *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					Settings: map[string]string{"id_generator": idGen},
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk("sipHash64(metric_name)"), mk("sipHash64(metric_name, all_tags)"))
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterTables, 1)
+	td := cs.Databases[0].AlterTables[0]
+	require.Len(t, td.SettingsChanged, 1)
+	assert.Equal(t, "id_generator", td.SettingsChanged[0].Key)
+	assert.False(t, td.IsUnsafe(), "id_generator change is in-place")
+}
+
+func TestDiff_TimeSeries_BakedSettingChange_Recreate(t *testing.T) {
+	mk := func(val string) *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					Settings: map[string]string{"store_min_time_and_max_time": val},
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk("0"), mk("1"))
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterTables, 1)
+	td := cs.Databases[0].AlterTables[0]
+	assert.True(t, td.IsUnsafe(), "non-alterable setting change should be recreate")
+}
+
+func TestDiff_TimeSeries_TargetChange_Recreate(t *testing.T) {
+	mk := func(target string) *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					Samples: &TimeSeriesTarget{Target: &target},
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk("db.old"), mk("db.new"))
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterTables, 1)
+	assert.True(t, cs.Databases[0].AlterTables[0].IsUnsafe())
+}
+
+func TestDiff_TimeSeries_TagsToColumnsChange_Recreate(t *testing.T) {
+	mk := func(m map[string]string) *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					TagsToColumns: m,
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk(map[string]string{"instance": "instance"}), mk(map[string]string{"instance": "instance", "job": "job"}))
+	td := cs.Databases[0].AlterTables[0]
+	assert.True(t, td.IsUnsafe())
+}
+
+func TestDiff_TimeSeries_NoChange(t *testing.T) {
+	tgt := "db.m_data"
+	mk := func() *Schema {
+		return &Schema{Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					Samples: &TimeSeriesTarget{Target: &tgt},
+				}},
+			}},
+		}}}
+	}
+	cs := Diff(mk(), mk())
+	assert.True(t, cs.IsEmpty(), "no change should produce empty diff")
+}

--- a/internal/loader/hcl/dump.go
+++ b/internal/loader/hcl/dump.go
@@ -259,6 +259,55 @@ func writeEngine(parent *hclwrite.Body, e Engine) {
 		if len(v.Extra) > 0 {
 			b.SetAttributeValue("extra", stringMap(v.Extra))
 		}
+	case EngineTimeSeries:
+		if len(v.Settings) > 0 {
+			b.SetAttributeValue("settings", stringMap(v.Settings))
+		}
+		if len(v.TagsToColumns) > 0 {
+			b.SetAttributeValue("tags_to_columns", stringMap(v.TagsToColumns))
+		}
+		for _, sub := range []struct {
+			label string
+			t     *TimeSeriesTarget
+		}{
+			{"samples", v.Samples},
+			{"tags", v.Tags},
+			{"metrics", v.Metrics},
+		} {
+			if sub.t == nil {
+				continue
+			}
+			tBlock := b.AppendNewBlock(sub.label, nil)
+			tb := tBlock.Body()
+			if sub.t.Target != nil {
+				tb.SetAttributeValue("target", cty.StringVal(*sub.t.Target))
+				continue
+			}
+			if sub.t.Inner == nil {
+				continue
+			}
+			innerBlock := tb.AppendNewBlock("inner", nil)
+			ib := innerBlock.Body()
+			for _, c := range sub.t.Inner.Columns {
+				colBlock := ib.AppendNewBlock("column", []string{c.Name})
+				colBlock.Body().SetAttributeValue("type", cty.StringVal(c.Type))
+			}
+			if sub.t.Inner.Engine != nil && sub.t.Inner.Engine.Decoded != nil {
+				writeEngine(ib, sub.t.Inner.Engine.Decoded)
+			}
+			if len(sub.t.Inner.PrimaryKey) > 0 {
+				ib.SetAttributeValue("primary_key", stringList(sub.t.Inner.PrimaryKey))
+			}
+			if len(sub.t.Inner.OrderBy) > 0 {
+				ib.SetAttributeValue("order_by", stringList(sub.t.Inner.OrderBy))
+			}
+			if sub.t.Inner.PartitionBy != nil {
+				ib.SetAttributeValue("partition_by", cty.StringVal(*sub.t.Inner.PartitionBy))
+			}
+			if len(sub.t.Inner.Settings) > 0 {
+				ib.SetAttributeValue("settings", stringMap(sub.t.Inner.Settings))
+			}
+		}
 	}
 }
 

--- a/internal/loader/hcl/engines.go
+++ b/internal/loader/hcl/engines.go
@@ -214,6 +214,61 @@ func (e EngineKafka) Virtuals() []DeclaredColumn {
 	return kafkaBaseVirtuals
 }
 
+// EngineTimeSeries models the (experimental) ClickHouse TimeSeries engine.
+// It stores Prometheus-style time series across three sibling target tables
+// (samples/tags/metrics), each either an external CH table reference or an
+// inline declaration with INNER COLUMNS + optional INNER ENGINE.
+//
+// TimeSeries exposes no engine-virtual columns — its outer columns are real
+// declared columns. Virtuals() returns nil.
+type EngineTimeSeries struct {
+	// Settings declared via `engine "time_series" { settings = {...} }`.
+	// Free-form for forward compatibility. Only two are ALTER-able
+	// (id_generator, filter_by_min_time_and_max_time); the rest are
+	// baked into the CREATE.
+	Settings map[string]string `hcl:"settings,optional"`
+
+	// TagsToColumns shapes the inner tags-target table by promoting
+	// specific label keys into their own columns. CH treats this as a
+	// setting at the SQL level; promoted here for HCL clarity. sqlgen
+	// folds it back into the SETTINGS clause at emit time.
+	TagsToColumns map[string]string `hcl:"tags_to_columns,optional"`
+
+	// Target sub-blocks. Nil = CH default applies (auto-generate the
+	// inner target for that kind).
+	Samples *TimeSeriesTarget `hcl:"samples,block"`
+	Tags    *TimeSeriesTarget `hcl:"tags,block"`
+	Metrics *TimeSeriesTarget `hcl:"metrics,block"`
+
+	// KeywordHint preserves whether the samples target's source SQL used
+	// SAMPLES or DATA. Populated by the introspector; sqlgen reads it to
+	// round-trip the same word. HCL authors never set this — no hcl tag
+	// so gohcl ignores it during decode.
+	KeywordHint string `diff:"-"`
+}
+
+func (EngineTimeSeries) Kind() string { return "time_series" }
+
+func (EngineTimeSeries) Virtuals() []DeclaredColumn { return nil }
+
+// TimeSeriesTarget is one of {samples, tags, metrics}. Exactly one of
+// Target or Inner must be set; both/neither is a resolve-time error.
+type TimeSeriesTarget struct {
+	Target *string               `hcl:"target,optional"`
+	Inner  *TimeSeriesInnerTable `hcl:"inner,block"`
+}
+
+// TimeSeriesInnerTable mirrors a small slice of TableSpec — only the
+// fields CH actually emits inside INNER COLUMNS / INNER ENGINE.
+type TimeSeriesInnerTable struct {
+	Columns     []ColumnSpec      `hcl:"column,block"`
+	Engine      *EngineSpec       `hcl:"engine,block"`
+	PrimaryKey  []string          `hcl:"primary_key,optional"`
+	OrderBy     []string          `hcl:"order_by,optional"`
+	PartitionBy *string           `hcl:"partition_by,optional"`
+	Settings    map[string]string `hcl:"settings,optional"`
+}
+
 var distributedSelfVirtuals = []DeclaredColumn{
 	{Name: "_shard_num", Type: "UInt32"},
 }
@@ -334,6 +389,24 @@ func DecodeEngine(spec *EngineSpec) (Engine, error) {
 	case "kafka":
 		var e EngineKafka
 		diags = gohcl.DecodeBody(spec.Body, nil, &e)
+		target = e
+	case "time_series":
+		var e EngineTimeSeries
+		diags = gohcl.DecodeBody(spec.Body, nil, &e)
+		if !diags.HasErrors() {
+			// Recursively decode inner engines so resolver/sqlgen see
+			// typed values without each caller having to do it again.
+			for _, t := range []*TimeSeriesTarget{e.Samples, e.Tags, e.Metrics} {
+				if t == nil || t.Inner == nil || t.Inner.Engine == nil {
+					continue
+				}
+				inner, err := DecodeEngine(t.Inner.Engine)
+				if err != nil {
+					return nil, fmt.Errorf("time_series inner engine: %w", err)
+				}
+				t.Inner.Engine.Decoded = inner
+			}
+		}
 		target = e
 	default:
 		return nil, fmt.Errorf("unknown engine kind %q", spec.Kind)

--- a/internal/loader/hcl/engines_test.go
+++ b/internal/loader/hcl/engines_test.go
@@ -80,6 +80,17 @@ func TestParseFile_AllEngineKinds(t *testing.T) {
 		GroupName:  ptr("ingest"),
 		Format:     ptr("JSONEachRow"),
 	}, byName["t_kafka"])
+
+	tgtData := "default.t_time_series_data"
+	tgtTags := "default.t_time_series_tags"
+	tgtMetrics := "default.t_time_series_metrics"
+	assert.Equal(t, EngineTimeSeries{
+		Settings:      map[string]string{"id_generator": "sipHash64(metric_name, all_tags)"},
+		TagsToColumns: map[string]string{"instance": "instance", "job": "job"},
+		Samples:       &TimeSeriesTarget{Target: &tgtData},
+		Tags:          &TimeSeriesTarget{Target: &tgtTags},
+		Metrics:       &TimeSeriesTarget{Target: &tgtMetrics},
+	}, byName["t_time_series"])
 }
 
 func TestParseFile_UnknownEngineKind(t *testing.T) {
@@ -92,6 +103,28 @@ func TestParseFile_EngineMissingRequired(t *testing.T) {
 	_, err := ParseFile(filepath.Join("testdata", "engine_missing_required.hcl"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "replica_name")
+}
+
+func TestParseFile_TimeSeries_InnerForm(t *testing.T) {
+	schema, err := ParseFile(filepath.Join("testdata", "engine_time_series_inner.hcl"))
+	require.NoError(t, err)
+	require.Len(t, schema.Databases, 1)
+	require.Len(t, schema.Databases[0].Tables, 1)
+
+	tbl := schema.Databases[0].Tables[0]
+	require.NotNil(t, tbl.Engine)
+	require.NotNil(t, tbl.Engine.Decoded)
+	e := tbl.Engine.Decoded.(EngineTimeSeries)
+
+	require.NotNil(t, e.Samples)
+	require.Nil(t, e.Samples.Target)
+	require.NotNil(t, e.Samples.Inner)
+	assert.Equal(t, []string{"id", "timestamp"}, e.Samples.Inner.OrderBy)
+	require.Len(t, e.Samples.Inner.Columns, 3)
+
+	require.NotNil(t, e.Samples.Inner.Engine)
+	_, ok := e.Samples.Inner.Engine.Decoded.(EngineMergeTree)
+	assert.True(t, ok, "inner engine should be decoded recursively (got %T)", e.Samples.Inner.Engine.Decoded)
 }
 
 func TestEngine_KindMethods(t *testing.T) {
@@ -112,6 +145,7 @@ func TestEngine_KindMethods(t *testing.T) {
 		{EngineDistributed{}, "distributed"},
 		{EngineLog{}, "log"},
 		{EngineKafka{}, "kafka"},
+		{EngineTimeSeries{}, "time_series"},
 	}
 	for _, c := range cases {
 		assert.Equal(t, c.want, c.engine.Kind())

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -156,6 +156,28 @@ func buildTableFromCreateTable(ct *chparser.CreateTable) (TableSpec, error) {
 		if err != nil {
 			return TableSpec{}, err
 		}
+		// TimeSeries target clauses live on CreateTable, not EngineExpr —
+		// fold them in here before stamping the engine onto the table.
+		if ts, ok := eng.(EngineTimeSeries); ok && len(ct.TimeSeriesTargets) > 0 {
+			for _, tc := range ct.TimeSeriesTargets {
+				target, err := buildTimeSeriesTarget(tc)
+				if err != nil {
+					return TableSpec{}, fmt.Errorf("%s target: %w", tc.Kind, err)
+				}
+				switch tc.Kind {
+				case "samples":
+					ts.Samples = target
+					ts.KeywordHint = tc.Keyword // SAMPLES or DATA
+				case "tags":
+					ts.Tags = target
+				case "metrics":
+					ts.Metrics = target
+				default:
+					return TableSpec{}, fmt.Errorf("unknown TimeSeries target kind: %q", tc.Kind)
+				}
+			}
+			eng = ts
+		}
 		t.Engine = &EngineSpec{Kind: eng.Kind(), Decoded: eng}
 
 		if ct.Engine.OrderBy != nil {
@@ -465,6 +487,26 @@ func engineFromAST(e *chparser.EngineExpr) (Engine, map[string]string, error) {
 			stripped = nil
 		}
 		return k, stripped, nil
+	case "TimeSeries":
+		// All SETTINGS on a TimeSeries engine belong to the engine itself,
+		// not to the table — promote tags_to_columns to a typed field,
+		// keep the rest in Settings.
+		ts := EngineTimeSeries{}
+		for k, v := range allSettings {
+			if k == "tags_to_columns" {
+				m, err := parseTagsToColumnsMap(v)
+				if err != nil {
+					return nil, nil, fmt.Errorf("tags_to_columns: %w", err)
+				}
+				ts.TagsToColumns = m
+				continue
+			}
+			if ts.Settings == nil {
+				ts.Settings = map[string]string{}
+			}
+			ts.Settings[k] = v
+		}
+		return ts, nil, nil
 	}
 	return nil, nil, fmt.Errorf("unsupported engine: %s", e.Name)
 }
@@ -1032,4 +1074,95 @@ func stringSliceEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// buildTimeSeriesTarget turns a chparser.TimeSeriesTargetClause into a typed
+// TimeSeriesTarget. Either External or Inner must be set on the clause;
+// the resolver enforces that both-or-neither is rejected.
+func buildTimeSeriesTarget(tc *chparser.TimeSeriesTargetClause) (*TimeSeriesTarget, error) {
+	if tc.External != nil {
+		ref := stripBackticks(tc.External.String())
+		return &TimeSeriesTarget{Target: &ref}, nil
+	}
+	if tc.InnerColumns == nil {
+		return nil, errors.New("clause has neither external table nor inner columns")
+	}
+	cols := columnsFromTableSchema(tc.InnerColumns)
+	inner := &TimeSeriesInnerTable{
+		Columns: make([]ColumnSpec, len(cols)),
+	}
+	for i, c := range cols {
+		inner.Columns[i] = ColumnSpec{Name: c.Name, Type: c.Type}
+	}
+	if tc.InnerEngine != nil {
+		eng, _, err := engineFromAST(tc.InnerEngine)
+		if err != nil {
+			return nil, fmt.Errorf("inner engine: %w", err)
+		}
+		inner.Engine = &EngineSpec{Kind: eng.Kind(), Decoded: eng}
+		if tc.InnerEngine.OrderBy != nil {
+			for _, it := range tc.InnerEngine.OrderBy.Items {
+				inner.OrderBy = append(inner.OrderBy, flattenTupleExpr(it)...)
+			}
+		}
+		if tc.InnerEngine.PrimaryKey != nil {
+			if pk := exprList(tc.InnerEngine.PrimaryKey.Expr); len(pk) > 0 && !stringSliceEqual(pk, inner.OrderBy) {
+				inner.PrimaryKey = pk
+			}
+		}
+		if tc.InnerEngine.PartitionBy != nil {
+			pb := formatNode(tc.InnerEngine.PartitionBy.Expr)
+			inner.PartitionBy = &pb
+		}
+	}
+	return &TimeSeriesTarget{Inner: inner}, nil
+}
+
+// parseTagsToColumnsMap parses the `{'tag1':'col1','tag2':'col2',...}` map
+// literal CH emits in SETTINGS for the TimeSeries tags_to_columns setting.
+func parseTagsToColumnsMap(s string) (map[string]string, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{") || !strings.HasSuffix(s, "}") {
+		return nil, fmt.Errorf("expected map literal, got %q", s)
+	}
+	inner := strings.TrimSpace(s[1 : len(s)-1])
+	if inner == "" {
+		return map[string]string{}, nil
+	}
+	out := map[string]string{}
+	for _, pair := range splitTopLevel(inner, ',') {
+		kv := splitTopLevel(strings.TrimSpace(pair), ':')
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("expected `key:value`, got %q", pair)
+		}
+		k := unquoteString(strings.TrimSpace(kv[0]))
+		v := unquoteString(strings.TrimSpace(kv[1]))
+		out[k] = v
+	}
+	return out, nil
+}
+
+// splitTopLevel splits s on sep, respecting single-quoted strings. The
+// TimeSeries map literal values are flat strings, so quote awareness is
+// enough — no nested brackets or commas inside values.
+func splitTopLevel(s string, sep byte) []string {
+	var parts []string
+	var current strings.Builder
+	inSingle := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\'' && (i == 0 || s[i-1] != '\\') {
+			inSingle = !inSingle
+		}
+		if c == sep && !inSingle {
+			parts = append(parts, current.String())
+			current.Reset()
+			continue
+		}
+		current.WriteByte(c)
+	}
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	return parts
 }

--- a/internal/loader/hcl/introspect_test.go
+++ b/internal/loader/hcl/introspect_test.go
@@ -597,3 +597,77 @@ func TestParseKafkaEngine_Cases(t *testing.T) {
 		})
 	}
 }
+
+func TestIntrospect_TimeSeries_External(t *testing.T) {
+	sql := "CREATE TABLE default.m (`id` UUID, `timestamp` DateTime64(3), `value` Float64, " +
+		"`metric_name` LowCardinality(String)) " +
+		"ENGINE = TimeSeries DATA default.m_data TAGS default.m_tags METRICS default.m_metrics"
+	db := &DatabaseSpec{Name: "default"}
+	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	require.Len(t, db.Tables, 1)
+	tbl := db.Tables[0]
+	assert.Equal(t, "m", tbl.Name)
+	assert.Equal(t, 4, len(tbl.Columns))
+	e, ok := tbl.Engine.Decoded.(EngineTimeSeries)
+	require.True(t, ok)
+	assert.Equal(t, "DATA", e.KeywordHint)
+	require.NotNil(t, e.Samples)
+	require.NotNil(t, e.Samples.Target)
+	assert.Equal(t, "default.m_data", *e.Samples.Target)
+	require.NotNil(t, e.Tags)
+	assert.Equal(t, "default.m_tags", *e.Tags.Target)
+	require.NotNil(t, e.Metrics)
+	assert.Equal(t, "default.m_metrics", *e.Metrics.Target)
+}
+
+func TestIntrospect_TimeSeries_Inner(t *testing.T) {
+	sql := "CREATE TABLE default.m (`metric_name` LowCardinality(String)) ENGINE = TimeSeries " +
+		"SAMPLES INNER COLUMNS (`id` UUID, `timestamp` DateTime64(3), `value` Float64) " +
+		"SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)"
+	db := &DatabaseSpec{Name: "default"}
+	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
+	assert.Equal(t, "SAMPLES", e.KeywordHint)
+	require.NotNil(t, e.Samples)
+	require.NotNil(t, e.Samples.Inner)
+	assert.Nil(t, e.Samples.Target)
+	require.Len(t, e.Samples.Inner.Columns, 3)
+	require.NotNil(t, e.Samples.Inner.Engine)
+	_, ok := e.Samples.Inner.Engine.Decoded.(EngineMergeTree)
+	assert.True(t, ok)
+	assert.Equal(t, []string{"id", "timestamp"}, e.Samples.Inner.OrderBy)
+}
+
+func TestIntrospect_TimeSeries_Bare(t *testing.T) {
+	sql := "CREATE TABLE default.m (`metric_name` LowCardinality(String)) ENGINE = TimeSeries"
+	db := &DatabaseSpec{Name: "default"}
+	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
+	assert.Nil(t, e.Samples)
+	assert.Nil(t, e.Tags)
+	assert.Nil(t, e.Metrics)
+	assert.Empty(t, e.Settings)
+}
+
+func TestIntrospect_TimeSeries_TagsToColumns(t *testing.T) {
+	sql := "CREATE TABLE default.m (`metric_name` LowCardinality(String)) ENGINE = TimeSeries " +
+		"SETTINGS id_generator = 'sipHash64(metric_name, all_tags)', " +
+		"tags_to_columns = {'instance':'instance','job':'job'}"
+	db := &DatabaseSpec{Name: "default"}
+	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
+	assert.Equal(t, "sipHash64(metric_name, all_tags)", e.Settings["id_generator"])
+	assert.Equal(t, map[string]string{"instance": "instance", "job": "job"}, e.TagsToColumns)
+}
+
+func TestIntrospect_TimeSeries_ProductionPromMetrics(t *testing.T) {
+	sql := "CREATE TABLE posthog.prom_metrics (`id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)), `timestamp` DateTime64(3), `value` Float64, `metric_name` LowCardinality(String), `tags` Map(LowCardinality(String), String), `all_tags` Map(String, String), `min_time` Nullable(DateTime64(3)), `max_time` Nullable(DateTime64(3)), `metric_family_name` String, `type` String, `unit` String, `help` String) ENGINE = TimeSeries DATA posthog.prom_metrics_data TAGS posthog.prom_metrics_tags METRICS posthog.prom_metrics_metrics"
+	db := &DatabaseSpec{Name: "posthog"}
+	require.NoError(t, processIntrospectRows(db, "posthog", &fakeRows{rows: []struct{ name, sql string }{{"prom_metrics", sql}}}))
+	require.Len(t, db.Tables, 1)
+	assert.Equal(t, "prom_metrics", db.Tables[0].Name)
+	assert.Len(t, db.Tables[0].Columns, 12)
+	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
+	assert.Equal(t, "DATA", e.KeywordHint)
+	assert.Equal(t, "posthog.prom_metrics_data", *e.Samples.Target)
+}

--- a/internal/loader/hcl/resolver.go
+++ b/internal/loader/hcl/resolver.go
@@ -267,6 +267,11 @@ func resolveDatabase(db *DatabaseSpec) error {
 		if t.Engine == nil || t.Engine.Decoded == nil {
 			return fmt.Errorf("%s.%s: non-abstract table requires an engine", db.Name, t.Name)
 		}
+		if ts, ok := t.Engine.Decoded.(EngineTimeSeries); ok {
+			if err := validateTimeSeriesEngine(db.Name, t.Name, ts); err != nil {
+				return err
+			}
+		}
 		if err := validateColumns(db.Name, t); err != nil {
 			return err
 		}
@@ -283,6 +288,58 @@ func resolveDatabase(db *DatabaseSpec) error {
 		}
 	}
 	return nil
+}
+
+// validateTimeSeriesEngine enforces the engine-specific resolve rules for
+// EngineTimeSeries: each target sub-block must have exactly one of Target
+// or Inner; inner engines must be MergeTree-family kinds.
+func validateTimeSeriesEngine(dbName, tableName string, e EngineTimeSeries) error {
+	for _, kv := range []struct {
+		kind string
+		t    *TimeSeriesTarget
+	}{
+		{"samples", e.Samples},
+		{"tags", e.Tags},
+		{"metrics", e.Metrics},
+	} {
+		if kv.t == nil {
+			continue
+		}
+		hasExternal := kv.t.Target != nil
+		hasInner := kv.t.Inner != nil
+		switch {
+		case hasExternal && hasInner:
+			return fmt.Errorf("%s.%s: time_series %s target: set either target or inner, not both",
+				dbName, tableName, kv.kind)
+		case !hasExternal && !hasInner:
+			return fmt.Errorf("%s.%s: time_series %s target: must set target or inner",
+				dbName, tableName, kv.kind)
+		}
+		if hasInner && kv.t.Inner.Engine != nil && kv.t.Inner.Engine.Decoded != nil {
+			if !isMergeTreeFamily(kv.t.Inner.Engine.Decoded) {
+				return fmt.Errorf("%s.%s: time_series %s inner engine %q: only MergeTree-family engines are allowed",
+					dbName, tableName, kv.kind, kv.t.Inner.Engine.Decoded.Kind())
+			}
+		}
+	}
+	return nil
+}
+
+func isMergeTreeFamily(e Engine) bool {
+	switch e.(type) {
+	case EngineMergeTree,
+		EngineReplicatedMergeTree,
+		EngineReplacingMergeTree,
+		EngineReplicatedReplacingMergeTree,
+		EngineSummingMergeTree,
+		EngineReplicatedSummingMergeTree,
+		EngineCollapsingMergeTree,
+		EngineReplicatedCollapsingMergeTree,
+		EngineAggregatingMergeTree,
+		EngineReplicatedAggregatingMergeTree:
+		return true
+	}
+	return false
 }
 
 func validateConstraints(db string, t TableSpec) error {

--- a/internal/loader/hcl/resolver_test.go
+++ b/internal/loader/hcl/resolver_test.go
@@ -476,3 +476,73 @@ func TestResolve_KafkaCollectionReference(t *testing.T) {
 	assert.Contains(t, err.Error(), "undeclared_nc")
 	assert.Contains(t, err.Error(), "not declared")
 }
+
+func TestResolve_TimeSeries_BothExternalAndInnerOnSameTarget_Rejected(t *testing.T) {
+	tgt := "db.x"
+	e := EngineTimeSeries{Samples: &TimeSeriesTarget{
+		Target: &tgt,
+		Inner:  &TimeSeriesInnerTable{Engine: &EngineSpec{Decoded: EngineMergeTree{}}},
+	}}
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine:  &EngineSpec{Kind: "time_series", Decoded: e},
+		}},
+	}}}
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "samples")
+	assert.Contains(t, err.Error(), "either")
+}
+
+func TestResolve_TimeSeries_NeitherForm_Rejected(t *testing.T) {
+	e := EngineTimeSeries{Samples: &TimeSeriesTarget{}}
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine:  &EngineSpec{Kind: "time_series", Decoded: e},
+		}},
+	}}}
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "samples")
+	assert.Contains(t, err.Error(), "target or inner")
+}
+
+func TestResolve_TimeSeries_InnerEngineRestrictedToMergeTreeFamily(t *testing.T) {
+	e := EngineTimeSeries{Samples: &TimeSeriesTarget{
+		Inner: &TimeSeriesInnerTable{Engine: &EngineSpec{Decoded: EngineKafka{}}},
+	}}
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine:  &EngineSpec{Kind: "time_series", Decoded: e},
+		}},
+	}}}
+	err := Resolve(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inner engine")
+	assert.Contains(t, err.Error(), "MergeTree")
+}
+
+func TestResolve_TimeSeries_AllValidForms_OK(t *testing.T) {
+	tgt := "db.m_data"
+	e := EngineTimeSeries{
+		Samples: &TimeSeriesTarget{Target: &tgt},
+		Tags: &TimeSeriesTarget{Inner: &TimeSeriesInnerTable{
+			Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+			Engine:  &EngineSpec{Decoded: EngineAggregatingMergeTree{}},
+		}},
+	}
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine:  &EngineSpec{Kind: "time_series", Decoded: e},
+		}},
+	}}}
+	require.NoError(t, Resolve(s))
+}

--- a/internal/loader/hcl/sqlgen.go
+++ b/internal/loader/hcl/sqlgen.go
@@ -354,6 +354,13 @@ func createTableSQL(database string, t TableSpec) string {
 	clause, extraSettings := engineSQL(engineOf(t))
 	fmt.Fprintf(&b, " ENGINE = %s", clause)
 
+	// TimeSeries: emit the SAMPLES/TAGS/METRICS tail clauses between the
+	// ENGINE clause and the storage clauses (which are mostly inapplicable
+	// to TimeSeries anyway — the outer table has no ORDER BY etc.).
+	if ts, ok := engineOf(t).(EngineTimeSeries); ok {
+		b.WriteString(timeSeriesTailSQL(ts))
+	}
+
 	if len(t.PrimaryKey) > 0 {
 		fmt.Fprintf(&b, " PRIMARY KEY (%s)", strings.Join(t.PrimaryKey, ", "))
 	}
@@ -609,8 +616,87 @@ func engineSQL(e Engine) (clause string, extraSettings map[string]string) {
 			settings[k] = val
 		}
 		return "Kafka()", settings
+	case EngineTimeSeries:
+		// TimeSeries takes no constructor args. Its tail clauses
+		// (SAMPLES/TAGS/METRICS) are emitted separately by
+		// createTableSQL via timeSeriesTailSQL. SETTINGS flow through the
+		// extraSettings map, with TagsToColumns folded back to its
+		// CH map-literal form.
+		settings := map[string]string{}
+		for k, val := range v.Settings {
+			settings[k] = val
+		}
+		if len(v.TagsToColumns) > 0 {
+			settings["tags_to_columns"] = renderTagsToColumnsMap(v.TagsToColumns)
+		}
+		return "TimeSeries", settings
 	}
 	return "", nil
+}
+
+// renderTagsToColumnsMap renders the typed TagsToColumns map back to the
+// `{'tag1':'col1', 'tag2':'col2'}` literal CH expects in SETTINGS. Keys
+// sorted for deterministic output.
+func renderTagsToColumnsMap(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("'%s':'%s'", k, m[k])
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+// timeSeriesTailSQL renders the SAMPLES/TAGS/METRICS tail clauses that
+// follow `ENGINE = TimeSeries` on a CREATE TABLE statement. Empty string
+// when no target sub-blocks are set.
+func timeSeriesTailSQL(e EngineTimeSeries) string {
+	var b strings.Builder
+	emitTimeSeriesTarget(&b, e.Samples, samplesKeyword(e.KeywordHint))
+	emitTimeSeriesTarget(&b, e.Tags, "TAGS")
+	emitTimeSeriesTarget(&b, e.Metrics, "METRICS")
+	return b.String()
+}
+
+func samplesKeyword(hint string) string {
+	if hint == "DATA" {
+		return "DATA"
+	}
+	return "SAMPLES"
+}
+
+func emitTimeSeriesTarget(b *strings.Builder, t *TimeSeriesTarget, keyword string) {
+	if t == nil {
+		return
+	}
+	if t.Target != nil {
+		fmt.Fprintf(b, " %s %s", keyword, *t.Target)
+		return
+	}
+	if t.Inner == nil {
+		return
+	}
+	parts := make([]string, len(t.Inner.Columns))
+	for i, c := range t.Inner.Columns {
+		parts[i] = columnDefSQL(c)
+	}
+	fmt.Fprintf(b, " %s INNER COLUMNS (%s)", keyword, strings.Join(parts, ", "))
+	if t.Inner.Engine != nil && t.Inner.Engine.Decoded != nil {
+		innerClause, _ := engineSQL(t.Inner.Engine.Decoded)
+		fmt.Fprintf(b, " %s INNER ENGINE = %s", keyword, innerClause)
+	}
+	if len(t.Inner.PrimaryKey) > 0 {
+		fmt.Fprintf(b, " PRIMARY KEY (%s)", strings.Join(t.Inner.PrimaryKey, ", "))
+	}
+	if len(t.Inner.OrderBy) > 0 {
+		fmt.Fprintf(b, " ORDER BY (%s)", strings.Join(t.Inner.OrderBy, ", "))
+	}
+	if t.Inner.PartitionBy != nil {
+		fmt.Fprintf(b, " PARTITION BY %s", *t.Inner.PartitionBy)
+	}
 }
 
 func mergeSettings(user, extra map[string]string) map[string]string {
@@ -644,6 +730,11 @@ var numericRe = regexp.MustCompile(`^-?\d+(\.\d+)?$`)
 
 func formatSettingValue(v string) string {
 	if numericRe.MatchString(v) {
+		return v
+	}
+	// Map and array literals (e.g. tags_to_columns = {'k':'v'}) are emitted
+	// bare. CH parses them as compound literals, not as quoted strings.
+	if len(v) >= 2 && ((v[0] == '{' && v[len(v)-1] == '}') || (v[0] == '[' && v[len(v)-1] == ']')) {
 		return v
 	}
 	return "'" + strings.ReplaceAll(v, "'", "\\'") + "'"

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -800,3 +800,83 @@ func TestSQLGen_Engine_ReplicatedSummingMergeTree(t *testing.T) {
 		assert.Nil(t, extra)
 	})
 }
+
+func TestSQLGen_TimeSeries_External_DataAlias(t *testing.T) {
+	tgtData := "default.m_data"
+	tgtTags := "default.m_tags"
+	tgtMetrics := "default.m_metrics"
+	ts := TableSpec{Name: "m",
+		Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+		Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+			Samples:     &TimeSeriesTarget{Target: &tgtData},
+			Tags:        &TimeSeriesTarget{Target: &tgtTags},
+			Metrics:     &TimeSeriesTarget{Target: &tgtMetrics},
+			KeywordHint: "DATA",
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	require.Len(t, out.Statements, 1)
+	stmt := out.Statements[0]
+	assert.Contains(t, stmt, "ENGINE = TimeSeries")
+	assert.Contains(t, stmt, "DATA default.m_data")
+	assert.Contains(t, stmt, "TAGS default.m_tags")
+	assert.Contains(t, stmt, "METRICS default.m_metrics")
+	assert.NotContains(t, stmt, "SAMPLES")
+}
+
+func TestSQLGen_TimeSeries_External_DefaultsToSamplesKeyword(t *testing.T) {
+	tgt := "default.m_data"
+	ts := TableSpec{Name: "m",
+		Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+		Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+			Samples: &TimeSeriesTarget{Target: &tgt},
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	stmt := out.Statements[0]
+	assert.Contains(t, stmt, "SAMPLES default.m_data")
+	assert.NotContains(t, stmt, "DATA default.m_data")
+}
+
+func TestSQLGen_TimeSeries_Inner(t *testing.T) {
+	inner := &TimeSeriesInnerTable{
+		Columns: []ColumnSpec{
+			{Name: "id", Type: "UUID"},
+			{Name: "timestamp", Type: "DateTime64(3)"},
+			{Name: "value", Type: "Float64"},
+		},
+		Engine:  &EngineSpec{Decoded: EngineMergeTree{}},
+		OrderBy: []string{"id", "timestamp"},
+	}
+	ts := TableSpec{Name: "m",
+		Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+		Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+			Samples: &TimeSeriesTarget{Inner: inner},
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	stmt := out.Statements[0]
+	assert.Contains(t, stmt, "SAMPLES INNER COLUMNS (id UUID, timestamp DateTime64(3), value Float64)")
+	assert.Contains(t, stmt, "SAMPLES INNER ENGINE = MergeTree()")
+	assert.Contains(t, stmt, "ORDER BY (id, timestamp)")
+}
+
+func TestSQLGen_TimeSeries_TagsToColumnsFolded(t *testing.T) {
+	ts := TableSpec{Name: "m",
+		Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+		Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+			TagsToColumns: map[string]string{"instance": "instance", "job": "job"},
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	stmt := out.Statements[0]
+	assert.Contains(t, stmt, "tags_to_columns = {'instance':'instance', 'job':'job'}")
+}

--- a/internal/loader/hcl/testdata/engine_time_series_inner.hcl
+++ b/internal/loader/hcl/testdata/engine_time_series_inner.hcl
@@ -1,0 +1,16 @@
+database "default" {
+  table "prom_metrics_inner" {
+    column "metric_name" { type = "LowCardinality(String)" }
+    engine "time_series" {
+      samples {
+        inner {
+          column "id" { type = "UUID" }
+          column "timestamp" { type = "DateTime64(3)" }
+          column "value" { type = "Float64" }
+          engine "merge_tree" {}
+          order_by = ["id", "timestamp"]
+        }
+      }
+    }
+  }
+}

--- a/internal/loader/hcl/testdata/engines_all_kinds.hcl
+++ b/internal/loader/hcl/testdata/engines_all_kinds.hcl
@@ -97,4 +97,15 @@ database "posthog" {
       format      = "JSONEachRow"
     }
   }
+
+  table "t_time_series" {
+    column "metric_name" { type = "LowCardinality(String)" }
+    engine "time_series" {
+      settings = { id_generator = "sipHash64(metric_name, all_tags)" }
+      tags_to_columns = { instance = "instance", job = "job" }
+      samples { target = "default.t_time_series_data" }
+      tags { target = "default.t_time_series_tags" }
+      metrics { target = "default.t_time_series_metrics" }
+    }
+  }
 }

--- a/internal/loader/hcl/validate.go
+++ b/internal/loader/hcl/validate.go
@@ -13,6 +13,7 @@ const (
 	DepMVSource          = "mv_source"          // a materialized view reads from this table
 	DepMVDest            = "mv_dest"            // a materialized view writes into this table
 	DepDistributedRemote = "distributed_remote" // a Distributed table forwards to this table
+	DepTimeSeriesTarget  = "ts_target"          // a TimeSeries table references an external samples/tags/metrics target
 	DepViewSource        = "view_source"        // a plain view reads from this table
 
 	// KindMVColumn flags a materialized view that references a column its
@@ -134,15 +135,26 @@ func CollectDependencies(dbs []DatabaseSpec) ([]Dependency, error) {
 			if t.Engine == nil {
 				continue
 			}
-			dist, ok := t.Engine.Decoded.(EngineDistributed)
-			if !ok {
-				continue
+			switch eng := t.Engine.Decoded.(type) {
+			case EngineDistributed:
+				deps = append(deps, Dependency{
+					From: ObjectRef{Database: db.Name, Name: t.Name},
+					To:   ObjectRef{Database: eng.RemoteDatabase, Name: eng.RemoteTable},
+					Kind: DepDistributedRemote,
+				})
+			case EngineTimeSeries:
+				from := ObjectRef{Database: db.Name, Name: t.Name}
+				for _, target := range []*TimeSeriesTarget{eng.Samples, eng.Tags, eng.Metrics} {
+					if target == nil || target.Target == nil {
+						continue
+					}
+					deps = append(deps, Dependency{
+						From: from,
+						To:   splitQualified(*target.Target, db.Name),
+						Kind: DepTimeSeriesTarget,
+					})
+				}
 			}
-			deps = append(deps, Dependency{
-				From: ObjectRef{Database: db.Name, Name: t.Name},
-				To:   ObjectRef{Database: dist.RemoteDatabase, Name: dist.RemoteTable},
-				Kind: DepDistributedRemote,
-			})
 		}
 
 		for _, v := range db.Views {
@@ -736,6 +748,8 @@ func depPhrase(kind string) string {
 		return "Distributed table remote table"
 	case DepViewSource:
 		return "view source table"
+	case DepTimeSeriesTarget:
+		return "TimeSeries target table"
 	default:
 		return "dependency"
 	}

--- a/internal/loader/hcl/validate_test.go
+++ b/internal/loader/hcl/validate_test.go
@@ -459,3 +459,68 @@ func TestValidate_MVColumn_SkipSetWorks(t *testing.T) {
 		assert.NotEqual(t, KindMVColumn, e.Kind, "skip should suppress mv_column: %s", e.Reason)
 	}
 }
+
+func TestValidate_TimeSeries_ExternalTargetMustExist(t *testing.T) {
+	tgt := "db.samples_does_not_exist"
+	dbs := []DatabaseSpec{{Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+				Samples: &TimeSeriesTarget{Target: &tgt},
+			}},
+		}},
+	}}
+	errs := Validate(dbs, SkipSet{})
+	var ferr *ValidationError
+	for i := range errs {
+		if errs[i].Kind == DepTimeSeriesTarget {
+			ferr = &errs[i]
+			break
+		}
+	}
+	require.NotNil(t, ferr, "external TimeSeries target should be flagged")
+	assert.Equal(t, "db.samples_does_not_exist", ferr.Missing.String())
+}
+
+func TestValidate_TimeSeries_InnerTargetNoDependency(t *testing.T) {
+	dbs := []DatabaseSpec{{Name: "db",
+		Tables: []TableSpec{{Name: "m",
+			Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+			Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+				Samples: &TimeSeriesTarget{Inner: &TimeSeriesInnerTable{
+					Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+					Engine:  &EngineSpec{Decoded: EngineMergeTree{}},
+				}},
+			}},
+		}},
+	}}
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, DepTimeSeriesTarget, e.Kind, "inner-form target should create no dep")
+	}
+}
+
+func TestValidate_TimeSeries_AllTargetsExist_OK(t *testing.T) {
+	tgtData := "db.m_data"
+	tgtTags := "db.m_tags"
+	tgtMetrics := "db.m_metrics"
+	dbs := []DatabaseSpec{{Name: "db",
+		Tables: []TableSpec{
+			{Name: "m",
+				Columns: []ColumnSpec{{Name: "metric_name", Type: "LowCardinality(String)"}},
+				Engine: &EngineSpec{Kind: "time_series", Decoded: EngineTimeSeries{
+					Samples: &TimeSeriesTarget{Target: &tgtData},
+					Tags:    &TimeSeriesTarget{Target: &tgtTags},
+					Metrics: &TimeSeriesTarget{Target: &tgtMetrics},
+				}},
+			},
+			{Name: "m_data", Engine: &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}}},
+			{Name: "m_tags", Engine: &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}}},
+			{Name: "m_metrics", Engine: &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}}},
+		},
+	}}
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, DepTimeSeriesTarget, e.Kind, "all targets exist; no errors expected: %s", e.Reason)
+	}
+}

--- a/test/hcl_introspect_live_test.go
+++ b/test/hcl_introspect_live_test.go
@@ -104,3 +104,78 @@ func TestLive_HCLIntrospect(t *testing.T) {
 
 	require.Equal(t, want, got)
 }
+
+// TestLive_HCLIntrospect_TimeSeries verifies that a TimeSeries-engine
+// table — both external-target and inner-target form — round-trips
+// through `hclload.Introspect`. TimeSeries is experimental in CH and
+// requires opt-in via the allow_experimental_time_series_table setting.
+func TestLive_HCLIntrospect_TimeSeries(t *testing.T) {
+	if !*clickhouse {
+		t.SkipNow()
+	}
+
+	conn := testhelpers.RequireClickHouse(t)
+	dbName := testhelpers.CreateTestDatabase(t, conn)
+	ctx := context.Background()
+
+	// External-target form: stand up the three target tables, then point
+	// a TimeSeries at them. `allow_experimental_time_series_table = 1` is
+	// appended to each CREATE that uses TimeSeries because the Go driver
+	// may use a connection pool — a session-level SET wouldn't survive.
+	tsSetting := " SETTINGS allow_experimental_time_series_table = 1"
+
+	stmts := []string{
+		`CREATE TABLE ` + dbName + `.prom_data (
+			id UUID,
+			timestamp DateTime64(3),
+			value Float64
+		) ENGINE = MergeTree ORDER BY (id, timestamp)`,
+		`CREATE TABLE ` + dbName + `.prom_tags (
+			id UUID,
+			metric_name LowCardinality(String),
+			tags Map(LowCardinality(String), String)
+		) ENGINE = AggregatingMergeTree PRIMARY KEY metric_name ORDER BY (metric_name, id)`,
+		`CREATE TABLE ` + dbName + `.prom_metrics_meta (
+			metric_family_name String,
+			type String,
+			unit String,
+			help String
+		) ENGINE = ReplacingMergeTree ORDER BY metric_family_name`,
+		`CREATE TABLE ` + dbName + `.prom_external ENGINE = TimeSeries ` +
+			`DATA ` + dbName + `.prom_data ` +
+			`TAGS ` + dbName + `.prom_tags ` +
+			`METRICS ` + dbName + `.prom_metrics_meta` + tsSetting,
+
+		// NOTE: the bare `ENGINE = TimeSeries` form (no targets) is
+		// intentionally NOT exercised here. CH's SHOW CREATE TABLE for
+		// such a table emits a shorthand the chparser fork doesn't
+		// recognise yet — `DATA ENGINE = MergeTree ORDER BY (...)` (no
+		// INNER keyword between DATA and ENGINE). To be filed as a
+		// follow-up chparser issue.
+	}
+	for _, s := range stmts {
+		require.NoError(t, conn.Exec(ctx, s), "create failed: %s", s)
+	}
+
+	got, err := hclload.Introspect(ctx, conn, dbName)
+	require.NoError(t, err)
+
+	var external *hclload.TableSpec
+	for i := range got.Tables {
+		if got.Tables[i].Name == "prom_external" {
+			external = &got.Tables[i]
+		}
+	}
+
+	require.NotNil(t, external, "prom_external should round-trip")
+	ext, ok := external.Engine.Decoded.(hclload.EngineTimeSeries)
+	require.True(t, ok)
+	require.Equal(t, "DATA", ext.KeywordHint, "DATA alias preserved")
+	require.NotNil(t, ext.Samples)
+	require.NotNil(t, ext.Samples.Target)
+	require.Equal(t, dbName+".prom_data", *ext.Samples.Target)
+	require.NotNil(t, ext.Tags)
+	require.Equal(t, dbName+".prom_tags", *ext.Tags.Target)
+	require.NotNil(t, ext.Metrics)
+	require.Equal(t, dbName+".prom_metrics_meta", *ext.Metrics.Target)
+}

--- a/test/testdata/posthog-create-statements/TimeSeries/prom_metrics_external.sql
+++ b/test/testdata/posthog-create-statements/TimeSeries/prom_metrics_external.sql
@@ -1,0 +1,19 @@
+CREATE TABLE default.prom_metrics
+(
+    `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
+    `timestamp` DateTime64(3),
+    `value` Float64,
+    `metric_name` LowCardinality(String),
+    `tags` Map(LowCardinality(String), String),
+    `all_tags` Map(String, String),
+    `min_time` Nullable(DateTime64(3)),
+    `max_time` Nullable(DateTime64(3)),
+    `metric_family_name` String,
+    `type` String,
+    `unit` String,
+    `help` String
+)
+ENGINE = TimeSeries
+DATA default.prom_metrics_data
+TAGS default.prom_metrics_tags
+METRICS default.prom_metrics_metrics

--- a/test/testdata/posthog-create-statements/TimeSeries/prom_metrics_inner.sql
+++ b/test/testdata/posthog-create-statements/TimeSeries/prom_metrics_inner.sql
@@ -1,0 +1,35 @@
+CREATE TABLE default.prom_metrics_inner
+(
+    `metric_name` String,
+    `tags` Map(String, String),
+    `time_series` Array(Tuple(DateTime64(3), Float64)),
+    `metric_family` String,
+    `type` String,
+    `unit` String,
+    `help` String
+)
+ENGINE = TimeSeries
+SAMPLES INNER COLUMNS
+(
+    `id` UUID,
+    `timestamp` DateTime64(3),
+    `value` Float64
+)
+SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)
+TAGS INNER COLUMNS
+(
+    `id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)),
+    `metric_name` LowCardinality(String),
+    `tags` Map(LowCardinality(String), String),
+    `min_time` SimpleAggregateFunction(min, Nullable(DateTime64(3))),
+    `max_time` SimpleAggregateFunction(max, Nullable(DateTime64(3)))
+)
+TAGS INNER ENGINE = AggregatingMergeTree PRIMARY KEY metric_name ORDER BY (metric_name, id)
+METRICS INNER COLUMNS
+(
+    `metric_family_name` String,
+    `type` LowCardinality(String),
+    `unit` LowCardinality(String),
+    `help` String
+)
+METRICS INNER ENGINE = ReplacingMergeTree ORDER BY metric_family_name

--- a/test/testdata/posthog-create-statements/TimeSeries/prom_metrics_minimal.sql
+++ b/test/testdata/posthog-create-statements/TimeSeries/prom_metrics_minimal.sql
@@ -1,0 +1,1 @@
+CREATE TABLE default.prom_metrics_minimal () ENGINE = TimeSeries


### PR DESCRIPTION
## Summary

PostHog's `posthog.prom_metrics` (and any other CH TimeSeries-engine table) now round-trips end-to-end through `hclexp introspect` / `hclexp diff` / `hclexp validate`. Fixes the production-dump failure on TimeSeries tables.

### What's added

- **`EngineTimeSeries`** value type with optional `samples`/`tags`/`metrics` sub-blocks (external `target` or inline `inner` with column list + nested engine), promoted `tags_to_columns` map, free-form `settings` map.
- **HCL grammar**: nested target sub-blocks; exactly-one-of `target` / `inner` per sub-block enforced at resolve time; inner-form engines restricted to MergeTree family.
- **Introspection**: `buildTableFromCreateTable` recognises `EngineTimeSeries` and walks `ct.TimeSeriesTargets` (the new chparser AST). `KeywordHint` preserves `DATA` vs `SAMPLES` for round-trip fidelity.
- **SQL generation**: emits `ENGINE = TimeSeries` plus the tail clauses (`SAMPLES`/`DATA`/`TAGS`/`METRICS` lines, external or `INNER COLUMNS` + `INNER ENGINE`), folding `tags_to_columns` back into the `SETTINGS` clause as the `{'k':'v'}` literal CH expects.
- **Diff**: two ALTER-able settings (`id_generator`, `filter_by_min_time_and_max_time`) → `ALTER TABLE ... MODIFY SETTING`. Everything else baked → `EngineChange` (recreate, `-- UNSAFE`).
- **Validate**: new `DepTimeSeriesTarget = "ts_target"` dependency for external-form targets. Inner-form targets create no dependency.
- **Docs**: `time_series` reference under "Engine kinds" in `README.hcl.md`; "How do I model a Prometheus TimeSeries table?" FAQ entry.

### Live test fixtures

Three SQL files under `test/testdata/posthog-create-statements/TimeSeries/`:
- `prom_metrics_external.sql` — the actual production CREATE.
- `prom_metrics_inner.sql` — doc's fully-generated inner form.
- `prom_metrics_minimal.sql` — bare `ENGINE = TimeSeries`.

Plus `TestLive_HCLIntrospect_TimeSeries` in `test/hcl_introspect_live_test.go` that creates an external-form TimeSeries against a real CH and asserts the introspected shape, including the `DATA` keyword round-trip.

### Dependencies

- Depends on chparser fork commit [`47aa1ff`](https://github.com/orian/clickhouse-sql-parser/commit/47aa1ff) (fixes [#8](https://github.com/orian/clickhouse-sql-parser/issues/8)). `go.mod` `replace` bumped to `v0.0.0-20260601104648-4521cd37e69b`.
- ClickHouse image pinned to `clickhouse/clickhouse-server:26.3.12.3` and `clickhouse/clickhouse-keeper:26.3.12.3` in `docker-compose.yml` (latest 26.3 LTS). Required for `allow_experimental_time_series_table = 1`.

### Known follow-up

One CH-emitted form is **not** parsed yet: the bare `ENGINE = TimeSeries` case expands to `<KEYWORD> ENGINE = engine_expr` (no `INNER` between the keyword and `ENGINE`) when echoed via `SHOW CREATE TABLE`. The chparser fork doesn't recognise this shorthand. To be filed as a follow-up upstream issue. The live test for the inner form is therefore omitted; the external-form coverage exercises the prod scenario.

## Spec / Plan

- Spec: [`docs/superpowers/specs/2026-06-01-timeseries-engine-support.md`](./docs/superpowers/specs/2026-06-01-timeseries-engine-support.md)
- Plan: [`docs/superpowers/plans/2026-06-01-timeseries-engine-support.md`](./docs/superpowers/plans/2026-06-01-timeseries-engine-support.md)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — 434/434 pass
- [x] `ENABLE_CLICKHOUSE=1 go test ./... -count=1` (against CH 26.3.12.3) — 495/495 pass
- [x] PostHog `prom_metrics` CREATE statement round-trips through introspect → sqlgen → introspect with no diff
- [ ] CI runs the same matrices

🤖 Generated with [Claude Code](https://claude.com/claude-code)