### PR TITLE
feat(hcl): Buffer, Null, Memory, Merge engines

### DIFF
--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -118,6 +118,10 @@ attributes depend on the kind.
 | `log`                                 | —                                                  | —                      |
 | `kafka`                               | `broker_list = [...]`, `topic`, `consumer_group`, `format` | —              |
 | `time_series` (experimental)          | —                                                  | `settings`, `tags_to_columns`, nested `samples`/`tags`/`metrics` blocks |
+| `null`                                | —                                                  | —                      |
+| `memory`                              | —                                                  | —                      |
+| `merge`                               | `db_regex`, `table_regex`                          | —                      |
+| `buffer`                              | `database`, `table`, `num_layers`, `min_time`, `max_time`, `min_rows`, `max_rows`, `min_bytes`, `max_bytes` | `flush_time`, `flush_rows`, `flush_bytes` |
 
 Unknown kinds and missing required attributes are rejected at parse time
 with file/line positions.

--- a/internal/loader/hcl/dump.go
+++ b/internal/loader/hcl/dump.go
@@ -166,8 +166,31 @@ func writeEngine(parent *hclwrite.Body, e Engine) {
 	block := parent.AppendNewBlock("engine", []string{e.Kind()})
 	b := block.Body()
 	switch v := e.(type) {
-	case EngineMergeTree, EngineAggregatingMergeTree, EngineLog:
+	case EngineMergeTree, EngineAggregatingMergeTree, EngineLog,
+		EngineNull, EngineMemory:
 		// no fields
+	case EngineMerge:
+		b.SetAttributeValue("db_regex", cty.StringVal(v.DBRegex))
+		b.SetAttributeValue("table_regex", cty.StringVal(v.TableRegex))
+	case EngineBuffer:
+		b.SetAttributeValue("database", cty.StringVal(v.Database))
+		b.SetAttributeValue("table", cty.StringVal(v.Table))
+		b.SetAttributeValue("num_layers", cty.NumberIntVal(v.NumLayers))
+		b.SetAttributeValue("min_time", cty.NumberIntVal(v.MinTime))
+		b.SetAttributeValue("max_time", cty.NumberIntVal(v.MaxTime))
+		b.SetAttributeValue("min_rows", cty.NumberIntVal(v.MinRows))
+		b.SetAttributeValue("max_rows", cty.NumberIntVal(v.MaxRows))
+		b.SetAttributeValue("min_bytes", cty.NumberIntVal(v.MinBytes))
+		b.SetAttributeValue("max_bytes", cty.NumberIntVal(v.MaxBytes))
+		if v.FlushTime != nil {
+			b.SetAttributeValue("flush_time", cty.NumberIntVal(*v.FlushTime))
+		}
+		if v.FlushRows != nil {
+			b.SetAttributeValue("flush_rows", cty.NumberIntVal(*v.FlushRows))
+		}
+		if v.FlushBytes != nil {
+			b.SetAttributeValue("flush_bytes", cty.NumberIntVal(*v.FlushBytes))
+		}
 	case EngineReplicatedMergeTree:
 		b.SetAttributeValue("zoo_path", cty.StringVal(v.ZooPath))
 		b.SetAttributeValue("replica_name", cty.StringVal(v.ReplicaName))

--- a/internal/loader/hcl/engines.go
+++ b/internal/loader/hcl/engines.go
@@ -93,6 +93,52 @@ type EngineLog struct{}
 
 func (EngineLog) Kind() string { return "log" }
 
+// EngineNull discards every write. Often used as a MV source that fans
+// out into multiple downstream MVs without storing rows itself.
+type EngineNull struct{}
+
+func (EngineNull) Kind() string { return "null" }
+
+// EngineMemory holds rows in RAM; non-durable, lost on restart. Common
+// in test pipelines and short-lived staging tables.
+type EngineMemory struct{}
+
+func (EngineMemory) Kind() string { return "memory" }
+
+// EngineMerge is a read-only union over multiple physical tables matched
+// by regex. CH syntax: Merge(db_regex, table_regex).
+type EngineMerge struct {
+	DBRegex    string `hcl:"db_regex"`
+	TableRegex string `hcl:"table_regex"`
+}
+
+func (EngineMerge) Kind() string { return "merge" }
+
+// EngineBuffer wraps another table with an in-memory write buffer that
+// flushes periodically based on time/row/byte thresholds. CH syntax:
+//
+//	Buffer(database, table, num_layers, min_time, max_time, min_rows, max_rows, min_bytes, max_bytes [, flush_time [, flush_rows [, flush_bytes]]])
+//
+// The optional flush_* triplet is captured as pointers; nil = not set
+// (CH defaults apply).
+type EngineBuffer struct {
+	Database  string `hcl:"database"`
+	Table     string `hcl:"table"`
+	NumLayers int64  `hcl:"num_layers"`
+	MinTime   int64  `hcl:"min_time"`
+	MaxTime   int64  `hcl:"max_time"`
+	MinRows   int64  `hcl:"min_rows"`
+	MaxRows   int64  `hcl:"max_rows"`
+	MinBytes  int64  `hcl:"min_bytes"`
+	MaxBytes  int64  `hcl:"max_bytes"`
+
+	FlushTime  *int64 `hcl:"flush_time,optional"`
+	FlushRows  *int64 `hcl:"flush_rows,optional"`
+	FlushBytes *int64 `hcl:"flush_bytes,optional"`
+}
+
+func (EngineBuffer) Kind() string { return "buffer" }
+
 type EngineKafka struct {
 	// Collection is the named-collection reference. Mutually exclusive
 	// with every other field; when set, no inline setting may be set.
@@ -384,6 +430,22 @@ func DecodeEngine(spec *EngineSpec) (Engine, error) {
 		target = e
 	case "log":
 		var e EngineLog
+		diags = gohcl.DecodeBody(spec.Body, nil, &e)
+		target = e
+	case "null":
+		var e EngineNull
+		diags = gohcl.DecodeBody(spec.Body, nil, &e)
+		target = e
+	case "memory":
+		var e EngineMemory
+		diags = gohcl.DecodeBody(spec.Body, nil, &e)
+		target = e
+	case "merge":
+		var e EngineMerge
+		diags = gohcl.DecodeBody(spec.Body, nil, &e)
+		target = e
+	case "buffer":
+		var e EngineBuffer
 		diags = gohcl.DecodeBody(spec.Body, nil, &e)
 		target = e
 	case "kafka":

--- a/internal/loader/hcl/engines_test.go
+++ b/internal/loader/hcl/engines_test.go
@@ -74,6 +74,27 @@ func TestParseFile_AllEngineKinds(t *testing.T) {
 
 	assert.Equal(t, EngineLog{}, byName["t_log"])
 
+	assert.Equal(t, EngineNull{}, byName["t_null"])
+	assert.Equal(t, EngineMemory{}, byName["t_memory"])
+	assert.Equal(t, EngineMerge{
+		DBRegex:    "default",
+		TableRegex: "^shard_.*",
+	}, byName["t_merge"])
+
+	flushTime := int64(30)
+	assert.Equal(t, EngineBuffer{
+		Database:  "",
+		Table:     "t_merge_tree",
+		NumLayers: 16,
+		MinTime:   10,
+		MaxTime:   100,
+		MinRows:   10000,
+		MaxRows:   1000000,
+		MinBytes:  10000000,
+		MaxBytes:  100000000,
+		FlushTime: &flushTime,
+	}, byName["t_buffer"])
+
 	assert.Equal(t, EngineKafka{
 		BrokerList: ptr("kafka:9092"),
 		TopicList:  ptr("events"),
@@ -146,6 +167,10 @@ func TestEngine_KindMethods(t *testing.T) {
 		{EngineLog{}, "log"},
 		{EngineKafka{}, "kafka"},
 		{EngineTimeSeries{}, "time_series"},
+		{EngineNull{}, "null"},
+		{EngineMemory{}, "memory"},
+		{EngineMerge{}, "merge"},
+		{EngineBuffer{}, "buffer"},
 	}
 	for _, c := range cases {
 		assert.Equal(t, c.want, c.engine.Kind())

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -471,6 +471,58 @@ func engineFromAST(e *chparser.EngineExpr) (Engine, map[string]string, error) {
 		return ee, allSettings, nil
 	case "Log":
 		return EngineLog{}, allSettings, nil
+	case "Null":
+		return EngineNull{}, allSettings, nil
+	case "Memory":
+		return EngineMemory{}, allSettings, nil
+	case "Merge":
+		if len(params) != 2 {
+			return nil, nil, fmt.Errorf("Merge needs (db_regex, table_regex)")
+		}
+		return EngineMerge{DBRegex: params[0], TableRegex: params[1]}, allSettings, nil
+	case "Buffer":
+		if len(params) < 9 || len(params) > 12 {
+			return nil, nil, fmt.Errorf("Buffer needs 9-12 args (db, table, num_layers, min/max time/rows/bytes [, flush_time [, flush_rows [, flush_bytes]]])")
+		}
+		toInt := func(s string) (int64, error) {
+			n, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("Buffer arg %q: %w", s, err)
+			}
+			return n, nil
+		}
+		nums := make([]int64, 0, len(params)-2)
+		for _, p := range params[2:] {
+			n, err := toInt(p)
+			if err != nil {
+				return nil, nil, err
+			}
+			nums = append(nums, n)
+		}
+		e := EngineBuffer{
+			Database:  params[0],
+			Table:     params[1],
+			NumLayers: nums[0],
+			MinTime:   nums[1],
+			MaxTime:   nums[2],
+			MinRows:   nums[3],
+			MaxRows:   nums[4],
+			MinBytes:  nums[5],
+			MaxBytes:  nums[6],
+		}
+		if len(nums) > 7 {
+			ft := nums[7]
+			e.FlushTime = &ft
+		}
+		if len(nums) > 8 {
+			fr := nums[8]
+			e.FlushRows = &fr
+		}
+		if len(nums) > 9 {
+			fb := nums[9]
+			e.FlushBytes = &fb
+		}
+		return e, allSettings, nil
 	case "Kafka":
 		k, err := buildKafkaEngine(params, allSettings)
 		if err != nil {

--- a/internal/loader/hcl/introspect_test.go
+++ b/internal/loader/hcl/introspect_test.go
@@ -671,3 +671,52 @@ func TestIntrospect_TimeSeries_ProductionPromMetrics(t *testing.T) {
 	assert.Equal(t, "DATA", e.KeywordHint)
 	assert.Equal(t, "posthog.prom_metrics_data", *e.Samples.Target)
 }
+
+func TestIntrospect_Buffer_FullArgs(t *testing.T) {
+	sql := "CREATE TABLE db.buf (`id` UUID) ENGINE = Buffer('', 'dest_table', 16, 10, 100, 10000, 1000000, 10000000, 100000000)"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"buf", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineBuffer)
+	assert.Equal(t, "", e.Database)
+	assert.Equal(t, "dest_table", e.Table)
+	assert.Equal(t, int64(16), e.NumLayers)
+	assert.Equal(t, int64(10), e.MinTime)
+	assert.Equal(t, int64(100000000), e.MaxBytes)
+	assert.Nil(t, e.FlushTime)
+}
+
+func TestIntrospect_Buffer_WithFlushTriplet(t *testing.T) {
+	sql := "CREATE TABLE db.buf (`id` UUID) ENGINE = Buffer('default', 'dest', 1, 5, 60, 100, 10000, 1000, 100000, 30, 200, 50000)"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"buf", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineBuffer)
+	assert.Equal(t, "default", e.Database)
+	require.NotNil(t, e.FlushTime)
+	assert.Equal(t, int64(30), *e.FlushTime)
+	require.NotNil(t, e.FlushRows)
+	assert.Equal(t, int64(200), *e.FlushRows)
+	require.NotNil(t, e.FlushBytes)
+	assert.Equal(t, int64(50000), *e.FlushBytes)
+}
+
+func TestIntrospect_Merge(t *testing.T) {
+	sql := "CREATE TABLE db.m (`id` UUID) ENGINE = Merge('default', '^shard_.*')"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineMerge)
+	assert.Equal(t, "default", e.DBRegex)
+	assert.Equal(t, "^shard_.*", e.TableRegex)
+}
+
+func TestIntrospect_Null_Memory(t *testing.T) {
+	for _, c := range []struct {
+		sql, kind string
+	}{
+		{"CREATE TABLE db.n (`id` UUID) ENGINE = Null()", "null"},
+		{"CREATE TABLE db.n (`id` UUID) ENGINE = Memory()", "memory"},
+	} {
+		db := &DatabaseSpec{Name: "db"}
+		require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"n", c.sql}}}))
+		assert.Equal(t, c.kind, db.Tables[0].Engine.Kind)
+	}
+}

--- a/internal/loader/hcl/sqlgen.go
+++ b/internal/loader/hcl/sqlgen.go
@@ -562,6 +562,41 @@ func engineSQL(e Engine) (clause string, extraSettings map[string]string) {
 		return fmt.Sprintf("Distributed('%s', '%s', '%s')", v.ClusterName, v.RemoteDatabase, v.RemoteTable), nil
 	case EngineLog:
 		return "Log()", nil
+	case EngineNull:
+		return "Null()", nil
+	case EngineMemory:
+		return "Memory()", nil
+	case EngineMerge:
+		return fmt.Sprintf("Merge('%s', '%s')", v.DBRegex, v.TableRegex), nil
+	case EngineBuffer:
+		// Buffer(db, table, num_layers, min_time, max_time, min_rows,
+		//        max_rows, min_bytes, max_bytes [, flush_time [, flush_rows [, flush_bytes]]]).
+		// The database arg uses currentDatabase() when empty (CH convention).
+		dbArg := "''"
+		if v.Database != "" {
+			dbArg = fmt.Sprintf("'%s'", v.Database)
+		}
+		args := []string{
+			dbArg,
+			fmt.Sprintf("'%s'", v.Table),
+			fmt.Sprintf("%d", v.NumLayers),
+			fmt.Sprintf("%d", v.MinTime),
+			fmt.Sprintf("%d", v.MaxTime),
+			fmt.Sprintf("%d", v.MinRows),
+			fmt.Sprintf("%d", v.MaxRows),
+			fmt.Sprintf("%d", v.MinBytes),
+			fmt.Sprintf("%d", v.MaxBytes),
+		}
+		if v.FlushTime != nil {
+			args = append(args, fmt.Sprintf("%d", *v.FlushTime))
+			if v.FlushRows != nil {
+				args = append(args, fmt.Sprintf("%d", *v.FlushRows))
+				if v.FlushBytes != nil {
+					args = append(args, fmt.Sprintf("%d", *v.FlushBytes))
+				}
+			}
+		}
+		return fmt.Sprintf("Buffer(%s)", strings.Join(args, ", ")), nil
 	case EngineKafka:
 		if v.Collection != nil {
 			// Named collection form: Kafka(<collection>); no settings emitted.

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -880,3 +880,56 @@ func TestSQLGen_TimeSeries_TagsToColumnsFolded(t *testing.T) {
 	stmt := out.Statements[0]
 	assert.Contains(t, stmt, "tags_to_columns = {'instance':'instance', 'job':'job'}")
 }
+
+func TestSQLGen_Buffer_BareArgs(t *testing.T) {
+	ts := TableSpec{Name: "buf",
+		Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+		Engine: &EngineSpec{Kind: "buffer", Decoded: EngineBuffer{
+			Database: "", Table: "dest", NumLayers: 16,
+			MinTime: 10, MaxTime: 100,
+			MinRows: 10000, MaxRows: 1000000,
+			MinBytes: 10000000, MaxBytes: 100000000,
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	assert.Contains(t, out.Statements[0], "ENGINE = Buffer('', 'dest', 16, 10, 100, 10000, 1000000, 10000000, 100000000)")
+}
+
+func TestSQLGen_Buffer_WithFlushTriplet(t *testing.T) {
+	ft, fr, fb := int64(30), int64(200), int64(50000)
+	ts := TableSpec{Name: "buf",
+		Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+		Engine: &EngineSpec{Kind: "buffer", Decoded: EngineBuffer{
+			Database: "default", Table: "dest", NumLayers: 1,
+			MinTime: 5, MaxTime: 60, MinRows: 100, MaxRows: 10000,
+			MinBytes: 1000, MaxBytes: 100000,
+			FlushTime: &ft, FlushRows: &fr, FlushBytes: &fb,
+		}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	assert.Contains(t, out.Statements[0], "Buffer('default', 'dest', 1, 5, 60, 100, 10000, 1000, 100000, 30, 200, 50000)")
+}
+
+func TestSQLGen_Null_Memory_Merge(t *testing.T) {
+	for _, c := range []struct {
+		dec    Engine
+		expect string
+	}{
+		{EngineNull{}, "ENGINE = Null()"},
+		{EngineMemory{}, "ENGINE = Memory()"},
+		{EngineMerge{DBRegex: "default", TableRegex: "^shard_.*"}, "ENGINE = Merge('default', '^shard_.*')"},
+	} {
+		ts := TableSpec{Name: "t",
+			Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+			Engine:  &EngineSpec{Kind: c.dec.Kind(), Decoded: c.dec},
+		}
+		out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+			Database: "default", AddTables: []TableSpec{ts},
+		}}})
+		assert.Contains(t, out.Statements[0], c.expect)
+	}
+}

--- a/internal/loader/hcl/testdata/engines_all_kinds.hcl
+++ b/internal/loader/hcl/testdata/engines_all_kinds.hcl
@@ -98,6 +98,40 @@ database "posthog" {
     }
   }
 
+  table "t_null" {
+    column "id" { type = "UUID" }
+    engine "null" {}
+  }
+
+  table "t_memory" {
+    column "id" { type = "UUID" }
+    engine "memory" {}
+  }
+
+  table "t_merge" {
+    column "id" { type = "UUID" }
+    engine "merge" {
+      db_regex    = "default"
+      table_regex = "^shard_.*"
+    }
+  }
+
+  table "t_buffer" {
+    column "id" { type = "UUID" }
+    engine "buffer" {
+      database    = ""
+      table       = "t_merge_tree"
+      num_layers  = 16
+      min_time    = 10
+      max_time    = 100
+      min_rows    = 10000
+      max_rows    = 1000000
+      min_bytes   = 10000000
+      max_bytes   = 100000000
+      flush_time  = 30
+    }
+  }
+
   table "t_time_series" {
     column "metric_name" { type = "LowCardinality(String)" }
     engine "time_series" {

--- a/internal/loader/hcl/validate.go
+++ b/internal/loader/hcl/validate.go
@@ -14,6 +14,7 @@ const (
 	DepMVDest            = "mv_dest"            // a materialized view writes into this table
 	DepDistributedRemote = "distributed_remote" // a Distributed table forwards to this table
 	DepTimeSeriesTarget  = "ts_target"          // a TimeSeries table references an external samples/tags/metrics target
+	DepBufferDestination = "buffer_dest"        // a Buffer table forwards writes into this table
 	DepViewSource        = "view_source"        // a plain view reads from this table
 
 	// KindMVColumn flags a materialized view that references a column its
@@ -154,6 +155,19 @@ func CollectDependencies(dbs []DatabaseSpec) ([]Dependency, error) {
 						Kind: DepTimeSeriesTarget,
 					})
 				}
+			case EngineBuffer:
+				// Buffer forwards writes to (database, table). Empty
+				// database means current — defaults to the buffer's own
+				// database (matches CH's currentDatabase() semantic).
+				destDB := eng.Database
+				if destDB == "" {
+					destDB = db.Name
+				}
+				deps = append(deps, Dependency{
+					From: ObjectRef{Database: db.Name, Name: t.Name},
+					To:   ObjectRef{Database: destDB, Name: eng.Table},
+					Kind: DepBufferDestination,
+				})
 			}
 		}
 
@@ -750,6 +764,8 @@ func depPhrase(kind string) string {
 		return "view source table"
 	case DepTimeSeriesTarget:
 		return "TimeSeries target table"
+	case DepBufferDestination:
+		return "Buffer destination table"
 	default:
 		return "dependency"
 	}

--- a/internal/loader/hcl/validate_test.go
+++ b/internal/loader/hcl/validate_test.go
@@ -524,3 +524,47 @@ func TestValidate_TimeSeries_AllTargetsExist_OK(t *testing.T) {
 		assert.NotEqual(t, DepTimeSeriesTarget, e.Kind, "all targets exist; no errors expected: %s", e.Reason)
 	}
 }
+
+func TestValidate_Buffer_DestMustExist(t *testing.T) {
+	dbs := []DatabaseSpec{{Name: "db",
+		Tables: []TableSpec{{Name: "buf",
+			Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+			Engine: &EngineSpec{Kind: "buffer", Decoded: EngineBuffer{
+				Database: "", Table: "missing_dest",
+				NumLayers: 1, MinTime: 1, MaxTime: 10,
+				MinRows: 1, MaxRows: 10, MinBytes: 1, MaxBytes: 10,
+			}},
+		}},
+	}}
+	errs := Validate(dbs, SkipSet{})
+	var ferr *ValidationError
+	for i := range errs {
+		if errs[i].Kind == DepBufferDestination {
+			ferr = &errs[i]
+		}
+	}
+	require.NotNil(t, ferr, "Buffer should require its destination table")
+	assert.Equal(t, "db.missing_dest", ferr.Missing.String())
+}
+
+func TestValidate_Buffer_DestExists_OK(t *testing.T) {
+	dbs := []DatabaseSpec{{Name: "db",
+		Tables: []TableSpec{
+			{Name: "buf",
+				Columns: []ColumnSpec{{Name: "id", Type: "UUID"}},
+				Engine: &EngineSpec{Kind: "buffer", Decoded: EngineBuffer{
+					Database: "", Table: "dest",
+					NumLayers: 1, MinTime: 1, MaxTime: 10,
+					MinRows: 1, MaxRows: 10, MinBytes: 1, MaxBytes: 10,
+				}},
+			},
+			{Name: "dest",
+				Engine: &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}},
+			},
+		},
+	}}
+	errs := Validate(dbs, SkipSet{})
+	for _, e := range errs {
+		assert.NotEqual(t, DepBufferDestination, e.Kind, "dest exists; no error: %s", e.Reason)
+	}
+}

--- a/test/hcl_introspect_live_test.go
+++ b/test/hcl_introspect_live_test.go
@@ -179,3 +179,56 @@ func TestLive_HCLIntrospect_TimeSeries(t *testing.T) {
 	require.NotNil(t, ext.Metrics)
 	require.Equal(t, dbName+".prom_metrics_meta", *ext.Metrics.Target)
 }
+
+// TestLive_HCLIntrospect_CommonEngines exercises a Buffer-over-MergeTree
+// pair (the production shape that motivated this change), plus Null,
+// Memory, and Merge — three of the cheaper engines added in the same
+// pass.
+func TestLive_HCLIntrospect_CommonEngines(t *testing.T) {
+	if !*clickhouse {
+		t.SkipNow()
+	}
+	conn := testhelpers.RequireClickHouse(t)
+	dbName := testhelpers.CreateTestDatabase(t, conn)
+	ctx := context.Background()
+
+	stmts := []string{
+		`CREATE TABLE ` + dbName + `.dest (id UUID, value Float64) ENGINE = MergeTree ORDER BY id`,
+		`CREATE TABLE ` + dbName + `.buf (id UUID, value Float64) ` +
+			`ENGINE = Buffer('` + dbName + `', 'dest', 16, 10, 100, 10000, 1000000, 10000000, 100000000)`,
+
+		`CREATE TABLE ` + dbName + `.null_sink (id UUID) ENGINE = Null`,
+		`CREATE TABLE ` + dbName + `.mem_stage (id UUID) ENGINE = Memory`,
+
+		`CREATE TABLE ` + dbName + `.shard_a (id UUID) ENGINE = MergeTree ORDER BY id`,
+		`CREATE TABLE ` + dbName + `.shard_b (id UUID) ENGINE = MergeTree ORDER BY id`,
+		`CREATE TABLE ` + dbName + `.merged (id UUID) ENGINE = Merge('` + dbName + `', '^shard_')`,
+	}
+	for _, s := range stmts {
+		require.NoError(t, conn.Exec(ctx, s), "create failed: %s", s)
+	}
+
+	got, err := hclload.Introspect(ctx, conn, dbName)
+	require.NoError(t, err)
+
+	byName := map[string]hclload.Engine{}
+	for _, tbl := range got.Tables {
+		byName[tbl.Name] = tbl.Engine.Decoded
+	}
+
+	buf, ok := byName["buf"].(hclload.EngineBuffer)
+	require.True(t, ok)
+	require.Equal(t, dbName, buf.Database)
+	require.Equal(t, "dest", buf.Table)
+	require.Equal(t, int64(16), buf.NumLayers)
+	require.Equal(t, int64(100000000), buf.MaxBytes)
+
+	_, ok = byName["null_sink"].(hclload.EngineNull)
+	require.True(t, ok)
+	_, ok = byName["mem_stage"].(hclload.EngineMemory)
+	require.True(t, ok)
+	merge, ok := byName["merged"].(hclload.EngineMerge)
+	require.True(t, ok)
+	require.Equal(t, dbName, merge.DBRegex)
+	require.Equal(t, "^shard_", merge.TableRegex)
+}


### PR DESCRIPTION
## Summary

PostHog production introspection failed on a `Buffer`-engine table (`writable_prom_metrics_data`). This adds four common ClickHouse engines as first-class kinds:

- **`Buffer`** — the prod blocker. 9–12 positional args (database, table, num_layers, min/max time/rows/bytes, optional flush_* triplet). Empty `database` string defaults to the buffer's own database (matches CH's `currentDatabase()` semantic). New `DepBufferDestination` dependency ensures the destination table is declared somewhere in the loaded schema.
- **`Null`** — discards every write. Common as an MV source that fans out into multiple downstream MVs without storing rows itself.
- **`Memory`** — RAM-only, non-durable. Common in test pipelines and short-lived staging tables.
- **`Merge`** — `Merge(db_regex, table_regex)`. Read-only union over multiple physical tables matched by regex. No dependency (regex over potentially many tables would be too noisy to validate).

## Files touched

`engines.go`, `engines_test.go`, `testdata/engines_all_kinds.hcl`, `introspect.go`, `introspect_test.go`, `sqlgen.go`, `sqlgen_test.go`, `dump.go` (HCL round-trip), `validate.go`, `validate_test.go`, `test/hcl_introspect_live_test.go`, `docs/README.hcl.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` — 443/443 pass
- [x] `ENABLE_CLICKHOUSE=1 go test ./...` (CH 26.3.12.3) — 505/505 pass
- [x] New live test (`TestLive_HCLIntrospect_CommonEngines`) creates a Buffer-over-MergeTree pair (production shape), plus Null, Memory, and a Merge-over-shards triple — all introspect back to the correct typed engines.
- [x] Production-shape Buffer statement (`Buffer('posthog', 'prom_metrics_data', 16, ...)`) round-trips through introspect.
- [ ] CI runs the same matrices

## Note on stacking

Independent of #26 (TimeSeries). Touches the same `engines_all_kinds.hcl` fixture and `engines_test.go` switch, so whichever lands second will need a small rebase to merge both engine sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)