### PR TITLE
Add hclexp drift command to detect cross-node schema drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ hclexp introspect -host ch.prod.internal -port 9440 -user readonly \
 **Flags:**
 
 - `-database` — comma-separated list of databases to introspect (required)
+- `-node` — name for the emitted `node {}` block; defaults to the server's
+  `hostName()`
 - `-host`, `-port`, `-user`, `-password` — connection overrides
 - `-secure` — connect over TLS (matches `CLICKHOUSE_SECURE`)
 - `-tls-skip-verify` — skip server-cert verification (requires `-secure`;
@@ -91,6 +93,12 @@ and `SETTINGS` all come back populated. Materialized views (TO-form),
 plain views (with `column_aliases`, `sql_security`, `definer`, comment),
 dictionaries (every supported source + layout kind), and named
 collections are dumped in the same pass.
+
+Each dump also gets a top-level `node {}` block recording the source
+node's name and ClickHouse macros (`shard`, `replica`, `hostClusterRole`,
+`hostClusterType`, …) read from `system.macros`. It's metadata only —
+`hclexp diff` ignores it — and exists so `hclexp drift` (below) can group
+nodes by their authoritative identity.
 
 ## Load & resolve an HCL schema
 
@@ -201,6 +209,59 @@ hclexp validate -config ./schema/posthog.hcl -skip-validation='*'
 `hclexp diff -sql` applies the same dependency knowledge to DDL ordering:
 within the generated migration, a table is created before any
 Distributed/MV/Dictionary that depends on it, and dropped after.
+
+## Detect cross-node drift
+
+`hclexp drift` compares the per-node HCL dumps in a directory and reports
+where nodes that should share a schema don't. It's built for fleet dumps
+like `prod/eu/*.hcl` — one file per node, each carrying a `node {}` block
+with that node's macros (see [Introspect](#introspect-a-live-database)).
+
+```sh
+# Compare every node, grouped by the hostClusterRole macro
+hclexp drift -dir prod/eu
+
+# Compare just one pool via a filename glob
+hclexp drift -dir prod/eu -glob '*ingestion-small*'
+
+# Group by the deployment role parsed from the node name; show full diffs
+hclexp drift -dir prod/eu -group-by role -details
+```
+
+Within each group every node is diffed — via the same engine as `hclexp
+diff` — against the lexically-first **reference** node, and a one-line
+change summary is printed per drifting node. The command exits non-zero
+when any drift is found, so it doubles as a CI guard.
+
+**Flags:**
+
+- `-dir` — directory of per-node `.hcl` dumps to compare (required)
+- `-glob` — filename glob selecting dumps within `-dir` (default `*`),
+  e.g. `'*ingestion-small*'`
+- `-group-by` — comma-separated keys to group nodes by (default
+  `hostClusterRole`). Each key is looked up first in the node's macros,
+  then as one of the pseudo-keys `role` / `shard` / `replica` parsed from
+  the node name (`prod-<region>-<az>-ch-<shard><replica>[-<role>]`).
+  Examples: `-group-by role`, `-group-by hostClusterRole,hostClusterType`.
+- `-details` — print the full change set of each drifting node against its
+  group reference, instead of just the one-line summary
+
+Example output:
+
+```
+group "ingestion" — 22 nodes, reference prod-eu-fra-ch-10a-ingestion-events — 6 drifting
+  ✗ prod-eu-fra-ch-1a-ingestion-medium: +16 table, -8 table, +8 mv, -4 mv
+  ✗ prod-eu-fra-ch-1a-ingestion-small: +25 table, -8 table, +10 mv, -4 mv
+group "ops" — 2 nodes, reference prod-eu-fra-ch-1a-ops — OK (all identical)
+
+summary: 58 nodes, 8 groups, 2 groups with drift, 28 drifting nodes
+```
+
+> **Tip:** `hostClusterRole` is coarse — it can lump distinct pools
+> together (e.g. `ingestion` covers ingestion-events / -medium / -small,
+> and `data` covers online and offline nodes). `-group-by role` uses the
+> finer deployment role from the node name and usually isolates genuine
+> drift.
 
 ## TLS / secure connections
 

--- a/cmd/hclexp/drift.go
+++ b/cmd/hclexp/drift.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
+)
+
+// driftNode is one per-node dump loaded for drift analysis: its identity
+// (from the node{} block and/or the filename) plus its resolved schema.
+type driftNode struct {
+	Name    string
+	File    string
+	Macros  map[string]string
+	Role    string // deployment role parsed from the filename suffix
+	Shard   string
+	Replica string
+	Schema  *hclload.Schema
+}
+
+// nodeNameRe extracts shard, replica, and the optional deployment-role
+// suffix from a node name like prod-eu-fra-ch-10a-ingestion-events
+// (shard 10, replica a, role ingestion-events) or prod-eu-fra-ch-1f
+// (shard 1, replica f, no role suffix).
+var nodeNameRe = regexp.MustCompile(`^[a-z]+-[a-z]+-[a-z]+-ch-([0-9]+)([a-z])(?:-(.+))?$`)
+
+// runDrift compares the per-node HCL dumps in a directory, grouping nodes
+// that are expected to share a schema and reporting any drift within each
+// group. It exits non-zero when any drift is found.
+func runDrift(args []string) {
+	fs := flag.NewFlagSet("hclexp drift", flag.ExitOnError)
+	dirFlag := fs.String("dir", "", "directory of per-node .hcl dumps to compare")
+	groupByFlag := fs.String("group-by", "hostClusterRole", "comma-separated keys to group nodes by: macro names, or the pseudo-keys role/shard/replica")
+	details := fs.Bool("details", false, "print the full change set of each drifting node against its group reference")
+	_ = fs.Parse(args)
+
+	if *dirFlag == "" {
+		fmt.Fprintln(os.Stderr, "drift: -dir is required")
+		os.Exit(2)
+	}
+
+	nodes, err := loadDriftNodes(*dirFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "drift: %v\n", err)
+		os.Exit(1)
+	}
+	if len(nodes) == 0 {
+		fmt.Fprintf(os.Stderr, "drift: no .hcl files found in %s\n", *dirFlag)
+		os.Exit(1)
+	}
+
+	keys := splitList(*groupByFlag)
+	groups, order := groupNodes(nodes, keys)
+
+	totalDrift := 0
+	groupsWithDrift := 0
+	for _, key := range order {
+		members := groups[key]
+		sort.Slice(members, func(i, j int) bool { return members[i].Name < members[j].Name })
+
+		if len(members) < 2 {
+			fmt.Printf("group %q — 1 node (no peers to compare): %s\n", key, members[0].Name)
+			continue
+		}
+
+		ref := members[0]
+		var drifters []driftNode
+		summaries := map[string]string{}
+		changeSets := map[string]hclload.ChangeSet{}
+		for _, m := range members[1:] {
+			cs := hclload.Diff(ref.Schema, m.Schema)
+			if cs.IsEmpty() {
+				continue
+			}
+			drifters = append(drifters, m)
+			summaries[m.Name] = summarizeChanges(cs)
+			changeSets[m.Name] = cs
+		}
+
+		fmt.Printf("group %q — %d nodes, reference %s", key, len(members), ref.Name)
+		if len(drifters) == 0 {
+			fmt.Printf(" — OK (all identical)\n")
+			continue
+		}
+		groupsWithDrift++
+		fmt.Printf(" — %d drifting\n", len(drifters))
+		for _, d := range drifters {
+			totalDrift++
+			fmt.Printf("  ✗ %s: %s\n", d.Name, summaries[d.Name])
+			if *details {
+				renderChangeSet(prefixWriter(os.Stdout, "      "), changeSets[d.Name])
+			}
+		}
+	}
+
+	fmt.Printf("\nsummary: %d nodes, %d groups, %d groups with drift, %d drifting nodes\n",
+		len(nodes), len(order), groupsWithDrift, totalDrift)
+	if totalDrift > 0 {
+		os.Exit(1)
+	}
+}
+
+// loadDriftNodes parses and resolves every .hcl file in dir into a
+// driftNode, taking identity from the file's node{} block when present and
+// otherwise from the filename.
+func loadDriftNodes(dir string) ([]driftNode, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir %q: %w", dir, err)
+	}
+	var nodes []driftNode
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".hcl" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		schema, err := loadSide(path)
+		if err != nil {
+			return nil, fmt.Errorf("load %s: %w", path, err)
+		}
+
+		n := driftNode{
+			File:   path,
+			Name:   strings.TrimSuffix(e.Name(), ".hcl"),
+			Schema: schema,
+		}
+		if len(schema.Nodes) > 0 {
+			if schema.Nodes[0].Name != "" {
+				n.Name = schema.Nodes[0].Name
+			}
+			n.Macros = schema.Nodes[0].Macros
+		}
+		n.Shard, n.Replica, n.Role = parseNodeIdentity(n.Name)
+		nodes = append(nodes, n)
+	}
+	return nodes, nil
+}
+
+// parseNodeIdentity extracts shard, replica, and deployment role from a
+// node name following the prod-<region>-<az>-ch-<shard><replica>[-role]
+// convention. Unmatched names yield empty strings.
+func parseNodeIdentity(name string) (shard, replica, role string) {
+	m := nodeNameRe.FindStringSubmatch(name)
+	if m == nil {
+		return "", "", ""
+	}
+	return m[1], m[2], m[3]
+}
+
+// groupNodes buckets nodes by the concatenation of the given keys. Each key
+// is resolved against the node's macros first, then the pseudo-keys
+// role/shard/replica. It returns the buckets and a deterministic key order.
+func groupNodes(nodes []driftNode, keys []string) (map[string][]driftNode, []string) {
+	groups := map[string][]driftNode{}
+	var order []string
+	for _, n := range nodes {
+		key := groupKey(n, keys)
+		if _, ok := groups[key]; !ok {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], n)
+	}
+	sort.Strings(order)
+	return groups, order
+}
+
+// groupKey computes a node's group key from the requested keys.
+func groupKey(n driftNode, keys []string) string {
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		var v string
+		if mv, ok := n.Macros[k]; ok {
+			v = mv
+		} else {
+			switch k {
+			case "role":
+				v = n.Role
+			case "shard":
+				v = n.Shard
+			case "replica":
+				v = n.Replica
+			}
+		}
+		if v == "" {
+			v = "(none)"
+		}
+		parts = append(parts, v)
+	}
+	return strings.Join(parts, "/")
+}
+
+// summarizeChanges renders a one-line count of a ChangeSet.
+func summarizeChanges(cs hclload.ChangeSet) string {
+	var addT, dropT, altT, addMV, dropMV, altMV, addD, dropD, altD, addV, dropV, altV int
+	for _, dc := range cs.Databases {
+		addT += len(dc.AddTables)
+		dropT += len(dc.DropTables)
+		altT += len(dc.AlterTables)
+		addMV += len(dc.AddMaterializedViews)
+		dropMV += len(dc.DropMaterializedViews)
+		altMV += len(dc.AlterMaterializedViews)
+		addD += len(dc.AddDictionaries)
+		dropD += len(dc.DropDictionaries)
+		altD += len(dc.AlterDictionaries)
+		addV += len(dc.AddViews)
+		dropV += len(dc.DropViews)
+		altV += len(dc.AlterViews)
+	}
+	var parts []string
+	add := func(label string, plus, minus, alt int) {
+		if plus > 0 {
+			parts = append(parts, fmt.Sprintf("+%d %s", plus, label))
+		}
+		if minus > 0 {
+			parts = append(parts, fmt.Sprintf("-%d %s", minus, label))
+		}
+		if alt > 0 {
+			parts = append(parts, fmt.Sprintf("~%d %s", alt, label))
+		}
+	}
+	add("table", addT, dropT, altT)
+	add("mv", addMV, dropMV, altMV)
+	add("dict", addD, dropD, altD)
+	add("view", addV, dropV, altV)
+	if len(parts) == 0 {
+		return "changed"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// prefixWriter returns an io.Writer that prepends prefix to every line.
+func prefixWriter(w *os.File, prefix string) *linePrefixer {
+	return &linePrefixer{w: w, prefix: prefix, atLineStart: true}
+}
+
+type linePrefixer struct {
+	w           *os.File
+	prefix      string
+	atLineStart bool
+}
+
+func (lp *linePrefixer) Write(p []byte) (int, error) {
+	for _, b := range p {
+		if lp.atLineStart {
+			if _, err := lp.w.WriteString(lp.prefix); err != nil {
+				return 0, err
+			}
+			lp.atLineStart = false
+		}
+		if _, err := lp.w.Write([]byte{b}); err != nil {
+			return 0, err
+		}
+		if b == '\n' {
+			lp.atLineStart = true
+		}
+	}
+	return len(p), nil
+}

--- a/cmd/hclexp/drift.go
+++ b/cmd/hclexp/drift.go
@@ -36,6 +36,7 @@ var nodeNameRe = regexp.MustCompile(`^[a-z]+-[a-z]+-[a-z]+-ch-([0-9]+)([a-z])(?:
 func runDrift(args []string) {
 	fs := flag.NewFlagSet("hclexp drift", flag.ExitOnError)
 	dirFlag := fs.String("dir", "", "directory of per-node .hcl dumps to compare")
+	globFlag := fs.String("glob", "*", "filename glob to select dumps within -dir, e.g. '*ingestion-small*'")
 	groupByFlag := fs.String("group-by", "hostClusterRole", "comma-separated keys to group nodes by: macro names, or the pseudo-keys role/shard/replica")
 	details := fs.Bool("details", false, "print the full change set of each drifting node against its group reference")
 	_ = fs.Parse(args)
@@ -45,13 +46,13 @@ func runDrift(args []string) {
 		os.Exit(2)
 	}
 
-	nodes, err := loadDriftNodes(*dirFlag)
+	nodes, err := loadDriftNodes(*dirFlag, *globFlag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "drift: %v\n", err)
 		os.Exit(1)
 	}
 	if len(nodes) == 0 {
-		fmt.Fprintf(os.Stderr, "drift: no .hcl files found in %s\n", *dirFlag)
+		fmt.Fprintf(os.Stderr, "drift: no .hcl files in %s match %q\n", *dirFlag, *globFlag)
 		os.Exit(1)
 	}
 
@@ -106,10 +107,19 @@ func runDrift(args []string) {
 	}
 }
 
-// loadDriftNodes parses and resolves every .hcl file in dir into a
-// driftNode, taking identity from the file's node{} block when present and
-// otherwise from the filename.
-func loadDriftNodes(dir string) ([]driftNode, error) {
+// loadDriftNodes parses and resolves every .hcl file in dir whose base name
+// matches glob into a driftNode, taking identity from the file's node{}
+// block when present and otherwise from the filename. An empty glob matches
+// every .hcl file.
+func loadDriftNodes(dir, glob string) ([]driftNode, error) {
+	if glob == "" {
+		glob = "*"
+	}
+	// Fail fast on an invalid pattern rather than silently matching nothing.
+	if _, err := filepath.Match(glob, ""); err != nil {
+		return nil, fmt.Errorf("invalid -glob %q: %w", glob, err)
+	}
+
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("read dir %q: %w", dir, err)
@@ -117,6 +127,9 @@ func loadDriftNodes(dir string) ([]driftNode, error) {
 	var nodes []driftNode
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".hcl" {
+			continue
+		}
+		if ok, _ := filepath.Match(glob, e.Name()); !ok {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())

--- a/cmd/hclexp/drift_test.go
+++ b/cmd/hclexp/drift_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNodeIdentity(t *testing.T) {
+	cases := []struct {
+		name                         string
+		wantShard, wantRep, wantRole string
+	}{
+		{"prod-eu-fra-ch-10a-ingestion-events", "10", "a", "ingestion-events"},
+		{"prod-us-iad-ch-1d-ops", "1", "d", "ops"},
+		{"prod-eu-fra-ch-1f", "1", "f", ""},
+		{"prod-eu-fra-ch-8h-offline", "8", "h", "offline"},
+		{"not-a-node", "", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			shard, rep, role := parseNodeIdentity(c.name)
+			assert.Equal(t, c.wantShard, shard)
+			assert.Equal(t, c.wantRep, rep)
+			assert.Equal(t, c.wantRole, role)
+		})
+	}
+}
+
+func TestGroupKey(t *testing.T) {
+	n := driftNode{
+		Macros:  map[string]string{"hostClusterRole": "data", "hostClusterType": "online"},
+		Role:    "ingestion-events",
+		Shard:   "3",
+		Replica: "a",
+	}
+	assert.Equal(t, "data", groupKey(n, []string{"hostClusterRole"}))
+	assert.Equal(t, "data/online", groupKey(n, []string{"hostClusterRole", "hostClusterType"}))
+	assert.Equal(t, "ingestion-events", groupKey(n, []string{"role"}))
+	assert.Equal(t, "3/a", groupKey(n, []string{"shard", "replica"}))
+	assert.Equal(t, "(none)", groupKey(n, []string{"missingMacro"}))
+}
+
+func TestSummarizeChanges(t *testing.T) {
+	cs := hclload.ChangeSet{
+		Databases: []hclload.DatabaseChange{{
+			Database:             "posthog",
+			AddTables:            []hclload.TableSpec{{Name: "a"}},
+			AlterTables:          []hclload.TableDiff{{Table: "b"}, {Table: "c"}},
+			AddMaterializedViews: []hclload.MaterializedViewSpec{{Name: "mv"}},
+		}},
+	}
+	assert.Equal(t, "+1 table, ~2 table, +1 mv", summarizeChanges(cs))
+	assert.Equal(t, "changed", summarizeChanges(hclload.ChangeSet{}))
+}
+
+func TestLoadAndGroupDriftNodes(t *testing.T) {
+	nodes, err := loadDriftNodes(filepath.Join("testdata", "drift"))
+	require.NoError(t, err)
+	require.Len(t, nodes, 4)
+
+	groups, order := groupNodes(nodes, []string{"hostClusterRole"})
+	assert.Equal(t, []string{"role1", "role2"}, order)
+	require.Len(t, groups["role1"], 3)
+	require.Len(t, groups["role2"], 1)
+
+	// Within role1, shard 3 adds a table; shard 2 matches the reference.
+	byName := map[string]driftNode{}
+	for _, n := range groups["role1"] {
+		byName[n.Name] = n
+	}
+	ref := byName["prod-xx-aaa-ch-1a-role1"]
+	same := byName["prod-xx-aaa-ch-2a-role1"]
+	drifted := byName["prod-xx-aaa-ch-3a-role1"]
+
+	assert.True(t, hclload.Diff(ref.Schema, same.Schema).IsEmpty(), "shard 2 should match reference")
+	assert.False(t, hclload.Diff(ref.Schema, drifted.Schema).IsEmpty(), "shard 3 should drift")
+
+	// Identity is parsed from the node name.
+	assert.Equal(t, "3", drifted.Shard)
+	assert.Equal(t, "role1", drifted.Role)
+}

--- a/cmd/hclexp/drift_test.go
+++ b/cmd/hclexp/drift_test.go
@@ -57,8 +57,28 @@ func TestSummarizeChanges(t *testing.T) {
 	assert.Equal(t, "changed", summarizeChanges(hclload.ChangeSet{}))
 }
 
+func TestLoadDriftNodes_Glob(t *testing.T) {
+	dir := filepath.Join("testdata", "drift")
+
+	all, err := loadDriftNodes(dir, "*")
+	require.NoError(t, err)
+	assert.Len(t, all, 4)
+
+	role2, err := loadDriftNodes(dir, "*-role2*")
+	require.NoError(t, err)
+	require.Len(t, role2, 1)
+	assert.Equal(t, "prod-xx-aaa-ch-1a-role2", role2[0].Name)
+
+	none, err := loadDriftNodes(dir, "*nomatch*")
+	require.NoError(t, err)
+	assert.Empty(t, none)
+
+	_, err = loadDriftNodes(dir, "[")
+	assert.Error(t, err, "invalid glob should error")
+}
+
 func TestLoadAndGroupDriftNodes(t *testing.T) {
-	nodes, err := loadDriftNodes(filepath.Join("testdata", "drift"))
+	nodes, err := loadDriftNodes(filepath.Join("testdata", "drift"), "*")
 	require.NoError(t, err)
 	require.Len(t, nodes, 4)
 

--- a/cmd/hclexp/hclexp.go
+++ b/cmd/hclexp/hclexp.go
@@ -29,6 +29,9 @@ func main() {
 		case "validate":
 			runValidate(os.Args[2:])
 			return
+		case "drift":
+			runDrift(os.Args[2:])
+			return
 		}
 	}
 	runLoad(os.Args[1:])

--- a/cmd/hclexp/testdata/drift/prod-xx-aaa-ch-1a-role1.hcl
+++ b/cmd/hclexp/testdata/drift/prod-xx-aaa-ch-1a-role1.hcl
@@ -1,0 +1,20 @@
+node "prod-xx-aaa-ch-1a-role1" {
+  macros = {
+    hostClusterRole = "role1"
+    replica         = "a"
+    shard           = "1"
+  }
+}
+
+database "posthog" {
+  table "events" {
+    column "team_id" {
+      type = "Int64"
+    }
+
+    engine "merge_tree" {
+    }
+
+    order_by = ["team_id"]
+  }
+}

--- a/cmd/hclexp/testdata/drift/prod-xx-aaa-ch-1a-role2.hcl
+++ b/cmd/hclexp/testdata/drift/prod-xx-aaa-ch-1a-role2.hcl
@@ -1,0 +1,20 @@
+node "prod-xx-aaa-ch-1a-role2" {
+  macros = {
+    hostClusterRole = "role2"
+    replica         = "a"
+    shard           = "1"
+  }
+}
+
+database "posthog" {
+  table "logs" {
+    column "ts" {
+      type = "DateTime"
+    }
+
+    engine "merge_tree" {
+    }
+
+    order_by = ["ts"]
+  }
+}

--- a/cmd/hclexp/testdata/drift/prod-xx-aaa-ch-2a-role1.hcl
+++ b/cmd/hclexp/testdata/drift/prod-xx-aaa-ch-2a-role1.hcl
@@ -1,0 +1,20 @@
+node "prod-xx-aaa-ch-2a-role1" {
+  macros = {
+    hostClusterRole = "role1"
+    replica         = "a"
+    shard           = "2"
+  }
+}
+
+database "posthog" {
+  table "events" {
+    column "team_id" {
+      type = "Int64"
+    }
+
+    engine "merge_tree" {
+    }
+
+    order_by = ["team_id"]
+  }
+}

--- a/cmd/hclexp/testdata/drift/prod-xx-aaa-ch-3a-role1.hcl
+++ b/cmd/hclexp/testdata/drift/prod-xx-aaa-ch-3a-role1.hcl
@@ -1,0 +1,31 @@
+node "prod-xx-aaa-ch-3a-role1" {
+  macros = {
+    hostClusterRole = "role1"
+    replica         = "a"
+    shard           = "3"
+  }
+}
+
+database "posthog" {
+  table "events" {
+    column "team_id" {
+      type = "Int64"
+    }
+
+    engine "merge_tree" {
+    }
+
+    order_by = ["team_id"]
+  }
+
+  table "extra" {
+    column "id" {
+      type = "Int64"
+    }
+
+    engine "merge_tree" {
+    }
+
+    order_by = ["id"]
+  }
+}

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -23,7 +23,7 @@ is just three layer directories passed to the loader in that order.
 
 ## Top-level blocks
 
-Every file declares one or more `database` blocks. Within a database, the
+Most files declare one or more `database` blocks. Within a database, the
 allowed children are `table`, `patch_table`, `materialized_view`, `view`,
 and `dictionary`.
 
@@ -33,6 +33,10 @@ database "posthog" {
   patch_table "events"  { ... }
 }
 ```
+
+Two other blocks live at the top level, as siblings of `database`:
+`named_collection` (cluster-scoped config bags) and `node` (per-node
+identity captured by `hclexp introspect`; see [`node`](#node)).
 
 ## `table`
 
@@ -317,6 +321,36 @@ hclexp validate -config schema.hcl -skip-validation='*'
 the generated DDL, a table is created before any Distributed table that
 forwards to it, and dropped after it.
 
+## Cross-node drift — `hclexp drift`
+
+`hclexp drift -dir <dir>` compares the per-node dumps in a directory and
+reports where nodes that should share a schema diverge. Each dump is one
+node (carrying its [`node`](#node) block); nodes are grouped, then every
+node in a group is diffed — using the same engine as `hclexp diff` —
+against the group's lexically-first **reference** node.
+
+```sh
+hclexp drift -dir prod/eu                              # group by hostClusterRole macro
+hclexp drift -dir prod/eu -glob '*ingestion-small*'    # one pool only
+hclexp drift -dir prod/eu -group-by role -details      # finer grouping + full diffs
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `-dir`      | —                 | directory of per-node `.hcl` dumps (required) |
+| `-glob`     | `*`               | filename glob selecting dumps within `-dir` |
+| `-group-by` | `hostClusterRole` | comma-separated grouping keys: macro names, or the pseudo-keys `role`/`shard`/`replica` parsed from the node name |
+| `-details`  | off               | print each drifting node's full change set, not just a one-line summary |
+
+A drifting node is printed as `✗ <name>: <summary>` (e.g. `+16 table, -8
+table, +8 mv`); a fully consistent group prints `OK (all identical)`. The
+command exits non-zero when any drift is found, so it works as a CI guard.
+
+`hostClusterRole` is coarse and can merge distinct pools (`ingestion`
+spans ingestion-events / -medium / -small; `data` spans online and offline
+nodes). `-group-by role` uses the deployment role from the node name and
+usually isolates genuine drift.
+
 ## `view`
 
 A `view` block declares a ClickHouse **plain** (non-materialized) view — a
@@ -354,6 +388,33 @@ requires drop-and-recreate and is flagged unsafe.
 
 **Not supported.** Live views, refreshable materialized views, and window
 views fail introspection with a clear error.
+
+## `node`
+
+A `node` block is metadata, not a managed object. `hclexp introspect`
+emits one at the top of each per-node dump to record that node's identity:
+the hostname (the block label) and its ClickHouse macros, read from
+`SELECT * FROM system.macros`.
+
+```hcl
+node "prod-eu-fra-ch-1d-ops" {
+  macros = {
+    hostClusterRole = "ops"
+    hostClusterType = "online"
+    replica         = "d"
+    shard           = "1"
+  }
+}
+```
+
+| Attribute | Required | Meaning |
+|-----------|----------|---------|
+| label     | yes      | node hostname (defaults to the server's `hostName()` on introspect; override with `-node`) |
+| `macros`  | no       | key/value bag from `system.macros` (`shard`, `replica`, `hostClusterRole`, `hostClusterType`, …) |
+
+`node` blocks are ignored by `hclexp diff` — they're identity, not schema.
+Their purpose is to let [`hclexp drift`](#cross-node-drift--hclexp-drift)
+group nodes by their authoritative macros.
 
 ## Virtual columns
 


### PR DESCRIPTION
## What

A new `hclexp drift` subcommand that compares the per-node HCL dumps in a directory, groups nodes expected to share a schema, and reports drift within each group. Exits non-zero when any drift is found (CI guard).

```
hclexp drift -dir prod/eu [-glob '*ingestion-small*'] [-group-by role] [-details]
```

- **`-dir`** — directory of per-node `.hcl` dumps (required).
- **`-glob`** — filename glob selecting dumps within `-dir` (default `*`), e.g. compare a single pool: `-glob '*ingestion-small*'`.
- **`-group-by`** (default `hostClusterRole`) — comma-separated keys resolved against each node's macros, or the pseudo-keys `role`/`shard`/`replica` parsed from the node name.
- **`-details`** — expand the full ChangeSet per drifting node.

Comparison uses the existing `hclload.Diff` against the lexically-first reference node in each group. Identity comes from the `node{}` block (macros) added in #31, with shard/replica/role also parsed from the node name.

## Results on the real EU dump

Default (`hostClusterRole`): small pools (ops/logs/sessions/aux/ai_events/batch_exports) are identical; coarse roles lump distinct pools together. `-group-by role` isolates **genuine** drift — ingestion-events/medium/small each become internally identical, replicas within a shard agree, and shard 1 differs from shards 2-8 in the online/offline data pools (leftover snapshot table, `SETTINGS` differences, engine changes).

## Docs

- `README.md`: "Detect cross-node drift" section (usage, flags, example output, grouping tip) + `-node` introspect flag + node-block note.
- `docs/README.hcl.md`: `node` block reference and "Cross-node drift — hclexp drift" section; top-level-blocks intro updated.

## Tests

`drift_test.go` covers `parseNodeIdentity`, `groupKey`, `summarizeChanges`, `-glob` selection (match/no-match/invalid), and an end-to-end `loadDriftNodes` + `groupNodes` + `Diff` over `testdata/drift/`. `go test ./...` → **465 passed**.

## Follow-up ideas (not in this PR)

- Normalize per-shard `{shard}`/`{replica}` so ReplicatedMergeTree zoo_path differences across shards aren't flagged (the `replicated_merge_tree -> replicated_merge_tree` lines).
- Smarter default grouping (filename role with macro fallback) once the coarse-macro behavior is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)