### PR TITLE
feat(hcl): Join engine

### DIFF
--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -118,6 +118,7 @@ attributes depend on the kind.
 | `log`                                 | —                                                  | —                      |
 | `kafka`                               | `broker_list = [...]`, `topic`, `consumer_group`, `format` | —              |
 | `time_series` (experimental)          | —                                                  | `settings`, `tags_to_columns`, nested `samples`/`tags`/`metrics` blocks |
+| `join`                                | `strictness` (`ANY`/`ALL`/`SEMI`/`ANTI`), `type` (`LEFT`/`INNER`/`RIGHT`/`FULL`), `keys = [...]` | — |
 
 Unknown kinds and missing required attributes are rejected at parse time
 with file/line positions.

--- a/internal/loader/hcl/dump.go
+++ b/internal/loader/hcl/dump.go
@@ -168,6 +168,10 @@ func writeEngine(parent *hclwrite.Body, e Engine) {
 	switch v := e.(type) {
 	case EngineMergeTree, EngineAggregatingMergeTree, EngineLog:
 		// no fields
+	case EngineJoin:
+		b.SetAttributeValue("strictness", cty.StringVal(v.Strictness))
+		b.SetAttributeValue("type", cty.StringVal(v.JoinType))
+		b.SetAttributeValue("keys", stringList(v.Keys))
 	case EngineReplicatedMergeTree:
 		b.SetAttributeValue("zoo_path", cty.StringVal(v.ZooPath))
 		b.SetAttributeValue("replica_name", cty.StringVal(v.ReplicaName))

--- a/internal/loader/hcl/engines.go
+++ b/internal/loader/hcl/engines.go
@@ -93,6 +93,22 @@ type EngineLog struct{}
 
 func (EngineLog) Kind() string { return "log" }
 
+// EngineJoin is a memory-resident table designed for the right-hand side
+// of JOINs (and joinGet calls). CH syntax:
+//
+//	Join(strictness, type, k1[, k2, ...])
+//
+// Strictness/type are bare identifiers in the DDL (not quoted strings)
+// and must match the JOIN operation the table is used with — see the CH
+// docs for the Join-table engine.
+type EngineJoin struct {
+	Strictness string   `hcl:"strictness"` // ANY | ALL | SEMI | ANTI
+	JoinType   string   `hcl:"type"`       // LEFT | INNER | RIGHT | FULL
+	Keys       []string `hcl:"keys"`
+}
+
+func (EngineJoin) Kind() string { return "join" }
+
 type EngineKafka struct {
 	// Collection is the named-collection reference. Mutually exclusive
 	// with every other field; when set, no inline setting may be set.
@@ -384,6 +400,10 @@ func DecodeEngine(spec *EngineSpec) (Engine, error) {
 		target = e
 	case "log":
 		var e EngineLog
+		diags = gohcl.DecodeBody(spec.Body, nil, &e)
+		target = e
+	case "join":
+		var e EngineJoin
 		diags = gohcl.DecodeBody(spec.Body, nil, &e)
 		target = e
 	case "kafka":

--- a/internal/loader/hcl/engines_test.go
+++ b/internal/loader/hcl/engines_test.go
@@ -81,6 +81,12 @@ func TestParseFile_AllEngineKinds(t *testing.T) {
 		Format:     ptr("JSONEachRow"),
 	}, byName["t_kafka"])
 
+	assert.Equal(t, EngineJoin{
+		Strictness: "ANY",
+		JoinType:   "LEFT",
+		Keys:       []string{"user_id", "session_id"},
+	}, byName["t_join"])
+
 	tgtData := "default.t_time_series_data"
 	tgtTags := "default.t_time_series_tags"
 	tgtMetrics := "default.t_time_series_metrics"
@@ -146,6 +152,7 @@ func TestEngine_KindMethods(t *testing.T) {
 		{EngineLog{}, "log"},
 		{EngineKafka{}, "kafka"},
 		{EngineTimeSeries{}, "time_series"},
+		{EngineJoin{}, "join"},
 	}
 	for _, c := range cases {
 		assert.Equal(t, c.want, c.engine.Kind())

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -471,6 +471,15 @@ func engineFromAST(e *chparser.EngineExpr) (Engine, map[string]string, error) {
 		return ee, allSettings, nil
 	case "Log":
 		return EngineLog{}, allSettings, nil
+	case "Join":
+		if len(params) < 3 {
+			return nil, nil, fmt.Errorf("Join needs (strictness, type, key[, key...])")
+		}
+		return EngineJoin{
+			Strictness: params[0],
+			JoinType:   params[1],
+			Keys:       params[2:],
+		}, allSettings, nil
 	case "Kafka":
 		k, err := buildKafkaEngine(params, allSettings)
 		if err != nil {

--- a/internal/loader/hcl/introspect_test.go
+++ b/internal/loader/hcl/introspect_test.go
@@ -671,3 +671,31 @@ func TestIntrospect_TimeSeries_ProductionPromMetrics(t *testing.T) {
 	assert.Equal(t, "DATA", e.KeywordHint)
 	assert.Equal(t, "posthog.prom_metrics_data", *e.Samples.Target)
 }
+
+func TestIntrospect_Join_SingleKey(t *testing.T) {
+	sql := "CREATE TABLE db.j (`id` UInt64, `value` String) ENGINE = Join(ANY, LEFT, id)"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"j", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineJoin)
+	assert.Equal(t, "ANY", e.Strictness)
+	assert.Equal(t, "LEFT", e.JoinType)
+	assert.Equal(t, []string{"id"}, e.Keys)
+}
+
+func TestIntrospect_Join_MultiKey(t *testing.T) {
+	sql := "CREATE TABLE db.j (`a` UInt64, `b` UInt64, `v` String) ENGINE = Join(ALL, INNER, a, b)"
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"j", sql}}}))
+	e := db.Tables[0].Engine.Decoded.(EngineJoin)
+	assert.Equal(t, "ALL", e.Strictness)
+	assert.Equal(t, "INNER", e.JoinType)
+	assert.Equal(t, []string{"a", "b"}, e.Keys)
+}
+
+func TestIntrospect_Join_RejectsTooFewArgs(t *testing.T) {
+	sql := "CREATE TABLE db.j (`id` UInt64) ENGINE = Join(ANY, LEFT)"
+	db := &DatabaseSpec{Name: "db"}
+	err := processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"j", sql}}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Join needs")
+}

--- a/internal/loader/hcl/sqlgen.go
+++ b/internal/loader/hcl/sqlgen.go
@@ -562,6 +562,11 @@ func engineSQL(e Engine) (clause string, extraSettings map[string]string) {
 		return fmt.Sprintf("Distributed('%s', '%s', '%s')", v.ClusterName, v.RemoteDatabase, v.RemoteTable), nil
 	case EngineLog:
 		return "Log()", nil
+	case EngineJoin:
+		// CH expects bare (unquoted) strictness, type, and key columns:
+		// Join(ANY, LEFT, k1, k2, ...).
+		parts := append([]string{v.Strictness, v.JoinType}, v.Keys...)
+		return fmt.Sprintf("Join(%s)", strings.Join(parts, ", ")), nil
 	case EngineKafka:
 		if v.Collection != nil {
 			// Named collection form: Kafka(<collection>); no settings emitted.

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -880,3 +880,25 @@ func TestSQLGen_TimeSeries_TagsToColumnsFolded(t *testing.T) {
 	stmt := out.Statements[0]
 	assert.Contains(t, stmt, "tags_to_columns = {'instance':'instance', 'job':'job'}")
 }
+
+func TestSQLGen_Join_SingleKey(t *testing.T) {
+	ts := TableSpec{Name: "j",
+		Columns: []ColumnSpec{{Name: "id", Type: "UInt64"}, {Name: "value", Type: "String"}},
+		Engine:  &EngineSpec{Kind: "join", Decoded: EngineJoin{Strictness: "ANY", JoinType: "LEFT", Keys: []string{"id"}}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	assert.Contains(t, out.Statements[0], "ENGINE = Join(ANY, LEFT, id)")
+}
+
+func TestSQLGen_Join_MultiKey(t *testing.T) {
+	ts := TableSpec{Name: "j",
+		Columns: []ColumnSpec{{Name: "a", Type: "UInt64"}, {Name: "b", Type: "UInt64"}, {Name: "v", Type: "String"}},
+		Engine:  &EngineSpec{Kind: "join", Decoded: EngineJoin{Strictness: "ALL", JoinType: "INNER", Keys: []string{"a", "b"}}},
+	}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "default", AddTables: []TableSpec{ts},
+	}}})
+	assert.Contains(t, out.Statements[0], "ENGINE = Join(ALL, INNER, a, b)")
+}

--- a/internal/loader/hcl/testdata/engines_all_kinds.hcl
+++ b/internal/loader/hcl/testdata/engines_all_kinds.hcl
@@ -98,6 +98,17 @@ database "posthog" {
     }
   }
 
+  table "t_join" {
+    column "user_id" { type = "UInt64" }
+    column "session_id" { type = "UInt64" }
+    column "value" { type = "String" }
+    engine "join" {
+      strictness = "ANY"
+      type       = "LEFT"
+      keys       = ["user_id", "session_id"]
+    }
+  }
+
   table "t_time_series" {
     column "metric_name" { type = "LowCardinality(String)" }
     engine "time_series" {

--- a/test/hcl_introspect_live_test.go
+++ b/test/hcl_introspect_live_test.go
@@ -179,3 +179,51 @@ func TestLive_HCLIntrospect_TimeSeries(t *testing.T) {
 	require.NotNil(t, ext.Metrics)
 	require.Equal(t, dbName+".prom_metrics_meta", *ext.Metrics.Target)
 }
+
+// TestLive_HCLIntrospect_Join verifies that a Join-engine table —
+// the most common missing engine in PostHog production with ~180
+// tables — round-trips through `hclload.Introspect`.
+func TestLive_HCLIntrospect_Join(t *testing.T) {
+	if !*clickhouse {
+		t.SkipNow()
+	}
+	conn := testhelpers.RequireClickHouse(t)
+	dbName := testhelpers.CreateTestDatabase(t, conn)
+	ctx := context.Background()
+
+	stmts := []string{
+		`CREATE TABLE ` + dbName + `.single_key (
+			id UInt64,
+			value String
+		) ENGINE = Join(ANY, LEFT, id)`,
+
+		`CREATE TABLE ` + dbName + `.multi_key (
+			user_id UInt64,
+			session_id UInt64,
+			value String
+		) ENGINE = Join(ALL, INNER, user_id, session_id)`,
+	}
+	for _, s := range stmts {
+		require.NoError(t, conn.Exec(ctx, s), "create failed: %s", s)
+	}
+
+	got, err := hclload.Introspect(ctx, conn, dbName)
+	require.NoError(t, err)
+
+	byName := map[string]hclload.Engine{}
+	for _, tbl := range got.Tables {
+		byName[tbl.Name] = tbl.Engine.Decoded
+	}
+
+	sk, ok := byName["single_key"].(hclload.EngineJoin)
+	require.True(t, ok)
+	require.Equal(t, "ANY", sk.Strictness)
+	require.Equal(t, "LEFT", sk.JoinType)
+	require.Equal(t, []string{"id"}, sk.Keys)
+
+	mk, ok := byName["multi_key"].(hclload.EngineJoin)
+	require.True(t, ok)
+	require.Equal(t, "ALL", mk.Strictness)
+	require.Equal(t, "INNER", mk.JoinType)
+	require.Equal(t, []string{"user_id", "session_id"}, mk.Keys)
+}


### PR DESCRIPTION
## Summary

Adds the `Join` engine. Per a `system.tables` engine count, PostHog production has ~180 Join-engine tables — the last remaining unsupported engine in that database.

### Engine model

CH syntax: `ENGINE = Join(strictness, type, k1[, k2, ...])`

```go
type EngineJoin struct {
    Strictness string   `hcl:"strictness"` // ANY | ALL | SEMI | ANTI
    JoinType   string   `hcl:"type"`       // LEFT | INNER | RIGHT | FULL
    Keys       []string `hcl:"keys"`
}
```

HCL form:

```hcl
table "user_lookup" {
  column "user_id" { type = "UInt64" }
  column "value"   { type = "String" }
  engine "join" {
    strictness = "ANY"
    type       = "LEFT"
    keys       = ["user_id"]
  }
}
```

Per the CH docs, `strictness`/`type`/`keys` are emitted **without quotes** (`Join(ANY, LEFT, id)`, not `Join('ANY', 'LEFT', 'id')`). Both introspect and sqlgen treat them as bare identifiers.

## Validation

No new dependency kind — Join's "key columns" are local column names, not cross-table references. A typo in a key column is already caught by CH at CREATE time.

## PostHog engine landscape (after this lands)

From the user's survey on `posthog` (5,524 tables total):

| Engine | Count | Status |
|---|---|---|
| Distributed | 1,980 | ✅ |
| ReplicatedReplacingMergeTree | 1,164 | ✅ |
| View | 900 | ✅ |
| ReplicatedMergeTree | 455 | ✅ |
| Dictionary | 378 | ✅ |
| **Join** | **180** | **✅ this PR** |
| ReplicatedAggregatingMergeTree | 150 | ✅ |
| MaterializedView | 120 | ✅ |
| ReplicatedCollapsingMergeTree | 90 | ✅ |
| MergeTree | 64 | ✅ |
| ReplicatedSummingMergeTree | 30 | ✅ |
| ReplacingMergeTree | 13 | ✅ |

All 12 engine kinds supported once this merges.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` — 439/439 pass
- [x] `ENABLE_CLICKHOUSE=1 go test ./... -count=1` (CH 26.3.12.3) — 501/501 pass
- [x] Live test `TestLive_HCLIntrospect_Join` exercises single-key (`ANY LEFT`) and multi-key (`ALL INNER`) variants
- [ ] CI runs the same matrices

## Stacking

Independent of #26 (TimeSeries, already merged) and #27 (Buffer/Null/Memory/Merge, open). Touches the same `engines_all_kinds.hcl` fixture and `engines_test.go` switch as #27 — whichever lands second needs a small rebase to fold both engine sets together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)