### PR TITLE
feat(hcl): complex_key_cache + 3 close-cousin dictionary layouts

### DIFF
--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -124,6 +124,8 @@ attributes depend on the kind.
 | `merge`                               | `db_regex`, `table_regex`                          | —                      |
 | `buffer`                              | `database`, `table`, `num_layers`, `min_time`, `max_time`, `min_rows`, `max_rows`, `min_bytes`, `max_bytes` | `flush_time`, `flush_rows`, `flush_bytes` |
 
+Dictionary layouts supported via `layout "<kind>"` inside a `dictionary` block: `flat`, `hashed`, `sparse_hashed`, `complex_key_hashed` (optional `preallocate`), `complex_key_sparse_hashed`, `range_hashed` / `complex_key_range_hashed` (optional `range_lookup_strategy`), `cache` (required `size_in_cells`), `complex_key_cache` (required `size_in_cells`), `hashed_array` / `complex_key_hashed_array` (optional `shards`), `direct`, `complex_key_direct`, `ip_trie` (optional `access_to_key_from_attributes`).
+
 Unknown kinds and missing required attributes are rejected at parse time
 with file/line positions.
 

--- a/internal/loader/hcl/dictionary_dump.go
+++ b/internal/loader/hcl/dictionary_dump.go
@@ -117,7 +117,8 @@ func writeDictionaryLayout(parent *hclwrite.Body, l DictionaryLayout) {
 	block := parent.AppendNewBlock("layout", []string{l.Kind()})
 	b := block.Body()
 	switch v := l.(type) {
-	case LayoutFlat, LayoutHashed, LayoutSparseHashed, LayoutComplexKeySparseHashed, LayoutDirect:
+	case LayoutFlat, LayoutHashed, LayoutSparseHashed, LayoutComplexKeySparseHashed,
+		LayoutDirect, LayoutComplexKeyDirect:
 		// no fields
 	case LayoutComplexKeyHashed:
 		writeOptInt(b, "preallocate", v.Preallocate)
@@ -127,6 +128,12 @@ func writeDictionaryLayout(parent *hclwrite.Body, l DictionaryLayout) {
 		writeOptStr(b, "range_lookup_strategy", v.RangeLookupStrategy)
 	case LayoutCache:
 		b.SetAttributeValue("size_in_cells", cty.NumberIntVal(v.SizeInCells))
+	case LayoutComplexKeyCache:
+		b.SetAttributeValue("size_in_cells", cty.NumberIntVal(v.SizeInCells))
+	case LayoutHashedArray:
+		writeOptInt(b, "shards", v.Shards)
+	case LayoutComplexKeyHashedArray:
+		writeOptInt(b, "shards", v.Shards)
 	case LayoutIPTrie:
 		writeOptBool(b, "access_to_key_from_attributes", v.AccessToKeyFromAttributes)
 	}

--- a/internal/loader/hcl/dictionary_introspect.go
+++ b/internal/loader/hcl/dictionary_introspect.go
@@ -295,6 +295,18 @@ func buildDictionaryLayoutFromAST(l *chparser.DictionaryLayoutClause) (*Dictiona
 			return nil, errors.New("layout cache: missing size_in_cells")
 		}
 		decoded = LayoutCache{SizeInCells: *n}
+	case "complex_key_cache":
+		n := optInt64(args["size_in_cells"])
+		if n == nil {
+			return nil, errors.New("layout complex_key_cache: missing size_in_cells")
+		}
+		decoded = LayoutComplexKeyCache{SizeInCells: *n}
+	case "complex_key_direct":
+		decoded = LayoutComplexKeyDirect{}
+	case "hashed_array":
+		decoded = LayoutHashedArray{Shards: optInt64(args["shards"])}
+	case "complex_key_hashed_array":
+		decoded = LayoutComplexKeyHashedArray{Shards: optInt64(args["shards"])}
 	case "ip_trie":
 		decoded = LayoutIPTrie{AccessToKeyFromAttributes: optBool(args["access_to_key_from_attributes"])}
 	default:

--- a/internal/loader/hcl/dictionary_layouts.go
+++ b/internal/loader/hcl/dictionary_layouts.go
@@ -46,6 +46,38 @@ type LayoutCache struct {
 
 func (LayoutCache) Kind() string { return "cache" }
 
+// LayoutComplexKeyCache is the complex-key (multi-column key) counterpart
+// to LayoutCache. Same single required parameter — size_in_cells controls
+// the number of cells in the LRU cache.
+type LayoutComplexKeyCache struct {
+	SizeInCells int64 `hcl:"size_in_cells"`
+}
+
+func (LayoutComplexKeyCache) Kind() string { return "complex_key_cache" }
+
+// LayoutComplexKeyDirect is the complex-key counterpart to LayoutDirect:
+// every lookup hits the source, no in-process caching. No parameters.
+type LayoutComplexKeyDirect struct{}
+
+func (LayoutComplexKeyDirect) Kind() string { return "complex_key_direct" }
+
+// LayoutHashedArray is a memory-efficient hash layout that stores values
+// in a packed array. `shards` partitions the dictionary across N parallel
+// hash tables for concurrent reads (default 1).
+type LayoutHashedArray struct {
+	Shards *int64 `hcl:"shards,optional"`
+}
+
+func (LayoutHashedArray) Kind() string { return "hashed_array" }
+
+// LayoutComplexKeyHashedArray is the complex-key counterpart to
+// LayoutHashedArray. Same optional `shards` parameter.
+type LayoutComplexKeyHashedArray struct {
+	Shards *int64 `hcl:"shards,optional"`
+}
+
+func (LayoutComplexKeyHashedArray) Kind() string { return "complex_key_hashed_array" }
+
 type LayoutIPTrie struct {
 	AccessToKeyFromAttributes *bool `hcl:"access_to_key_from_attributes,optional"`
 }
@@ -73,6 +105,8 @@ func DecodeDictionaryLayout(spec *DictionaryLayoutSpec) (DictionaryLayout, error
 		return LayoutComplexKeySparseHashed{}, nil
 	case "direct":
 		return LayoutDirect{}, nil
+	case "complex_key_direct":
+		return LayoutComplexKeyDirect{}, nil
 	case "complex_key_hashed":
 		var l LayoutComplexKeyHashed
 		if d := gohcl.DecodeBody(spec.Body, nil, &l); d.HasErrors() {
@@ -95,6 +129,24 @@ func DecodeDictionaryLayout(spec *DictionaryLayoutSpec) (DictionaryLayout, error
 		var l LayoutCache
 		if d := gohcl.DecodeBody(spec.Body, nil, &l); d.HasErrors() {
 			return nil, fmt.Errorf("layout cache: %s", d.Error())
+		}
+		return l, nil
+	case "complex_key_cache":
+		var l LayoutComplexKeyCache
+		if d := gohcl.DecodeBody(spec.Body, nil, &l); d.HasErrors() {
+			return nil, fmt.Errorf("layout complex_key_cache: %s", d.Error())
+		}
+		return l, nil
+	case "hashed_array":
+		var l LayoutHashedArray
+		if d := gohcl.DecodeBody(spec.Body, nil, &l); d.HasErrors() {
+			return nil, fmt.Errorf("layout hashed_array: %s", d.Error())
+		}
+		return l, nil
+	case "complex_key_hashed_array":
+		var l LayoutComplexKeyHashedArray
+		if d := gohcl.DecodeBody(spec.Body, nil, &l); d.HasErrors() {
+			return nil, fmt.Errorf("layout complex_key_hashed_array: %s", d.Error())
 		}
 		return l, nil
 	case "ip_trie":

--- a/internal/loader/hcl/dictionary_layouts_test.go
+++ b/internal/loader/hcl/dictionary_layouts_test.go
@@ -76,6 +76,27 @@ func TestDecodeDictionaryLayout_AllSupportedKinds(t *testing.T) {
 		{"direct", `dictionary "d" {
 			layout "direct" {}
 		}`, LayoutDirect{}},
+		{"complex_key_cache", `dictionary "d" {
+			layout "complex_key_cache" {
+				size_in_cells = 2000
+			}
+		}`, LayoutComplexKeyCache{SizeInCells: 2000}},
+		{"complex_key_direct", `dictionary "d" {
+			layout "complex_key_direct" {}
+		}`, LayoutComplexKeyDirect{}},
+		{"hashed_array_no_shards", `dictionary "d" {
+			layout "hashed_array" {}
+		}`, LayoutHashedArray{}},
+		{"hashed_array_with_shards", `dictionary "d" {
+			layout "hashed_array" {
+				shards = 4
+			}
+		}`, LayoutHashedArray{Shards: ptr(int64(4))}},
+		{"complex_key_hashed_array", `dictionary "d" {
+			layout "complex_key_hashed_array" {
+				shards = 8
+			}
+		}`, LayoutComplexKeyHashedArray{Shards: ptr(int64(8))}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -88,12 +109,12 @@ func TestDecodeDictionaryLayout_AllSupportedKinds(t *testing.T) {
 
 func TestDecodeDictionaryLayout_Unsupported(t *testing.T) {
 	src := `dictionary "d" {
-		layout "hashed_array" {}
+		layout "polygon" {}
 	}`
 	_, err := decodeLayout(t, src)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported dictionary layout kind")
-	assert.Contains(t, err.Error(), "hashed_array")
+	assert.Contains(t, err.Error(), "polygon")
 }
 
 func TestDecodeDictionaryLayout_NilSpec(t *testing.T) {

--- a/internal/loader/hcl/dictionary_live_test.go
+++ b/internal/loader/hcl/dictionary_live_test.go
@@ -115,8 +115,14 @@ func TestCHLive_Dictionary_LayoutMatrix(t *testing.T) {
 		{"range_hashed", LayoutRangeHashed{}, false, true, false},
 		{"complex_key_range_hashed", LayoutComplexKeyRangeHashed{RangeLookupStrategy: ptr("max")}, true, true, false},
 		{"cache", LayoutCache{SizeInCells: 1000}, false, false, false},
+		{"complex_key_cache", LayoutComplexKeyCache{SizeInCells: 1000}, true, false, false},
+		{"hashed_array", LayoutHashedArray{}, false, false, false},
+		{"hashed_array_shards", LayoutHashedArray{Shards: ptr(int64(2))}, false, false, false},
+		{"complex_key_hashed_array", LayoutComplexKeyHashedArray{}, true, false, false},
+		{"complex_key_hashed_array_shards", LayoutComplexKeyHashedArray{Shards: ptr(int64(4))}, true, false, false},
 		{"ip_trie", LayoutIPTrie{}, false, false, true},
 		{"direct", LayoutDirect{}, false, false, false},
+		{"complex_key_direct", LayoutComplexKeyDirect{}, true, false, false},
 	}
 
 	for _, tc := range cases {

--- a/internal/loader/hcl/dictionary_sqlgen.go
+++ b/internal/loader/hcl/dictionary_sqlgen.go
@@ -159,6 +159,20 @@ func layoutSQL(l DictionaryLayout) string {
 		return "COMPLEX_KEY_RANGE_HASHED()"
 	case LayoutCache:
 		return fmt.Sprintf("CACHE(SIZE_IN_CELLS %d)", v.SizeInCells)
+	case LayoutComplexKeyCache:
+		return fmt.Sprintf("COMPLEX_KEY_CACHE(SIZE_IN_CELLS %d)", v.SizeInCells)
+	case LayoutComplexKeyDirect:
+		return "COMPLEX_KEY_DIRECT()"
+	case LayoutHashedArray:
+		if v.Shards != nil {
+			return fmt.Sprintf("HASHED_ARRAY(SHARDS %d)", *v.Shards)
+		}
+		return "HASHED_ARRAY()"
+	case LayoutComplexKeyHashedArray:
+		if v.Shards != nil {
+			return fmt.Sprintf("COMPLEX_KEY_HASHED_ARRAY(SHARDS %d)", *v.Shards)
+		}
+		return "COMPLEX_KEY_HASHED_ARRAY()"
 	case LayoutIPTrie:
 		if v.AccessToKeyFromAttributes != nil {
 			return fmt.Sprintf("IP_TRIE(ACCESS_TO_KEY_FROM_ATTRIBUTES %t)", *v.AccessToKeyFromAttributes)

--- a/internal/loader/hcl/introspect_test.go
+++ b/internal/loader/hcl/introspect_test.go
@@ -492,7 +492,7 @@ LIFETIME(0)`
 func TestBuildDictionaryFromAST_UnsupportedLayout(t *testing.T) {
 	src := `CREATE DICTIONARY db.d (` + "`k`" + ` UInt64, ` + "`v`" + ` String) PRIMARY KEY k
 SOURCE(NULL())
-LAYOUT(HASHED_ARRAY())
+LAYOUT(POLYGON())
 LIFETIME(0)`
 	_, err := buildDictionaryFromCreateSQL(src)
 	require.Error(t, err)


### PR DESCRIPTION
## Summary

PostHog production failed introspection on `posthog.team_events_last_month_dictionary` with `LAYOUT(COMPLEX_KEY_CACHE(...))` — that layout kind wasn't modeled. Adds it plus the three closest cousins likely to appear in the same schema.

### New layouts

| Layout | HCL fields | CH form |
|---|---|---|
| `complex_key_cache` | `size_in_cells` (required) | `COMPLEX_KEY_CACHE(SIZE_IN_CELLS N)` |
| `complex_key_direct` | — | `COMPLEX_KEY_DIRECT()` |
| `hashed_array` | `shards` (optional) | `HASHED_ARRAY([SHARDS N])` |
| `complex_key_hashed_array` | `shards` (optional) | `COMPLEX_KEY_HASHED_ARRAY([SHARDS N])` |

### Wiring

Each layout flows through the full pipeline: `dictionary_layouts.go` types + `DecodeDictionaryLayout` case, `dictionary_introspect.go` LAYOUT-clause parser case, `dictionary_sqlgen.go` CH-form emission, `dictionary_dump.go` HCL round-trip, decode tests, plus `TestCHLive_Dictionary_LayoutMatrix` grows from 11 to 17 cases (all 15 layouts now exercised against real CH).

### Maintenance note

`TestBuildDictionaryFromAST_UnsupportedLayout` was using `HASHED_ARRAY` as its "unsupported" example. Now that it's supported, the test uses `POLYGON` instead.

## Deferred

Still unmodeled (file a follow-up if production needs any):

- `ssd_cache` / `complex_key_ssd_cache` — many tunables; needs design
- `polygon` — geo-specific; rare outside dedicated use

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` — 453/453 pass
- [x] `ENABLE_CLICKHOUSE=1 go test ./... -count=1` (CH 26.3.12.3) — 522/522 pass
- [x] `TestCHLive_Dictionary_LayoutMatrix` covers all 4 new layouts (incl. `shards` variants) against real CH
- [ ] CI runs the same matrices

🤖 Generated with [Claude Code](https://claude.com/claude-code)