### PR TITLE
Switch SQL parser dependency to github.com/orian/clickhouse-sql-parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/posthog/chschema
 go 1.25
 
 require (
-	github.com/AfterShip/clickhouse-sql-parser v0.5.1
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.3
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/hcl/v2 v2.24.0
+	github.com/orian/clickhouse-sql-parser v0.0.0-20260601143443-2d5bbc5ac581
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 	github.com/zclconf/go-cty v1.16.3
@@ -46,5 +46,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/AfterShip/clickhouse-sql-parser => github.com/orian/clickhouse-sql-parser v0.0.0-20260601104648-4521cd37e69b

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/orian/clickhouse-sql-parser v0.0.0-20260601104648-4521cd37e69b h1:EpAXD/zgcZFpBP+9jnfi/vrKJUe0aASf/fU/iFlfBR0=
-github.com/orian/clickhouse-sql-parser v0.0.0-20260601104648-4521cd37e69b/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
+github.com/orian/clickhouse-sql-parser v0.0.0-20260601143443-2d5bbc5ac581 h1:6wqmvQ05kkbKA85BgGVAi01RCiHXFb+7Zh+fyPZUZ+Q=
+github.com/orian/clickhouse-sql-parser v0.0.0-20260601143443-2d5bbc5ac581/go.mod h1:22D/qoWV/Ipbn5Gcub+0ttta1wgzSDaJMprQRZWghoE=
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
 github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=

--- a/internal/loader/hcl/clickhouse_create_table_test.go
+++ b/internal/loader/hcl/clickhouse_create_table_test.go
@@ -47,8 +47,8 @@ type createTableCase struct {
 	wantContains []string
 	skipLive     bool
 	// skipIntrospect skips the case in the round-trip introspection test
-	// when the upstream ClickHouse SQL parser (AfterShip/clickhouse-sql-parser
-	// v0.5.1) can't parse the create_table_query CH produces. Currently:
+	// when the upstream ClickHouse SQL parser (orian/clickhouse-sql-parser)
+	// can't parse the create_table_query CH produces. Currently:
 	// bare EPHEMERAL (no expression) and CONSTRAINT … ASSUME.
 	skipIntrospect bool
 }

--- a/internal/loader/hcl/dictionary_introspect.go
+++ b/internal/loader/hcl/dictionary_introspect.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	chparser "github.com/AfterShip/clickhouse-sql-parser/parser"
+	chparser "github.com/orian/clickhouse-sql-parser/parser"
 )
 
 // buildDictionaryFromCreateSQL parses a CREATE DICTIONARY statement and

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	chparser "github.com/AfterShip/clickhouse-sql-parser/parser"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	chparser "github.com/orian/clickhouse-sql-parser/parser"
 )
 
 // rowScanner is the minimal subset of driver.Rows used by the introspection
@@ -27,7 +27,7 @@ type rowScanner interface {
 // the declaration order ClickHouse reports.
 //
 // The function reads `create_table_query` for each table and parses it with
-// a ClickHouse SQL parser (AfterShip/clickhouse-sql-parser). All
+// a ClickHouse SQL parser (orian/clickhouse-sql-parser). All
 // per-table data is derived from that AST: columns (including TTL, CODEC,
 // default/materialized/ephemeral/alias, comment), indexes, constraints,
 // engine, ORDER BY, PARTITION BY, SAMPLE BY, table TTL, SETTINGS, and

--- a/internal/loader/hcl/named_collection_introspect.go
+++ b/internal/loader/hcl/named_collection_introspect.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	chparser "github.com/AfterShip/clickhouse-sql-parser/parser"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	chparser "github.com/orian/clickhouse-sql-parser/parser"
 )
 
 // IntrospectNamedCollections returns every named collection the live

--- a/internal/loader/hcl/validate.go
+++ b/internal/loader/hcl/validate.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	chparser "github.com/AfterShip/clickhouse-sql-parser/parser"
+	chparser "github.com/orian/clickhouse-sql-parser/parser"
 )
 
 // Dependency kinds.


### PR DESCRIPTION
## What

Switch the ClickHouse SQL parser dependency from `github.com/AfterShip/clickhouse-sql-parser` (a `require` + `replace`-to-fork setup) to a **direct** dependency on `github.com/orian/clickhouse-sql-parser`, now that the fork's module path has been renamed.

## Why

Introspecting the `posthog` database failed on `posthog.trace_spans`:

```
parse create_table_query for posthog.trace_spans: parser: line 0:2924
expected the last token kind is: ), but got <keyword>
```

The crash was the parser choking on a projection's trailing `WITH SETTINGS (...)` clause:

```
PROJECTION projection_index_trace_id (SELECT _part_offset ORDER BY trace_id) WITH SETTINGS (index_granularity = 512)
```

`parseProjectionSelect` returned right after the projection's closing `)` and never consumed the `WITH SETTINGS (...)` tail, so the caller hit the unexpected `WITH` keyword. Filed and fixed upstream as orian/clickhouse-sql-parser#11. The fork version pulled in here includes that fix.

## Changes

- `go.mod` / `go.sum`: drop `require AfterShip` + the `replace` directive; add direct `require github.com/orian/clickhouse-sql-parser`.
- Update the four `chparser` imports (`introspect.go`, `named_collection_introspect.go`, `dictionary_introspect.go`, `validate.go`) and two comment references. Alias `chparser` and all call sites unchanged.

## Verification

- `go build ./...` clean; no `AfterShip` references remain.
- `go test ./...` → **453 passed**.
- The exact failing `posthog.trace_spans` `create_table_query` now parses (confirmed with a throwaway parse test, since removed).

## Known limitation (out of scope)

Projections now parse, but are still **silently dropped** during introspection — `buildTableFromCreateTable` only handles `ColumnDef`/`TableIndex`/`ConstraintClause`, and `TableSpec` has no `Projection` type. Introspection succeeds, but projections aren't represented in the schema model or managed by diff/sqlgen. Projection round-trip would be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)