### PR TITLE
drift: zoo_path normalization (-zk-paths) + multi-pattern -glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,12 @@ when any drift is found, so it doubles as a CI guard.
 **Flags:**
 
 - `-dir` — directory of per-node `.hcl` dumps to compare (required)
-- `-glob` — filename glob selecting dumps within `-dir` (default `*`),
-  e.g. `'*ingestion-small*'`
+- `-glob` — comma-separated filename globs selecting dumps within `-dir`
+  (default `*`); a file is included if it matches **any** pattern. Use it
+  to hand-pick exactly the nodes you want compared, e.g.
+  `'*ingestion-small*'` for one pool, or `'*-ch-*[fg].hcl,*-offline.hcl'`
+  to pull all DATA nodes (online `f`/`g` replicas plus offline `h`)
+  together into one comparison.
 - `-group-by` — comma-separated keys to group nodes by (default
   `hostClusterRole`). Each key is looked up first in the node's macros,
   then as one of the pseudo-keys `role` / `shard` / `replica` parsed from

--- a/README.md
+++ b/README.md
@@ -243,6 +243,16 @@ when any drift is found, so it doubles as a CI guard.
   then as one of the pseudo-keys `role` / `shard` / `replica` parsed from
   the node name (`prod-<region>-<az>-ch-<shard><replica>[-<role>]`).
   Examples: `-group-by role`, `-group-by hostClusterRole,hostClusterType`.
+- `-zk-paths` — how to treat ReplicatedMergeTree `zoo_path` before diffing
+  (default `mask-uuid`):
+  - `mask-uuid` — replace the literal table UUID with the `{uuid}` macro.
+    ClickHouse expands `{uuid}` to the table's own UUID at `CREATE` time
+    (while keeping `{shard}`/`{replica}` as macros), so the same table on
+    different shards otherwise looks like drift. Masking compares the
+    *intended* path; genuine differences (e.g. a different database in the
+    path) still drift.
+  - `keep` — compare paths verbatim (no normalization).
+  - `ignore` — blank `zoo_path`/`replica_name` entirely.
 - `-details` — print the full change set of each drifting node against its
   group reference, instead of just the one-line summary
 

--- a/cmd/hclexp/drift.go
+++ b/cmd/hclexp/drift.go
@@ -5,12 +5,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
 
 	hclload "github.com/posthog/chschema/internal/loader/hcl"
 )
+
+// zkUUIDRe matches a table UUID embedded in a ReplicatedMergeTree zoo_path.
+// ClickHouse expands the {uuid} macro to the table's literal UUID at CREATE
+// time (while keeping {shard}/{replica} as macros), so the same logical
+// table gets a different path on every shard — noise for cross-node drift.
+var zkUUIDRe = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
 
 // driftNode is one per-node dump loaded for drift analysis: its identity
 // (from the node{} block and/or the filename) plus its resolved schema.
@@ -38,6 +45,7 @@ func runDrift(args []string) {
 	dirFlag := fs.String("dir", "", "directory of per-node .hcl dumps to compare")
 	globFlag := fs.String("glob", "*", "filename glob to select dumps within -dir, e.g. '*ingestion-small*'")
 	groupByFlag := fs.String("group-by", "hostClusterRole", "comma-separated keys to group nodes by: macro names, or the pseudo-keys role/shard/replica")
+	zkFlag := fs.String("zk-paths", "mask-uuid", "treat ReplicatedMergeTree zoo_path before diffing: keep | mask-uuid | ignore")
 	details := fs.Bool("details", false, "print the full change set of each drifting node against its group reference")
 	_ = fs.Parse(args)
 
@@ -45,11 +53,20 @@ func runDrift(args []string) {
 		fmt.Fprintln(os.Stderr, "drift: -dir is required")
 		os.Exit(2)
 	}
+	switch *zkFlag {
+	case "keep", "mask-uuid", "ignore":
+	default:
+		fmt.Fprintf(os.Stderr, "drift: invalid -zk-paths %q (want keep|mask-uuid|ignore)\n", *zkFlag)
+		os.Exit(2)
+	}
 
 	nodes, err := loadDriftNodes(*dirFlag, *globFlag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "drift: %v\n", err)
 		os.Exit(1)
+	}
+	for i := range nodes {
+		normalizeZKPaths(nodes[i].Schema, *zkFlag)
 	}
 	if len(nodes) == 0 {
 		fmt.Fprintf(os.Stderr, "drift: no .hcl files in %s match %q\n", *dirFlag, *globFlag)
@@ -153,6 +170,59 @@ func loadDriftNodes(dir, glob string) ([]driftNode, error) {
 		nodes = append(nodes, n)
 	}
 	return nodes, nil
+}
+
+// normalizeZKPaths rewrites every table's ReplicatedMergeTree zoo_path in
+// schema according to mode, so per-node path noise doesn't register as
+// drift:
+//
+//   - keep      — leave paths untouched (raw comparison)
+//   - mask-uuid — replace the literal table UUID with the {uuid} macro,
+//     so the same table on different shards compares equal while genuine
+//     path differences (e.g. a different database) still drift
+//   - ignore    — blank zoo_path and replica_name entirely
+func normalizeZKPaths(schema *hclload.Schema, mode string) {
+	if schema == nil || mode == "keep" {
+		return
+	}
+	for di := range schema.Databases {
+		tables := schema.Databases[di].Tables
+		for ti := range tables {
+			t := &tables[ti]
+			if t.Engine == nil || t.Engine.Decoded == nil {
+				continue
+			}
+			t.Engine.Decoded = normalizeEngineZK(t.Engine.Decoded, mode)
+		}
+	}
+}
+
+// normalizeEngineZK returns dec with its ZooPath (and, for ignore mode,
+// ReplicaName) rewritten per mode. Engines without a ZooPath field are
+// returned unchanged. It works across all ReplicatedMergeTree variants via
+// reflection on the shared field names.
+func normalizeEngineZK(dec hclload.Engine, mode string) hclload.Engine {
+	v := reflect.ValueOf(dec)
+	if v.Kind() != reflect.Struct {
+		return dec
+	}
+	cp := reflect.New(v.Type()).Elem()
+	cp.Set(v)
+
+	zp := cp.FieldByName("ZooPath")
+	if !zp.IsValid() || zp.Kind() != reflect.String || !zp.CanSet() {
+		return dec
+	}
+	switch mode {
+	case "mask-uuid":
+		zp.SetString(zkUUIDRe.ReplaceAllString(zp.String(), "{uuid}"))
+	case "ignore":
+		zp.SetString("")
+		if rn := cp.FieldByName("ReplicaName"); rn.IsValid() && rn.Kind() == reflect.String && rn.CanSet() {
+			rn.SetString("")
+		}
+	}
+	return cp.Interface().(hclload.Engine)
 }
 
 // parseNodeIdentity extracts shard, replica, and deployment role from a

--- a/cmd/hclexp/drift.go
+++ b/cmd/hclexp/drift.go
@@ -43,7 +43,7 @@ var nodeNameRe = regexp.MustCompile(`^[a-z]+-[a-z]+-[a-z]+-ch-([0-9]+)([a-z])(?:
 func runDrift(args []string) {
 	fs := flag.NewFlagSet("hclexp drift", flag.ExitOnError)
 	dirFlag := fs.String("dir", "", "directory of per-node .hcl dumps to compare")
-	globFlag := fs.String("glob", "*", "filename glob to select dumps within -dir, e.g. '*ingestion-small*'")
+	globFlag := fs.String("glob", "*", "comma-separated filename globs selecting dumps within -dir; a file matching any pattern is included, e.g. '*[fg].hcl,*-offline.hcl' for all data nodes")
 	groupByFlag := fs.String("group-by", "hostClusterRole", "comma-separated keys to group nodes by: macro names, or the pseudo-keys role/shard/replica")
 	zkFlag := fs.String("zk-paths", "mask-uuid", "treat ReplicatedMergeTree zoo_path before diffing: keep | mask-uuid | ignore")
 	details := fs.Bool("details", false, "print the full change set of each drifting node against its group reference")
@@ -125,16 +125,19 @@ func runDrift(args []string) {
 }
 
 // loadDriftNodes parses and resolves every .hcl file in dir whose base name
-// matches glob into a driftNode, taking identity from the file's node{}
-// block when present and otherwise from the filename. An empty glob matches
-// every .hcl file.
+// matches any of the comma-separated globs into a driftNode, taking identity
+// from the file's node{} block when present and otherwise from the filename.
+// An empty glob matches every .hcl file.
 func loadDriftNodes(dir, glob string) ([]driftNode, error) {
-	if glob == "" {
-		glob = "*"
+	globs := splitList(glob)
+	if len(globs) == 0 {
+		globs = []string{"*"}
 	}
 	// Fail fast on an invalid pattern rather than silently matching nothing.
-	if _, err := filepath.Match(glob, ""); err != nil {
-		return nil, fmt.Errorf("invalid -glob %q: %w", glob, err)
+	for _, g := range globs {
+		if _, err := filepath.Match(g, ""); err != nil {
+			return nil, fmt.Errorf("invalid -glob %q: %w", g, err)
+		}
 	}
 
 	entries, err := os.ReadDir(dir)
@@ -146,7 +149,7 @@ func loadDriftNodes(dir, glob string) ([]driftNode, error) {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".hcl" {
 			continue
 		}
-		if ok, _ := filepath.Match(glob, e.Name()); !ok {
+		if !matchesAny(globs, e.Name()) {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())
@@ -223,6 +226,16 @@ func normalizeEngineZK(dec hclload.Engine, mode string) hclload.Engine {
 		}
 	}
 	return cp.Interface().(hclload.Engine)
+}
+
+// matchesAny reports whether name matches at least one of the globs.
+func matchesAny(globs []string, name string) bool {
+	for _, g := range globs {
+		if ok, _ := filepath.Match(g, name); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // parseNodeIdentity extracts shard, replica, and deployment role from a

--- a/cmd/hclexp/drift_test.go
+++ b/cmd/hclexp/drift_test.go
@@ -73,8 +73,17 @@ func TestLoadDriftNodes_Glob(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, none)
 
-	_, err = loadDriftNodes(dir, "[")
-	assert.Error(t, err, "invalid glob should error")
+	// Comma-separated globs union their matches.
+	union, err := loadDriftNodes(dir, "*-role2*,*-3a-*")
+	require.NoError(t, err)
+	names := make([]string, len(union))
+	for i, n := range union {
+		names[i] = n.Name
+	}
+	assert.ElementsMatch(t, []string{"prod-xx-aaa-ch-1a-role2", "prod-xx-aaa-ch-3a-role1"}, names)
+
+	_, err = loadDriftNodes(dir, "*-role2*,[")
+	assert.Error(t, err, "an invalid pattern in the list should error")
 }
 
 func TestNormalizeZKPaths(t *testing.T) {

--- a/cmd/hclexp/drift_test.go
+++ b/cmd/hclexp/drift_test.go
@@ -77,6 +77,53 @@ func TestLoadDriftNodes_Glob(t *testing.T) {
 	assert.Error(t, err, "invalid glob should error")
 }
 
+func TestNormalizeZKPaths(t *testing.T) {
+	schemaWithZK := func(path string) *hclload.Schema {
+		return &hclload.Schema{Databases: []hclload.DatabaseSpec{{
+			Name: "posthog",
+			Tables: []hclload.TableSpec{{
+				Name:    "t",
+				Columns: []hclload.ColumnSpec{{Name: "id", Type: "Int64"}},
+				OrderBy: []string{"id"},
+				Engine: &hclload.EngineSpec{
+					Kind: "replicated_merge_tree",
+					Decoded: hclload.EngineReplicatedMergeTree{
+						ZooPath:     path,
+						ReplicaName: "{replica}",
+					},
+				},
+			}},
+		}}}
+	}
+	uuidA := "/clickhouse/tables/3e6d8f0a-13bc-433c-9173-9ec7d4deb230_noshard/posthog.t"
+	uuidB := "/clickhouse/tables/7695bea2-a760-4ff1-9f2e-d33cb4de53dd_noshard/posthog.t"
+
+	// keep: UUID-only difference shows as drift.
+	assert.False(t, hclload.Diff(schemaWithZK(uuidA), schemaWithZK(uuidB)).IsEmpty(),
+		"raw paths with different UUIDs should differ")
+
+	// mask-uuid: the same logical table compares equal.
+	na, nb := schemaWithZK(uuidA), schemaWithZK(uuidB)
+	normalizeZKPaths(na, "mask-uuid")
+	normalizeZKPaths(nb, "mask-uuid")
+	assert.True(t, hclload.Diff(na, nb).IsEmpty(),
+		"mask-uuid should collapse UUID-only path differences")
+
+	// mask-uuid: a genuine path difference still drifts.
+	ga := schemaWithZK("/clickhouse/tables/{shard}/posthog.t")
+	gb := schemaWithZK("/clickhouse/tables/{shard}/other.t")
+	normalizeZKPaths(ga, "mask-uuid")
+	normalizeZKPaths(gb, "mask-uuid")
+	assert.False(t, hclload.Diff(ga, gb).IsEmpty(),
+		"non-UUID path differences must still register as drift")
+
+	// ignore: any path difference is erased.
+	ia, ib := schemaWithZK(uuidA), schemaWithZK("/clickhouse/tables/{shard}/other.t")
+	normalizeZKPaths(ia, "ignore")
+	normalizeZKPaths(ib, "ignore")
+	assert.True(t, hclload.Diff(ia, ib).IsEmpty(), "ignore should erase all zoo_path differences")
+}
+
 func TestLoadAndGroupDriftNodes(t *testing.T) {
 	nodes, err := loadDriftNodes(filepath.Join("testdata", "drift"), "*")
 	require.NoError(t, err)

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -338,7 +338,7 @@ hclexp drift -dir prod/eu -group-by role -details      # finer grouping + full d
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `-dir`      | —                 | directory of per-node `.hcl` dumps (required) |
-| `-glob`     | `*`               | filename glob selecting dumps within `-dir` |
+| `-glob`     | `*`               | comma-separated filename globs selecting dumps within `-dir` (a file matching any pattern is included); e.g. `*-ch-*[fg].hcl,*-offline.hcl` to compare all DATA nodes together |
 | `-group-by` | `hostClusterRole` | comma-separated grouping keys: macro names, or the pseudo-keys `role`/`shard`/`replica` parsed from the node name |
 | `-zk-paths` | `mask-uuid`       | ReplicatedMergeTree `zoo_path` handling: `mask-uuid` (replace the literal table UUID with `{uuid}`), `keep` (verbatim), or `ignore` (blank path + replica) |
 | `-details`  | off               | print each drifting node's full change set, not just a one-line summary |

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -340,7 +340,14 @@ hclexp drift -dir prod/eu -group-by role -details      # finer grouping + full d
 | `-dir`      | —                 | directory of per-node `.hcl` dumps (required) |
 | `-glob`     | `*`               | filename glob selecting dumps within `-dir` |
 | `-group-by` | `hostClusterRole` | comma-separated grouping keys: macro names, or the pseudo-keys `role`/`shard`/`replica` parsed from the node name |
+| `-zk-paths` | `mask-uuid`       | ReplicatedMergeTree `zoo_path` handling: `mask-uuid` (replace the literal table UUID with `{uuid}`), `keep` (verbatim), or `ignore` (blank path + replica) |
 | `-details`  | off               | print each drifting node's full change set, not just a one-line summary |
+
+ClickHouse expands the `{uuid}` macro to the table's literal UUID at
+`CREATE` time (while keeping `{shard}`/`{replica}` as macros), so the same
+table on different shards gets a different `zoo_path` — pure noise for
+drift. The default `-zk-paths=mask-uuid` collapses that back to `{uuid}`
+so only genuine path differences register.
 
 A drifting node is printed as `✗ <name>: <summary>` (e.g. `+16 table, -8
 table, +8 mv`); a fully consistent group prints `OK (all identical)`. The


### PR DESCRIPTION
Two refinements to `hclexp drift`, found while investigating real EU drift.

## 1. `-zk-paths` — normalize ReplicatedMergeTree zoo_path

| mode | behavior |
|------|----------|
| `mask-uuid` (default) | replace the literal table UUID in `zoo_path` with the `{uuid}` macro |
| `keep` | compare paths verbatim |
| `ignore` | blank `zoo_path` + `replica_name` entirely |

**Why:** ClickHouse expands the `{uuid}` macro to a table's literal UUID at `CREATE` time (keeping `{shard}`/`{replica}` as macros), so the same logical table gets a different `zoo_path` on every shard. That accounted for **42 of the EU engine diffs** (`replicated_merge_tree -> replicated_merge_tree`, everything else equal). Masking compares the *intended* path; genuine differences (e.g. a different database) still drift.

Impact on EU (`-group-by role`): drifting nodes 21 → 19, engine-noise lines 42 → 0.

## 2. `-glob` accepts comma-separated patterns (union)

A file is included if its base name matches **any** of the patterns, so the user hand-picks the comparison set instead of relying on grouping heuristics:

```
# all DATA nodes (online f/g replicas + offline h) in one comparison
hclexp drift -dir prod/eu -glob '*-ch-*[fg].hcl,*-offline.hcl'
→ group "data" — 24 nodes, reference prod-eu-fra-ch-1f
```

An invalid pattern anywhere in the list fails fast.

## Implementation

- `normalizeZKPaths` rewrites `ZooPath`/`ReplicaName` on the decoded engine via reflection (covers all 5 Replicated* variants); `diffEngine` compares `Decoded` with `reflect.DeepEqual`, so the rewrite suppresses the false `EngineChange`.
- `-glob` splits on comma; `matchesAny` unions the matches.

## Tests

`TestNormalizeZKPaths` (keep/mask-uuid/ignore + genuine-diff-still-drifts) and an extended `TestLoadDriftNodes_Glob` (single, union, no-match, invalid-in-list). `go test ./...` → **466 passed**. Docs updated in `README.md` and `docs/README.hcl.md`.

> Builds on the drift command from #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)