### PR TITLE
Add shell-capable "ops" container image (hclexp + sh/git/curl)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,3 +52,32 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    # ---- ops image (hclexp + sh + git + curl) ----
+    # Separate image name with its own clean tag stream; published alongside
+    # the distroless image above. Uses a distinct gha cache scope so the two
+    # builds don't clobber each other's cache.
+    - name: Ops image metadata (tags + labels)
+      id: meta-ops
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+      with:
+        images: ghcr.io/posthog/chschema-ops
+        tags: |
+          type=ref,event=branch
+          type=sha,format=short,prefix=sha-
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+
+    - name: Build and push ops (linux/amd64,linux/arm64)
+      uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
+      with:
+        context: .
+        target: ops
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta-ops.outputs.tags }}
+        labels: ${{ steps.meta-ops.outputs.labels }}
+        cache-from: type=gha,scope=ops
+        cache-to: type=gha,mode=max,scope=ops

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,23 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags="-s -w" \
     -o /out/hclexp ./cmd/hclexp
 
-# ---- Runtime stage ----
+# ---- Ops runtime (shell-capable: sh + git + curl) ----
+# Built only on demand with `docker build --target ops .`. Intended as a
+# deployment-time schema-dump hook: a Kubernetes Job runs `hclexp introspect`
+# per ClickHouse node and git-commits the output, so it needs a shell, git,
+# and curl that the distroless image deliberately lacks.
+FROM alpine:3.20.3 AS ops
+RUN apk add --no-cache git curl ca-certificates \
+    && addgroup -S hclexp \
+    && adduser -S -G hclexp -h /home/hclexp -s /bin/sh hclexp
+COPY --from=build /out/hclexp /usr/local/bin/hclexp
+USER hclexp
+ENTRYPOINT ["/usr/local/bin/hclexp"]
+
+# ---- Runtime stage (distroless; default) ----
+# Kept LAST on purpose: a plain `docker build .` (no --target) resolves to the
+# final stage, so this remains the default image — minimal, no shell, just the
+# static binary. Do not move the ops stage below this one.
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/hclexp /hclexp
 USER nonroot:nonroot

--- a/README.md
+++ b/README.md
@@ -295,19 +295,35 @@ hclexp diff \
   -right 'clickhouse://ro:secret@ch.prod.internal:9440/posthog?secure=true&skip-verify=true'
 ```
 
-## Container image
+## Container images
 
-`hclexp` ships as a minimal multi-arch container image — distroless, no
-shell, no AWS CLI, no extras. It's built and pushed on every `main` push
-and Git tag.
+Two multi-arch (`linux/amd64`, `linux/arm64`) images are built and pushed
+on every `main` push and Git tag. Both bundle the same static `hclexp`
+binary and share one tag stream each:
 
-- Registry: [`ghcr.io/posthog/chschema`](https://github.com/PostHog/chschema/pkgs/container/chschema)
-  (GitHub Container Registry; the chschema repo is public, so the image
-  is publicly pullable without authentication)
-- Architectures: `linux/amd64`, `linux/arm64`
-- Tags:
-  - `main` push → `main` + `sha-<short>` + `latest`
-  - `vX.Y.Z` tag → `X.Y.Z`, `X.Y`, `X`
+- `main` push → `main` + `sha-<short>` + `latest`
+- `vX.Y.Z` tag → `X.Y.Z`, `X.Y`, `X`
+
+| Image | Base | Contents | Use |
+| ----- | ---- | -------- | --- |
+| [`ghcr.io/posthog/chschema`](https://github.com/PostHog/chschema/pkgs/container/chschema) | distroless | `hclexp` only — no shell | default; minimal runtime for diff/introspect |
+| [`ghcr.io/posthog/chschema-ops`](https://github.com/PostHog/chschema/pkgs/container/chschema-ops) | `alpine:3.20` | `hclexp` + `sh`, `git`, `curl`, `ca-certificates` | deploy-time schema-dump hook (needs a shell to git-commit dumps) |
+
+Both packages are published **public** (the repo is public), so an EKS
+cluster can pull them without credentials. If a package is ever flipped to
+private, consumers must attach an `imagePullSecret` holding a GHCR token
+with `read:packages`:
+
+```sh
+kubectl create secret docker-registry ghcr-pull \
+  --docker-server=ghcr.io --docker-username=<gh-user> \
+  --docker-password=<PAT-with-read:packages>
+# then reference it via the workload's imagePullSecrets / serviceAccount
+```
+
+### `chschema` (distroless, default)
+
+Minimal — distroless, no shell, no AWS CLI, no extras.
 
 ```sh
 # Print usage
@@ -323,17 +339,35 @@ docker run --rm \
   introspect -database posthog,system -out /dump
 ```
 
-The image is intended to be paired with `amazon/aws-cli` (or any other
-uploader) via a shared `emptyDir` volume in the consuming workload. The
-deployment pattern that drives the design lives in
-[`posthog/charts`](https://github.com/PostHog/charts) — `hclexp` writes
-HCL to the shared volume, the sidecar pushes it to S3.
+It can be paired with `amazon/aws-cli` (or any other uploader) via a shared
+`emptyDir` volume — `hclexp` writes HCL to the volume, the sidecar ships it.
 
-To build the image locally:
+### `chschema-ops` (shell-capable)
+
+Same binary plus `sh`, `git`, and `curl`. It exists for the deploy-time
+**schema-dump hook**: a Kubernetes Job in
+[`posthog/charts`](https://github.com/PostHog/charts) (the
+`clickhouse-schema-dump` PostSync hook) runs `hclexp introspect` against
+each ClickHouse node and then `git`-commits the dumped HCL — which needs a
+shell, git, and curl that the distroless image deliberately omits. The
+`ENTRYPOINT` is still `hclexp`; override it (e.g. `--entrypoint sh`) to run
+the surrounding dump-and-commit script.
 
 ```sh
+docker run --rm --entrypoint sh ghcr.io/posthog/chschema-ops:latest -c \
+  'hclexp introspect -database posthog -out /work && cd /work && git ...'
+```
+
+### Building locally
+
+```sh
+# Default (distroless)
 docker build -t hclexp:dev .
 docker run --rm hclexp:dev -help
+
+# Ops image
+docker build --target ops -t chschema-ops:dev .
+docker run --rm --entrypoint sh chschema-ops:dev -c 'hclexp -h; git --version'
 ```
 
 ## HCL schema format


### PR DESCRIPTION
## What

Adds a second container image, **`ghcr.io/posthog/chschema-ops`**, alongside the existing distroless `chschema` image. It bundles the same static `hclexp` binary on `alpine:3.20` with `sh`, `git`, `curl`, and `ca-certificates` (running as a non-root `hclexp` user).

## Why

It's consumed by PostHog/charts' **`clickhouse-schema-dump` PostSync hook** — a Kubernetes Job that runs `hclexp introspect` against each ClickHouse node and then `git`-commits the dumped HCL. That needs a shell, git, and curl, which the distroless image deliberately omits. Keeping a separate, minimal distroless image as the default avoids bloating the common runtime.

## Changes

- **`Dockerfile`** — now multi-stage with a new `ops` target reusing the existing `build` stage. The distroless stage is kept **last** so a plain `docker build .` (no `--target`) still produces the unchanged distroless image; `docker build --target ops .` produces the ops image.
- **`.github/workflows/publish.yml`** — a second `metadata-action` + `build-push-action` pair publishes `chschema-ops` (multi-arch `amd64`/`arm64`, same triggers/tag rules as the distroless image) with `target: ops` and its own gha cache scope so it doesn't clobber the existing build's cache. The existing distroless publish is untouched.
- **`README.md`** — "Container images" section now documents both images, their contents, and the ops image's intended use; plus a note that both GHCR packages are published public (with the `imagePullSecret` fallback if ever made private).

## Image visibility

The `chschema-ops` GHCR package is created on first publish from `main`. Since the repo is public, its visibility should be confirmed **public** in the package settings so an EKS cluster can pull it without credentials (matching the existing `chschema` package). The README documents the `imagePullSecret` consumers would need if it's ever private.

## Verification

- `docker build --target ops -t chschema-ops:test .` ✅
- `docker run --rm --entrypoint sh chschema-ops:test -c 'hclexp -h; git --version; curl --version; echo OK'` → hclexp usage, `git version 2.45.4`, `curl 8.14.1`, `OK` ✅ (runs as non-root `hclexp`)
- `docker build .` (no target) → distroless unchanged (`User=nonroot:nonroot`, `Entrypoint=[/hclexp]`, no shell) ✅
- `actionlint` on the workflow → clean (only the pre-existing `depot-ubuntu-24.04` custom-runner-label note) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)