### PR TITLE
Dump ClickHouse macros + node identity per node

### DIFF
--- a/cmd/hclexp/hclexp.go
+++ b/cmd/hclexp/hclexp.go
@@ -131,6 +131,7 @@ func runIntrospect(args []string) {
 	user := fs.String("user", cfg.User, "ClickHouse user")
 	password := fs.String("password", cfg.Password, "ClickHouse password")
 	outFlag := fs.String("out", "", "output .hcl file, or a directory (one <db>.hcl per database); empty writes to stdout")
+	nodeFlag := fs.String("node", "", "node name for the emitted node{} block; defaults to the server's hostName()")
 	secure := fs.Bool("secure", cfg.Secure, "connect to ClickHouse over TLS")
 	skipVerify := fs.Bool("tls-skip-verify", cfg.TLSSkipVerify, "skip TLS certificate verification (requires -secure)")
 	_ = fs.Parse(args)
@@ -175,6 +176,14 @@ func runIntrospect(args []string) {
 	}
 	schema.NamedCollections = ncs
 	slog.Info("introspected named collections", "count", len(schema.NamedCollections))
+
+	node, err := hclload.IntrospectNode(ctx, conn, *nodeFlag)
+	if err != nil {
+		slog.Error("failed to introspect node macros", "err", err)
+		os.Exit(1)
+	}
+	schema.Nodes = []hclload.NodeSpec{node}
+	slog.Info("introspected node", "name", node.Name, "macros", len(node.Macros))
 	for _, nc := range schema.NamedCollections {
 		if redacted := hclload.RedactedParamKeys(nc); len(redacted) > 0 {
 			slog.Warn("named collection has redacted values; diff will skip these params to avoid overwriting real secrets with '[HIDDEN]'",
@@ -520,7 +529,10 @@ func writeIntrospected(out string, schema *hclload.Schema) error {
 	if info, err := os.Stat(out); err == nil && info.IsDir() {
 		for _, db := range schema.Databases {
 			path := filepath.Join(out, db.Name+".hcl")
-			if err := writeFile(path, &hclload.Schema{Databases: []hclload.DatabaseSpec{db}}); err != nil {
+			// Include node identity in every per-database file so the
+			// dump carries its source node's macros regardless of which
+			// <db>.hcl a reader opens.
+			if err := writeFile(path, &hclload.Schema{Databases: []hclload.DatabaseSpec{db}, Nodes: schema.Nodes}); err != nil {
 				return err
 			}
 			slog.Info("schema written", "path", path)

--- a/internal/loader/hcl/dump.go
+++ b/internal/loader/hcl/dump.go
@@ -23,8 +23,18 @@ func Write(w io.Writer, schema *Schema) error {
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 
-	for i, db := range schema.Databases {
+	nodes := append([]NodeSpec(nil), schema.Nodes...)
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
+	for i, n := range nodes {
 		if i > 0 {
+			body.AppendNewline()
+		}
+		nodeBlock := body.AppendNewBlock("node", []string{n.Name})
+		writeNode(nodeBlock.Body(), n)
+	}
+
+	for i, db := range schema.Databases {
+		if i > 0 || len(nodes) > 0 {
 			body.AppendNewline()
 		}
 		dbBlock := body.AppendNewBlock("database", []string{db.Name})
@@ -43,6 +53,14 @@ func Write(w io.Writer, schema *Schema) error {
 
 	_, err := w.Write(f.Bytes())
 	return err
+}
+
+// writeNode emits a node block carrying the node's macros. Macro keys are
+// sorted for deterministic output (via stringMap).
+func writeNode(body *hclwrite.Body, n NodeSpec) {
+	if len(n.Macros) > 0 {
+		body.SetAttributeValue("macros", stringMap(n.Macros))
+	}
 }
 
 func writeDatabase(body *hclwrite.Body, db DatabaseSpec) {

--- a/internal/loader/hcl/dump_test.go
+++ b/internal/loader/hcl/dump_test.go
@@ -97,6 +97,36 @@ func TestWrite_RoundTrip_KafkaInlineSettings(t *testing.T) {
 	roundTrip(t, filepath.Join("testdata", "kafka_inline_settings.hcl"))
 }
 
+func TestWrite_RoundTrip_NodeMacros(t *testing.T) {
+	roundTrip(t, filepath.Join("testdata", "node_macros.hcl"))
+}
+
+func TestDumpSchema_RendersNodeBlock(t *testing.T) {
+	want := NodeSpec{
+		Name: "prod-us-iad-ch-1d-ops",
+		Macros: map[string]string{
+			"shard":           "1",
+			"replica":         "d",
+			"hostClusterRole": "ops",
+			"hostClusterType": "online",
+		},
+	}
+	s := &Schema{Nodes: []NodeSpec{want}}
+
+	var buf bytes.Buffer
+	require.NoError(t, Write(&buf, s))
+
+	got := buf.String()
+	assert.Contains(t, got, `node "prod-us-iad-ch-1d-ops" {`)
+
+	tmp := filepath.Join(t.TempDir(), "node.hcl")
+	require.NoError(t, os.WriteFile(tmp, buf.Bytes(), 0o600))
+	reparsed, err := ParseFile(tmp)
+	require.NoError(t, err)
+	require.Len(t, reparsed.Nodes, 1)
+	assert.Equal(t, want, reparsed.Nodes[0])
+}
+
 func TestDumpSchema_RendersViewBlocks(t *testing.T) {
 	want := ViewSpec{
 		Name:          "metrics",

--- a/internal/loader/hcl/layers.go
+++ b/internal/loader/hcl/layers.go
@@ -20,6 +20,8 @@ func LoadLayers(layerDirs []string) (*Schema, error) {
 	var ordered []string
 	ncByName := map[string]*NamedCollectionSpec{}
 	var ncOrder []string
+	nodeByName := map[string]*NodeSpec{}
+	var nodeOrder []string
 
 	for _, dir := range layerDirs {
 		files, err := hclFilesIn(dir)
@@ -54,6 +56,15 @@ func LoadLayers(layerDirs []string) (*Schema, error) {
 					ncOrder = append(ncOrder, nc.Name)
 				}
 			}
+			for _, n := range parsed.Nodes {
+				if existing, ok := nodeByName[n.Name]; ok {
+					*existing = n // last declaration wins
+				} else {
+					cp := n
+					nodeByName[n.Name] = &cp
+					nodeOrder = append(nodeOrder, n.Name)
+				}
+			}
 		}
 	}
 
@@ -63,6 +74,9 @@ func LoadLayers(layerDirs []string) (*Schema, error) {
 	}
 	for _, name := range ncOrder {
 		out.NamedCollections = append(out.NamedCollections, *ncByName[name])
+	}
+	for _, name := range nodeOrder {
+		out.Nodes = append(out.Nodes, *nodeByName[name])
 	}
 	return out, nil
 }

--- a/internal/loader/hcl/macros_introspect.go
+++ b/internal/loader/hcl/macros_introspect.go
@@ -1,0 +1,74 @@
+package hcl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// IntrospectMacros returns the ClickHouse macros configured on the
+// connected node, read from system.macros. Macros carry a node's
+// identity within the cluster — shard, replica, hostClusterRole,
+// hostClusterType — substituted into ON CLUSTER DDL and ReplicatedMergeTree
+// zoo paths. The returned map is keyed by macro name.
+func IntrospectMacros(ctx context.Context, conn driver.Conn) (map[string]string, error) {
+	const q = `SELECT macro, substitution FROM system.macros ORDER BY macro`
+	rows, err := conn.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("query system.macros: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string]string{}
+	for rows.Next() {
+		var macro, substitution string
+		if err := rows.Scan(&macro, &substitution); err != nil {
+			return nil, fmt.Errorf("scan system.macros: %w", err)
+		}
+		out[macro] = substitution
+	}
+	return out, rows.Err()
+}
+
+// IntrospectNode builds a NodeSpec for the connected node: its macros plus
+// a name. When nameOverride is non-empty it is used as the node name;
+// otherwise the name is read from ClickHouse via hostName().
+func IntrospectNode(ctx context.Context, conn driver.Conn, nameOverride string) (NodeSpec, error) {
+	macros, err := IntrospectMacros(ctx, conn)
+	if err != nil {
+		return NodeSpec{}, err
+	}
+
+	name := nameOverride
+	if name == "" {
+		host, err := introspectHostName(ctx, conn)
+		if err != nil {
+			return NodeSpec{}, err
+		}
+		name = host
+	}
+
+	return NodeSpec{Name: name, Macros: macros}, nil
+}
+
+// introspectHostName returns the server-reported hostname via hostName().
+func introspectHostName(ctx context.Context, conn driver.Conn) (string, error) {
+	rows, err := conn.Query(ctx, `SELECT hostName()`)
+	if err != nil {
+		return "", fmt.Errorf("query hostName(): %w", err)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", fmt.Errorf("query hostName(): %w", err)
+		}
+		return "", fmt.Errorf("query hostName(): no rows returned")
+	}
+	var host string
+	if err := rows.Scan(&host); err != nil {
+		return "", fmt.Errorf("scan hostName(): %w", err)
+	}
+	return host, nil
+}

--- a/internal/loader/hcl/macros_introspect_live_test.go
+++ b/internal/loader/hcl/macros_introspect_live_test.go
@@ -1,0 +1,35 @@
+package hcl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/posthog/chschema/test/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCHLive_IntrospectNode(t *testing.T) {
+	if !*clickhouseLive {
+		t.Skip("pass -clickhouse to run against a live ClickHouse")
+	}
+	conn := testhelpers.RequireClickHouse(t)
+	ctx := context.Background()
+
+	// Macros may be empty on a vanilla instance, but the query must succeed
+	// and return a non-nil map.
+	macros, err := IntrospectMacros(ctx, conn)
+	require.NoError(t, err)
+	assert.NotNil(t, macros)
+
+	// hostName() always resolves, so a node with no override gets a name.
+	node, err := IntrospectNode(ctx, conn, "")
+	require.NoError(t, err)
+	assert.NotEmpty(t, node.Name, "node name should fall back to hostName()")
+	assert.Equal(t, macros, node.Macros)
+
+	// An explicit override wins over hostName().
+	named, err := IntrospectNode(ctx, conn, "prod-us-iad-ch-1d-ops")
+	require.NoError(t, err)
+	assert.Equal(t, "prod-us-iad-ch-1d-ops", named.Name)
+}

--- a/internal/loader/hcl/parser.go
+++ b/internal/loader/hcl/parser.go
@@ -13,6 +13,7 @@ import (
 type fileSpec struct {
 	Databases        []DatabaseSpec        `hcl:"database,block"`
 	NamedCollections []NamedCollectionSpec `hcl:"named_collection,block"`
+	Nodes            []NodeSpec            `hcl:"node,block"`
 }
 
 // ParseFile parses a single HCL file and returns the declared schema.
@@ -63,6 +64,7 @@ func ParseFile(path string) (*Schema, error) {
 	return &Schema{
 		Databases:        spec.Databases,
 		NamedCollections: spec.NamedCollections,
+		Nodes:            spec.Nodes,
 	}, nil
 }
 

--- a/internal/loader/hcl/testdata/node_macros.hcl
+++ b/internal/loader/hcl/testdata/node_macros.hcl
@@ -1,0 +1,21 @@
+node "prod-us-iad-ch-1d-ops" {
+  macros = {
+    hostClusterRole = "ops"
+    hostClusterType = "online"
+    replica         = "d"
+    shard           = "1"
+  }
+}
+
+database "posthog" {
+  table "events" {
+    column "team_id" {
+      type = "Int64"
+    }
+
+    engine "merge_tree" {
+    }
+
+    order_by = ["team_id"]
+  }
+}

--- a/internal/loader/hcl/types.go
+++ b/internal/loader/hcl/types.go
@@ -232,6 +232,21 @@ type DictionaryLayout interface{ Kind() string }
 type Schema struct {
 	Databases        []DatabaseSpec
 	NamedCollections []NamedCollectionSpec
+
+	// Nodes carries per-node identity captured at introspection time:
+	// the node hostname (label) and its ClickHouse macros (shard,
+	// replica, hostClusterRole, hostClusterType, …). It is metadata only
+	// — Diff() ignores it — and exists so multi-node drift analysis can
+	// group nodes by their authoritative macros rather than by filename.
+	Nodes []NodeSpec
+}
+
+// NodeSpec records the identity of a single physical ClickHouse node,
+// dumped alongside its schema. Name is the node hostname; Macros is the
+// raw key/value bag from `SELECT * FROM system.macros`.
+type NodeSpec struct {
+	Name   string            `hcl:"name,label"`
+	Macros map[string]string `hcl:"macros,optional"`
 }
 
 // NamedCollectionSpec models a ClickHouse named collection — a


### PR DESCRIPTION
## What

Introspection now captures each node's **macros** (`SELECT * FROM system.macros`) and **hostname**, emitting them as a new top-level block alongside the schema dump:

```hcl
node "prod-us-iad-ch-1d-ops" {
  macros = {
    hostClusterRole = "ops"
    hostClusterType = "online"
    replica         = "d"
    shard           = "1"
  }
}

database "posthog" {
  ...
}
```

## Why

`prod/us/` holds ~69 per-node dumps where node identity (shard/replica/role) lives **only in the filename** — nothing inside the file records which physical node it came from. Macros are the authoritative source of that identity. Capturing them in the dump lets a later drift-analysis tool group nodes by role/shard reliably instead of parsing filenames.

This is the **macro-dump half**; the `hclexp drift` command is a planned follow-up.

## Changes

- **`types.go`** — new `NodeSpec` (`Name` label + `Macros map[string]string`); `Schema` gains `Nodes []NodeSpec`. Metadata only — `Diff()` ignores it.
- **`parser.go`** — `node` block added to `fileSpec` and propagated to `Schema`. Maps decode via gohcl for free (same as table `settings`).
- **`layers.go`** — `LoadLayers` accumulates `node` blocks (last-wins by name).
- **`macros_introspect.go`** (new) — `IntrospectMacros` + `IntrospectNode` (falls back to `SELECT hostName()` when no `-node` override).
- **`dump.go`** — `Write` emits sorted `node` blocks before databases; `writeNode` reuses the existing `stringMap()` serializer for deterministic output.
- **`cmd/hclexp/hclexp.go`** — new `-node` flag; `runIntrospect` captures the node and includes it in output (including each per-`<db>.hcl` file in directory mode).

## Tests

- `TestWrite_RoundTrip_NodeMacros` + `testdata/node_macros.hcl` — parse → dump → parse equality.
- `TestDumpSchema_RendersNodeBlock` — asserts the rendered `node "…" {` header and macro round-trip.
- `TestCHLive_IntrospectNode` (gated by `-clickhouse`) — exercises `IntrospectMacros`/`IntrospectNode` against a real instance.

`go test ./...` → **455 passed** (+2). Build and gofmt clean.

## Follow-up (not in this PR)

`hclexp drift`: group nodes by role (all-or-nothing), diff each against a per-group reference via `hclload.Diff`, grouped summary with a `-details` flag. Prefers `node{}` macros, falls back to filename parsing for older dumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)