### PR TITLE
hclexp: print help and command list when run with no arguments

### DIFF
--- a/cmd/hclexp/hclexp.go
+++ b/cmd/hclexp/hclexp.go
@@ -18,23 +18,62 @@ import (
 )
 
 func main() {
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "introspect":
-			runIntrospect(os.Args[2:])
-			return
-		case "diff":
-			runDiff(os.Args[2:])
-			return
-		case "validate":
-			runValidate(os.Args[2:])
-			return
-		case "drift":
-			runDrift(os.Args[2:])
-			return
-		}
+	if len(os.Args) <= 1 {
+		usage(os.Stdout)
+		return
 	}
-	runLoad(os.Args[1:])
+
+	switch os.Args[1] {
+	case "-h", "--help", "help":
+		usage(os.Stdout)
+		return
+	case "introspect":
+		runIntrospect(os.Args[2:])
+		return
+	case "diff":
+		runDiff(os.Args[2:])
+		return
+	case "validate":
+		runValidate(os.Args[2:])
+		return
+	case "drift":
+		runDrift(os.Args[2:])
+		return
+	case "load":
+		runLoad(os.Args[2:])
+		return
+	}
+
+	// A flag as the first argument (e.g. -config, -layer) is the
+	// backward-compatible way to invoke the default load behavior.
+	if strings.HasPrefix(os.Args[1], "-") {
+		runLoad(os.Args[1:])
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "hclexp: unknown command %q\n\n", os.Args[1])
+	usage(os.Stderr)
+	os.Exit(2)
+}
+
+// usage prints a short description of hclexp and its available subcommands.
+func usage(w io.Writer) {
+	fmt.Fprint(w, `hclexp manages ClickHouse schemas declaratively from HCL.
+
+Usage:
+  hclexp <command> [flags]
+  hclexp [flags]            run the default load behavior
+
+Commands:
+  introspect   dump a live ClickHouse schema as canonical HCL
+  diff         compare two schemas (HCL or live), optionally emit migration DDL
+  validate     check that MV and Distributed dependency references resolve
+  drift        detect cross-node schema drift across per-node HCL dumps
+  load         parse and resolve an HCL config (default when flags are given)
+  help         print this help
+
+Run "hclexp <command> -h" for command-specific flags.
+`)
 }
 
 // runValidate loads an HCL config (single file or layers), resolves it, and

--- a/cmd/hclexp/hclexp_test.go
+++ b/cmd/hclexp/hclexp_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUsage(t *testing.T) {
+	var buf bytes.Buffer
+	usage(&buf)
+	out := buf.String()
+	for _, cmd := range []string{"introspect", "diff", "validate", "drift", "load"} {
+		require.Contains(t, out, cmd)
+	}
+}
+
 func TestApplyTLSFlags(t *testing.T) {
 	t.Run("both off leaves cfg untouched", func(t *testing.T) {
 		cfg := config.ClickHouseConfig{}


### PR DESCRIPTION
## Summary

Bare `hclexp` previously fell through to the default load path, which tried to parse a default config file and logged `"HCL experiment is up"` — confusing for a user just trying to discover what the tool does (and an error if the default config was absent).

Now:
- **no args**, `-h`, `--help`, `help` → print a short description + subcommand list, exit 0
- the default load behavior is reachable as an explicit `load` subcommand, and (for backward compatibility) still runs when the first argument is a flag (e.g. `-config`, `-layer`)
- an **unknown command** prints usage to stderr and exits 2

## Help output

```
hclexp manages ClickHouse schemas declaratively from HCL.

Usage:
  hclexp <command> [flags]
  hclexp [flags]            run the default load behavior

Commands:
  introspect   dump a live ClickHouse schema as canonical HCL
  diff         compare two schemas (HCL or live), optionally emit migration DDL
  validate     check that MV and Distributed dependency references resolve
  drift        detect cross-node schema drift across per-node HCL dumps
  load         parse and resolve an HCL config (default when flags are given)
  help         print this help

Run "hclexp <command> -h" for command-specific flags.
```

## Test plan

- `go test ./cmd/hclexp` — 30 passed, including new `TestUsage` asserting all subcommand names appear in the help text
- Manually exercised: no-args (exit 0), `-h` (exit 0), `help` (exit 0), `bogus` (usage to stderr, exit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)