### PR TITLE
Add raw{} escape hatch for unparseable/unexpressible CREATE DDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ hclexp introspect -host ch.prod.internal -port 9440 -user readonly \
   - omitted → write HCL to stdout
   - a directory → write one `<database>.hcl` per database
   - any other path → write all databases to that single file
+- `-allow-raw` — capture objects whose `CREATE` DDL can't be parsed or
+  expressed as a `raw {}` block instead of failing (see below)
 
 Introspection reads each object's `create_table_query` and parses it with
 the ClickHouse SQL parser, so columns (types, defaults, codecs, comments,
@@ -99,6 +101,16 @@ node's name and ClickHouse macros (`shard`, `replica`, `hostClusterRole`,
 `hostClusterType`, …) read from `system.macros`. It's metadata only —
 `hclexp diff` ignores it — and exists so `hclexp drift` (below) can group
 nodes by their authoritative identity.
+
+Introspection is **strict by default**: an object whose DDL the parser can't
+handle, or that uses an engine/form the HCL model can't express, aborts the
+dump with an error. Pass `-allow-raw` to capture such objects verbatim as
+`raw "<kind>" "<name>" { sql = ... }` escape-hatch blocks (with a warning)
+and continue, so one unusual object never breaks the whole dump.
+`hclexp dump-cluster` takes the same flag. Raw blocks are opaque — diffed as
+text and recreated (`DROP` + `CREATE`) on change, with a `table`-kind change
+flagged `-- UNSAFE`. See [`docs/README.hcl.md`](docs/README.hcl.md#raw) for
+the full reference.
 
 ## Load & resolve an HCL schema
 
@@ -588,6 +600,37 @@ Kinds outside these lists error during introspection with `unsupported dictionar
 **Diff & apply.** ClickHouse has no useful in-place `ALTER DICTIONARY`. `hclexp diff` reports any non-empty change with `~ dictionary <name> (changed: ...)`; `-sql` emits a `CREATE OR REPLACE DICTIONARY` statement, which is the idiomatic ClickHouse update path and is treated as safe.
 
 **`PASSWORD '[HIDDEN]'` caveat.** ClickHouse's `system.tables.create_table_query` redacts secrets, so an introspected dictionary's `password` is the literal string `[HIDDEN]`. Applying a dumped dictionary verbatim will leave it unable to load data from its source. Edit dumped HCL to restore real credentials (or wire secrets through some out-of-band mechanism) before deploying.
+
+### Raw escape hatch
+
+When an object's `CREATE` DDL can't be parsed, or uses an engine/form the HCL
+model doesn't express, capture it verbatim in a `raw` block. The two labels
+mirror Terraform's `resource "<type>" "<name>"` — first the `kind`
+(`table`, `materialized_view`, `view`, or `dictionary`), then the name:
+
+```hcl
+database "posthog" {
+  raw "dictionary" "city_postal_ip_trie" {
+    sql = <<SQL
+CREATE DICTIONARY posthog.city_postal_ip_trie (`prefix` String)
+PRIMARY KEY prefix
+SOURCE(CLICKHOUSE(USER 'reader' QUERY 'SELECT prefix FROM s3(...)'))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(IP_TRIE)
+SQL
+  }
+}
+```
+
+Raw objects are opaque: `hclexp diff` compares the stored `sql` as text and
+renders `+ / - / ~ raw <kind> <name>`; `-sql` emits the `sql` verbatim to
+create and a `DROP` + `CREATE` to change. Recreating a view/dictionary/MV is
+lossless; a **`table`-kind change is flagged `-- UNSAFE`** and its
+destructive DDL is not auto-generated. A declared raw block also satisfies
+dependency references to it (an MV `to_table`, a Distributed `remote_table`).
+`hclexp introspect`/`dump-cluster` only emit raw blocks under `-allow-raw`;
+otherwise an object they can't express is a hard error. Full reference:
+[`docs/README.hcl.md#raw`](docs/README.hcl.md#raw).
 
 ### Named collections
 

--- a/cmd/hclexp/hclexp.go
+++ b/cmd/hclexp/hclexp.go
@@ -181,6 +181,7 @@ func runIntrospect(args []string) {
 	nodeFlag := fs.String("node", "", "node name for the emitted node{} block; defaults to the server's hostName()")
 	secure := fs.Bool("secure", cfg.Secure, "connect to ClickHouse over TLS")
 	skipVerify := fs.Bool("tls-skip-verify", cfg.TLSSkipVerify, "skip TLS certificate verification (requires -secure)")
+	allowRaw := fs.Bool("allow-raw", false, "capture objects whose CREATE DDL cannot be parsed or expressed as a raw{} block instead of failing")
 	_ = fs.Parse(args)
 
 	databases := splitList(*dbFlag)
@@ -204,7 +205,7 @@ func runIntrospect(args []string) {
 	defer conn.Close()
 
 	ctx := context.Background()
-	schema, err := introspectSchema(ctx, conn, databases, *nodeFlag)
+	schema, err := introspectSchema(ctx, conn, databases, *nodeFlag, *allowRaw)
 	if err != nil {
 		slog.Error("failed to introspect schema", "err", err)
 		os.Exit(1)
@@ -221,16 +222,16 @@ func runIntrospect(args []string) {
 // identity — and assembles them into a single *hclload.Schema. The nodeName
 // override is passed through to IntrospectNode (empty string makes it use the
 // server's hostName()). It is shared by runIntrospect and runDumpCluster.
-func introspectSchema(ctx context.Context, conn driver.Conn, databases []string, nodeName string) (*hclload.Schema, error) {
+func introspectSchema(ctx context.Context, conn driver.Conn, databases []string, nodeName string, allowRaw bool) (*hclload.Schema, error) {
 	schema := &hclload.Schema{}
 	for _, name := range databases {
-		spec, err := hclload.Introspect(ctx, conn, name)
+		spec, err := hclload.Introspect(ctx, conn, name, allowRaw)
 		if err != nil {
 			return nil, fmt.Errorf("introspect database %q: %w", name, err)
 		}
 		slog.Info("introspected database", "name", spec.Name,
 			"tables", len(spec.Tables), "materialized_views", len(spec.MaterializedViews),
-			"dictionaries", len(spec.Dictionaries))
+			"dictionaries", len(spec.Dictionaries), "raw", len(spec.Raws))
 		schema.Databases = append(schema.Databases, *spec)
 	}
 
@@ -278,6 +279,7 @@ func runDumpCluster(args []string) {
 	outDirFlag := fs.String("out-dir", "", "directory to write one <short-host>.hcl per node (required)")
 	secure := fs.Bool("secure", cfg.Secure, "connect to ClickHouse over TLS")
 	skipVerify := fs.Bool("tls-skip-verify", cfg.TLSSkipVerify, "skip TLS certificate verification (requires -secure)")
+	allowRaw := fs.Bool("allow-raw", false, "capture objects whose CREATE DDL cannot be parsed or expressed as a raw{} block instead of failing the node")
 	_ = fs.Parse(args)
 
 	databases := splitList(*dbFlag)
@@ -344,7 +346,7 @@ func runDumpCluster(args []string) {
 	for _, h := range hosts {
 		nodeCfg := cfg
 		nodeCfg.Host = h
-		if err := dumpNode(ctx, nodeCfg, databases, *outDirFlag); err != nil {
+		if err := dumpNode(ctx, nodeCfg, databases, *outDirFlag, *allowRaw); err != nil {
 			slog.Warn("failed to dump node; continuing", "host", h, "err", err)
 			failures++
 			continue
@@ -358,7 +360,7 @@ func runDumpCluster(args []string) {
 // dumpNode opens a fresh native connection to one host, introspects the
 // requested databases, and writes the whole schema (all databases + named
 // collections + the node block) to <out-dir>/<short-host>.hcl.
-func dumpNode(ctx context.Context, cfg config.ClickHouseConfig, databases []string, outDir string) error {
+func dumpNode(ctx context.Context, cfg config.ClickHouseConfig, databases []string, outDir string, allowRaw bool) error {
 	conn, err := config.NewConnection(cfg)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
@@ -366,7 +368,7 @@ func dumpNode(ctx context.Context, cfg config.ClickHouseConfig, databases []stri
 	defer conn.Close()
 
 	// Empty node name: let IntrospectNode use the server's own hostName().
-	schema, err := introspectSchema(ctx, conn, databases, "")
+	schema, err := introspectSchema(ctx, conn, databases, "", allowRaw)
 	if err != nil {
 		return err
 	}
@@ -486,7 +488,10 @@ func loadFromClickHouse(uri string) (*hclload.Schema, error) {
 	ctx := context.Background()
 	schema := &hclload.Schema{}
 	for _, name := range databases {
-		spec, err := hclload.Introspect(ctx, conn, name)
+		// Diff's live side stays strict: an unparseable object surfaces as a
+		// diff error rather than being silently captured. Use `introspect
+		// -allow-raw` to materialize raw blocks into HCL first.
+		spec, err := hclload.Introspect(ctx, conn, name, false)
 		if err != nil {
 			return nil, fmt.Errorf("introspect %s: %w", name, err)
 		}
@@ -619,6 +624,19 @@ func renderChangeSet(w io.Writer, cs hclload.ChangeSet) {
 		}
 		for _, dd := range dc.AlterDictionaries {
 			fmt.Fprintf(w, "  ~ dictionary %s (changed: %s)\n", dd.Name, strings.Join(dd.Changed, ", "))
+		}
+		for _, r := range dc.AddRaws {
+			fmt.Fprintf(w, "  + raw %s %s\n", r.Kind, r.Name)
+		}
+		for _, r := range dc.DropRaws {
+			fmt.Fprintf(w, "  - raw %s %s\n", r.Kind, r.Name)
+		}
+		for _, rc := range dc.AlterRaws {
+			if rc.IsUnsafe() {
+				fmt.Fprintf(w, "  ~ raw %s %s (recreate) ! UNSAFE: destroys data\n", rc.Kind, rc.Name)
+			} else {
+				fmt.Fprintf(w, "  ~ raw %s %s (recreate)\n", rc.Kind, rc.Name)
+			}
 		}
 	}
 

--- a/cmd/hclexp/hclexp_test.go
+++ b/cmd/hclexp/hclexp_test.go
@@ -338,6 +338,29 @@ func TestRenderChangeSet_Dictionaries(t *testing.T) {
 	require.Equal(t, want, buf.String())
 }
 
+func TestRenderChangeSet_Raws(t *testing.T) {
+	cs := hclload.ChangeSet{Databases: []hclload.DatabaseChange{{
+		Database: "posthog",
+		AddRaws:  []hclload.RawSpec{{Kind: "dictionary", Name: "new_raw"}},
+		DropRaws: []hclload.RawSpec{{Kind: "view", Name: "old_raw"}},
+		AlterRaws: []hclload.RawChange{
+			{Kind: "dictionary", Name: "safe_raw"},
+			{Kind: "table", Name: "risky_raw"},
+		},
+	}}}
+
+	var buf bytes.Buffer
+	renderChangeSet(&buf, cs)
+
+	want := `database "posthog"
+  + raw dictionary new_raw
+  - raw view old_raw
+  ~ raw dictionary safe_raw (recreate)
+  ~ raw table risky_raw (recreate) ! UNSAFE: destroys data
+`
+	require.Equal(t, want, buf.String())
+}
+
 func TestRenderChangeSet_NamedCollections(t *testing.T) {
 	cs := hclload.ChangeSet{
 		NamedCollections: []hclload.NamedCollectionChange{

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -25,7 +25,7 @@ is just three layer directories passed to the loader in that order.
 
 Most files declare one or more `database` blocks. Within a database, the
 allowed children are `table`, `patch_table`, `materialized_view`, `view`,
-and `dictionary`.
+`dictionary`, and `raw` (the escape hatch; see [`raw`](#raw)).
 
 ```hcl
 database "posthog" {
@@ -395,6 +395,55 @@ requires drop-and-recreate and is flagged unsafe.
 
 **Not supported.** Live views, refreshable materialized views, and window
 views fail introspection with a clear error.
+
+## `raw`
+
+The escape hatch for objects whose `CREATE` DDL the parser cannot handle, or
+that use an engine/form this schema language does not express. The whole
+statement is stored verbatim and round-tripped unchanged. The two labels
+mirror Terraform's `resource "<type>" "<name>"`: the first is the object
+`kind`, the second its name.
+
+```hcl
+database "posthog" {
+  raw "dictionary" "city_postal_ip_trie" {
+    sql = <<SQL
+CREATE DICTIONARY posthog.city_postal_ip_trie (`prefix` String, `city_name` String DEFAULT '')
+PRIMARY KEY prefix
+SOURCE(CLICKHOUSE(USER 'reader' QUERY 'SELECT prefix, city_name FROM s3(...)'))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(IP_TRIE)
+SQL
+  }
+}
+```
+
+| Field  | Meaning |
+|--------|---------|
+| `kind` (1st label) | `table`, `materialized_view`, `view`, or `dictionary`. Drives the `DROP` form on a recreate. |
+| `name` (2nd label) | The object name. |
+| `sql`  | The original `CREATE` statement, emitted verbatim on apply. |
+
+**Semantics.** Raw objects are opaque:
+
+- **Diff** compares the stored `sql` as text (trailing newlines ignored;
+  all other whitespace is significant). There is no structural diff.
+- **Apply** emits the `sql` verbatim to create. A changed `sql` is a
+  **recreate** (`DROP` + `CREATE`). Recreating a `view`, `dictionary`, or
+  `materialized_view` is lossless; recreating a **`table` is flagged
+  `-- UNSAFE`** (it destroys on-disk data) and the destructive DDL is *not*
+  auto-generated — you must apply it by hand.
+- **Validation** runs no outgoing dependency checks on raw objects (their SQL
+  is opaque), but a declared `raw` block *does* satisfy references to it — a
+  real materialized view's `to_table` or a Distributed table's `remote_table`
+  pointing at a raw object resolves cleanly.
+
+**Capturing.** `hclexp introspect` is **strict by default**: an object it
+cannot parse or express aborts the dump with an error that names the flag.
+Pass `-allow-raw` to capture such objects as `raw` blocks (with a warning)
+and continue. `hclexp dump-cluster` takes the same flag. The diff live side
+stays strict regardless — materialize raw blocks into HCL with
+`introspect -allow-raw` first.
 
 ## `node`
 

--- a/docs/superpowers/specs/2026-06-16-raw-sql-escape-hatch-design.md
+++ b/docs/superpowers/specs/2026-06-16-raw-sql-escape-hatch-design.md
@@ -1,0 +1,185 @@
+# Raw SQL escape hatch — design
+
+## Context
+
+`hclexp introspect` reconstructs a declarative HCL schema by reading each
+object's `create_table_query` from `system.tables` and parsing it with the
+ClickHouse SQL parser (`chparser`). When the parser cannot handle a DDL
+construct, or when the parsed object uses an engine / form the HCL model does
+not express (e.g. inner-engine MVs, exotic engines, future ClickHouse syntax),
+introspection **aborts the entire database dump** with a hard error
+(`introspect.go:69` and the per-builder error paths). A single unusual object
+takes down the whole dump.
+
+This is brittle in production: the `dump-cluster` k8s job feeds drift
+detection, and one weird object on one node should not break that node's dump.
+At the same time, silently papering over a *parser bug* (like the recent
+`LAYOUT(IP_TRIE)` gap) would hide problems we want to fix upstream.
+
+This design adds a **raw SQL escape hatch**: an object that cannot be parsed or
+expressed in HCL can be stored verbatim as a `raw` block, round-tripped, and
+re-applied. The behavior is **opt-in** — strict-by-default keeps parser gaps
+loud — so robustness is a deliberate choice (a flag), not a silent default.
+
+## Goal
+
+Survive + round-trip. When enabled, introspection never crashes on an
+unparseable/unsupported object; it captures the original CREATE DDL so dumps
+stay complete and re-appliable. Raw objects are opaque: diffed by literal SQL
+text, recreated (DROP+CREATE) on change.
+
+Non-goals: dependency analysis of raw SQL, structural diffing of raw SQL,
+in-place ALTER of raw objects.
+
+## HCL shape
+
+A generic, type-agnostic block scoped to a `database`, mirroring Terraform's
+`resource "<type>" "<name>"` two-label addressing:
+
+```hcl
+database "posthog" {
+  raw "dictionary" "city_postal_ip_trie" {
+    sql = <<-SQL
+      CREATE DICTIONARY posthog.city_postal_ip_trie (
+        `prefix` String,
+        `city_name` String DEFAULT '',
+        `postal_code` String DEFAULT ''
+      )
+      PRIMARY KEY prefix
+      SOURCE(CLICKHOUSE(USER 'admin' PASSWORD '[HIDDEN]' QUERY '...'))
+      LIFETIME(MIN 0 MAX 3600)
+      LAYOUT(IP_TRIE)
+    SQL
+  }
+}
+```
+
+- First label = `kind` ∈ {`table`, `materialized_view`, `view`, `dictionary`}.
+  Drives the `DROP` form on a recreate.
+- Second label = object `name`.
+- `sql` = the original CREATE DDL, emitted verbatim on apply.
+
+## Components
+
+### 1. Type model (`internal/loader/hcl/types.go`)
+
+```go
+type RawSpec struct {
+    Kind string `hcl:"kind,label"`  // table | materialized_view | view | dictionary
+    Name string `hcl:"name,label"`
+    SQL  string `hcl:"sql"`
+}
+```
+
+`DatabaseSpec` gains: `Raws []RawSpec `hcl:"raw,block"``.
+
+Allowed kinds are a small package-level set; anything else is a decode error.
+
+### 2. Introspection capture (`internal/loader/hcl/introspect.go`)
+
+- Extend the query to carry the object kind:
+  `SELECT name, create_table_query, engine FROM system.tables ...`.
+  Map `engine` → kind: `Dictionary`→`dictionary`, `View`→`view`,
+  `MaterializedView`→`materialized_view`, everything else→`table`.
+  (`engine` is populated even when `create_table_query` will not parse.)
+- `Introspect` / `processIntrospectRows` take an `allowRaw bool`.
+- In the per-row flow, wrap parse + build. On `parseCreateStatement` failure,
+  an unsupported-engine/form `build*` error, or the `default` unsupported
+  statement type:
+  - **`allowRaw == false` (default, strict):** return the existing error, but
+    extended to name the flag, e.g.
+    `parse create_table_query for posthog.x: <err> (re-run with -allow-raw to capture this object as a raw SQL block instead of failing)`.
+  - **`allowRaw == true`:** append `RawSpec{Kind, Name, SQL: createSQL}` to
+    `db.Raws`, `slog.Warn("captured object as raw SQL", "object", name, "reason", err)`,
+    and continue to the next row.
+- The `rowScanner`/`fakeRows` test helper is updated to scan the extra column.
+
+### 3. Decode (`internal/loader/hcl/parser.go`)
+
+gohcl auto-decodes the two-label `raw` block via the struct tags — no new
+post-decode phase. Add a `kind` validation pass alongside the existing engine
+decode loop: reject unknown kinds with `database %q raw %q: unknown kind %q`.
+
+### 4. Encode (`internal/loader/hcl/dump.go`)
+
+In `writeDatabase`, after the existing object types, emit each `RawSpec`
+(sorted by name) as a `raw "<kind>" "<name>"` block with `sql` rendered as a
+**heredoc** (`<<-SQL ... SQL`) for readability. Heredoc emission is built with
+`hclwrite` tokens; if that proves fiddly, fall back to a quoted `cty.StringVal`
+(correct round-trip, less pretty). A small helper
+`setHeredocAttribute(body, name, tag, content)` keeps it contained.
+
+### 5. Diff (`internal/loader/hcl/diff.go`)
+
+- `DatabaseChange` gains `AddRaws []RawSpec`, `DropRaws []RawSpec`,
+  `AlterRaws []RawChange` where
+  `RawChange struct { Kind, Name, OldSQL, NewSQL string }`.
+- Raw objects are matched by `(kind, name)`. `sql` is compared by **exact
+  string equality** — no whitespace normalization, because whitespace inside
+  SQL string literals (e.g. a dictionary's `QUERY '...'`) is significant.
+- A new-vs-old DB follows the existing add/drop-everything pattern; the
+  same-name path diffs raw maps and emits `AlterRaws` on a `sql` mismatch.
+- `sortDatabaseChange` sorts the three new slices by name for deterministic
+  output.
+
+### 6. SQL generation (`internal/loader/hcl/sqlgen.go`)
+
+- **Add:** emit the stored `sql` verbatim, in its own phase placed after table
+  creates (raw objects are usually leaf dictionaries/views; their dependencies
+  cannot be analyzed, so no finer ordering is attempted).
+- **Drop:** `DROP <form> IF EXISTS db.name` where `<form>` is kind-mapped —
+  `dictionary`→`DICTIONARY`, `view`→`VIEW`, `table`/`materialized_view`→`TABLE`.
+- **Change (`AlterRaws`):** DROP + CREATE (the new `sql`). Flag the DROP+CREATE
+  `-- UNSAFE` **only when `kind == "table"`** (real on-disk data loss). A
+  helper `rawRecreateIsUnsafe(kind) bool` returns true only for `table`;
+  `materialized_view`, `view`, `dictionary` recreate without the flag.
+
+### 7. Validation (`internal/loader/hcl/validate.go`)
+
+Raw objects are opaque, so they contribute **no outgoing** dependency checks.
+But a declared `raw` block **registers its name** in the known-objects set, so
+a real materialized view's `to_table` or a Distributed table's `remote_table`
+that points at a raw object resolves cleanly instead of reporting a missing
+dependency.
+
+### 8. CLI plumbing (`cmd/hclexp/hclexp.go`)
+
+- Add `-allow-raw` (bool, default false) to both `runIntrospect` and
+  `runDumpCluster`.
+- Thread it through the shared `introspectSchema(ctx, conn, databases, nodeName, allowRaw)`
+  helper into `hclload.Introspect`.
+- `dump-cluster` already treats per-node failures as non-fatal; with
+  `-allow-raw` a node containing an unparseable object now produces a complete
+  dump (raw blocks) instead of being skipped.
+
+## Documentation
+
+`docs/README.hcl.md`: new "Raw SQL fallback" subsection documenting the `raw`
+block, the `-allow-raw` flag, the opaque/recreate-only semantics, and that a
+`table`-kind change is flagged `-- UNSAFE`.
+
+Update the supported-features list in `CLAUDE.md` to mention the escape hatch.
+
+## Testing
+
+- **Round-trip:** an introspect row whose `create_table_query` does not parse,
+  with `allowRaw=true`, produces a `RawSpec`; `Write` emits a `raw` block;
+  re-parsing the emitted HCL yields the same `RawSpec`. Use a real
+  `LAYOUT(...)`-style or deliberately-unparseable DDL fixture.
+- **Strict default:** the same row with `allowRaw=false` returns an error whose
+  message contains `-allow-raw`.
+- **Kind mapping:** `engine` values map to the right kind.
+- **Decode validation:** an unknown `kind` label is a decode error.
+- **Diff:** add / drop / change of a raw object yields the right
+  `AddRaws`/`DropRaws`/`AlterRaws`.
+- **SQLgen:** add emits the `sql` verbatim; drop emits the kind-mapped `DROP`;
+  a `table`-kind change is `-- UNSAFE`, a `dictionary`/`view` change is not.
+- **Validation:** a real MV `to_table` pointing at a declared raw object passes.
+
+## Decisions (resolved)
+
+1. **Goal:** survive + round-trip (opaque, recreate-on-change).
+2. **HCL shape:** two-label `raw "<kind>" "<name>" { sql = ... }`.
+3. **UNSAFE flagging:** only `table` recreate is flagged `-- UNSAFE`.
+4. **Default posture:** strict by default; `-allow-raw` opts into capture; the
+   strict error names the flag.

--- a/internal/loader/hcl/dictionary_live_test.go
+++ b/internal/loader/hcl/dictionary_live_test.go
@@ -51,7 +51,7 @@ func TestCHLive_Dictionary_ApplyRoundTrip(t *testing.T) {
 	stmt := createDictionarySQL(dbName, want)
 	require.NoError(t, conn.Exec(ctx, stmt), "DDL rejected:\n%s", stmt)
 
-	db, err := Introspect(ctx, conn, dbName)
+	db, err := Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 	got := findDictByName(db.Dictionaries, "rich_dict")
 	require.NotNil(t, got)
@@ -220,7 +220,7 @@ func TestCHLive_Dictionary_LayoutMatrix(t *testing.T) {
 			stmt := createDictionarySQL(dbName, spec)
 			require.NoError(t, conn.Exec(ctx, stmt), "DDL rejected:\n%s", stmt)
 
-			db, err := Introspect(ctx, conn, dbName)
+			db, err := Introspect(ctx, conn, dbName, false)
 			require.NoError(t, err)
 			got := findDictByName(db.Dictionaries, dictName)
 			require.NotNil(t, got, "introspected schema missing %s", dictName)
@@ -265,7 +265,7 @@ func TestCHLive_Dictionary_LifetimeForms(t *testing.T) {
 	t.Run("simple form LIFETIME(300)", func(t *testing.T) {
 		spec := makeSpec("simple_lifetime_dict", &DictionaryLifetime{Min: ptr(int64(300))})
 		require.NoError(t, conn.Exec(ctx, createDictionarySQL(dbName, spec)))
-		db, err := Introspect(ctx, conn, dbName)
+		db, err := Introspect(ctx, conn, dbName, false)
 		require.NoError(t, err)
 		got := findDictByName(db.Dictionaries, "simple_lifetime_dict")
 		require.NotNil(t, got)
@@ -284,7 +284,7 @@ func TestCHLive_Dictionary_LifetimeForms(t *testing.T) {
 	t.Run("range form LIFETIME(MIN 300 MAX 600)", func(t *testing.T) {
 		spec := makeSpec("range_lifetime_dict", &DictionaryLifetime{Min: ptr(int64(300)), Max: ptr(int64(600))})
 		require.NoError(t, conn.Exec(ctx, createDictionarySQL(dbName, spec)))
-		db, err := Introspect(ctx, conn, dbName)
+		db, err := Introspect(ctx, conn, dbName, false)
 		require.NoError(t, err)
 		got := findDictByName(db.Dictionaries, "range_lifetime_dict")
 		require.NotNil(t, got)
@@ -327,7 +327,7 @@ func TestCHLive_Dictionary_AttributeFlags(t *testing.T) {
 	stmt := createDictionarySQL(dbName, spec)
 	require.NoError(t, conn.Exec(ctx, stmt), "DDL rejected:\n%s", stmt)
 
-	db, err := Introspect(ctx, conn, dbName)
+	db, err := Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 	got := findDictByName(db.Dictionaries, "flagged_dict")
 	require.NotNil(t, got)
@@ -393,7 +393,7 @@ func TestCHLive_Dictionary_PosthogFixtures(t *testing.T) {
 	}
 
 	// One Introspect call covers all fixtures created above.
-	db, err := Introspect(ctx, conn, dbName)
+	db, err := Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err, "Introspect failed on posthog fixtures")
 	assert.Len(t, db.Dictionaries, count, "all %d fixture dictionaries should round-trip through Introspect", count)
 }

--- a/internal/loader/hcl/diff.go
+++ b/internal/loader/hcl/diff.go
@@ -31,7 +31,26 @@ type DatabaseChange struct {
 	AddViews   []ViewSpec // emitted via CREATE VIEW
 	DropViews  []string   // emitted via DROP VIEW
 	AlterViews []ViewDiff
+
+	AddRaws   []RawSpec   // emitted verbatim via the stored CREATE DDL
+	DropRaws  []RawSpec   // emitted via a kind-mapped DROP
+	AlterRaws []RawChange // emitted as DROP + CREATE (recreate)
 }
+
+// RawChange describes a change to a raw escape-hatch object. Raw SQL is
+// opaque, so the only reconciliation is DROP + CREATE. Kind is the object's
+// kind (drives the DROP form); OldSQL/NewSQL are the stored DDL on each side.
+type RawChange struct {
+	Kind   string
+	Name   string
+	OldSQL string
+	NewSQL string
+}
+
+// IsUnsafe reports whether recreating the object risks data loss. Only a
+// table holds rows on disk; recreating a view/dictionary/materialized_view is
+// not destructive.
+func (rc RawChange) IsUnsafe() bool { return rc.Kind == "table" }
 
 // DictionaryDiff describes a change to a dictionary. ClickHouse has no
 // useful in-place ALTER DICTIONARY, so any non-empty diff is materialized
@@ -167,7 +186,8 @@ func (dc DatabaseChange) IsEmpty() bool {
 		len(dc.AddViews) == 0 && len(dc.DropViews) == 0 &&
 		len(dc.AlterViews) == 0 &&
 		len(dc.AddDictionaries) == 0 && len(dc.DropDictionaries) == 0 &&
-		len(dc.AlterDictionaries) == 0
+		len(dc.AlterDictionaries) == 0 &&
+		len(dc.AddRaws) == 0 && len(dc.DropRaws) == 0 && len(dc.AlterRaws) == 0
 }
 
 func (td TableDiff) IsEmpty() bool {
@@ -219,6 +239,7 @@ func Diff(from, to *Schema) ChangeSet {
 				AddTables:            append([]TableSpec(nil), t.Tables...),
 				AddMaterializedViews: append([]MaterializedViewSpec(nil), t.MaterializedViews...),
 				AddViews:             append([]ViewSpec(nil), t.Views...),
+				AddRaws:              append([]RawSpec(nil), t.Raws...),
 			}
 		case !tOK:
 			dc = DatabaseChange{Database: name}
@@ -231,6 +252,7 @@ func Diff(from, to *Schema) ChangeSet {
 			for _, v := range f.Views {
 				dc.DropViews = append(dc.DropViews, v.Name)
 			}
+			dc.DropRaws = append(dc.DropRaws, f.Raws...)
 		default:
 			dc = diffDatabase(name, f, t, fromR, toR)
 		}
@@ -363,7 +385,51 @@ func diffDatabase(name string, from, to *DatabaseSpec, fromR, toR TableResolver)
 			dc.AlterDictionaries = append(dc.AlterDictionaries, dd)
 		}
 	}
+
+	fromRaws := indexRaws(from.Raws)
+	toRaws := indexRaws(to.Raws)
+	for _, k := range sortedKeys(toRaws) {
+		if _, ok := fromRaws[k]; !ok {
+			dc.AddRaws = append(dc.AddRaws, *toRaws[k])
+		}
+	}
+	for _, k := range sortedKeys(fromRaws) {
+		if _, ok := toRaws[k]; !ok {
+			dc.DropRaws = append(dc.DropRaws, *fromRaws[k])
+		}
+	}
+	for _, k := range sortedKeys(fromRaws) {
+		t, ok := toRaws[k]
+		if !ok {
+			continue
+		}
+		f := fromRaws[k]
+		if !rawSQLEqual(f.SQL, t.SQL) {
+			dc.AlterRaws = append(dc.AlterRaws, RawChange{
+				Kind: t.Kind, Name: t.Name, OldSQL: f.SQL, NewSQL: t.SQL,
+			})
+		}
+	}
 	return dc
+}
+
+// indexRaws keys raw objects by (kind, name): a raw object's identity is its
+// kind plus its name, so renaming the kind for the same name reads as a
+// drop-of-old-kind plus an add-of-new-kind rather than an in-place change.
+func indexRaws(rs []RawSpec) map[string]*RawSpec {
+	out := make(map[string]*RawSpec, len(rs))
+	for i := range rs {
+		out[rs[i].Kind+"\x00"+rs[i].Name] = &rs[i]
+	}
+	return out
+}
+
+// rawSQLEqual compares two raw SQL bodies. Trailing newlines are never
+// semantically significant in a CREATE statement, so they are ignored; all
+// other whitespace is significant (it may sit inside a string literal) and is
+// compared exactly.
+func rawSQLEqual(a, b string) bool {
+	return strings.TrimRight(a, "\n") == strings.TrimRight(b, "\n")
 }
 
 func indexDictionaries(ds []DictionarySpec) map[string]*DictionarySpec {
@@ -803,6 +869,9 @@ func sortDatabaseChange(dc *DatabaseChange) {
 	sort.Slice(dc.AddViews, func(i, j int) bool { return dc.AddViews[i].Name < dc.AddViews[j].Name })
 	sort.Strings(dc.DropViews)
 	sort.Slice(dc.AlterViews, func(i, j int) bool { return dc.AlterViews[i].Name < dc.AlterViews[j].Name })
+	sort.Slice(dc.AddRaws, func(i, j int) bool { return dc.AddRaws[i].Name < dc.AddRaws[j].Name })
+	sort.Slice(dc.DropRaws, func(i, j int) bool { return dc.DropRaws[i].Name < dc.DropRaws[j].Name })
+	sort.Slice(dc.AlterRaws, func(i, j int) bool { return dc.AlterRaws[i].Name < dc.AlterRaws[j].Name })
 }
 
 // virtualNameSet returns the names recognised as virtual on engine e in

--- a/internal/loader/hcl/diff_test.go
+++ b/internal/loader/hcl/diff_test.go
@@ -22,6 +22,58 @@ func mkDB(name string, tables ...TableSpec) DatabaseSpec {
 	return DatabaseSpec{Name: name, Tables: tables}
 }
 
+func TestDiff_Raw_AddDropChange(t *testing.T) {
+	from := &Schema{Databases: []DatabaseSpec{{Name: "db", Raws: []RawSpec{
+		{Kind: "dictionary", Name: "keep", SQL: "CREATE DICTIONARY db.keep (k UInt64) ...\n"},
+		{Kind: "table", Name: "gone", SQL: "CREATE TABLE db.gone (id UInt64) ENGINE = Log\n"},
+		{Kind: "dictionary", Name: "changed", SQL: "CREATE DICTIONARY db.changed LAYOUT(FLAT)\n"},
+	}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "db", Raws: []RawSpec{
+		{Kind: "dictionary", Name: "keep", SQL: "CREATE DICTIONARY db.keep (k UInt64) ...\n"},
+		{Kind: "view", Name: "fresh", SQL: "CREATE VIEW db.fresh AS SELECT 1\n"},
+		{Kind: "dictionary", Name: "changed", SQL: "CREATE DICTIONARY db.changed LAYOUT(HASHED)\n"},
+	}}}}
+
+	cs := Diff(from, to)
+	require.Len(t, cs.Databases, 1)
+	dc := cs.Databases[0]
+
+	require.Len(t, dc.AddRaws, 1)
+	assert.Equal(t, "fresh", dc.AddRaws[0].Name)
+
+	require.Len(t, dc.DropRaws, 1)
+	assert.Equal(t, "gone", dc.DropRaws[0].Name)
+
+	require.Len(t, dc.AlterRaws, 1)
+	assert.Equal(t, "changed", dc.AlterRaws[0].Name)
+	assert.Equal(t, "dictionary", dc.AlterRaws[0].Kind)
+	assert.Contains(t, dc.AlterRaws[0].NewSQL, "LAYOUT(HASHED)")
+	assert.False(t, dc.AlterRaws[0].IsUnsafe(), "a dictionary recreate is safe")
+}
+
+func TestDiff_Raw_TableChangeIsUnsafe(t *testing.T) {
+	from := &Schema{Databases: []DatabaseSpec{{Name: "db", Raws: []RawSpec{
+		{Kind: "table", Name: "t", SQL: "CREATE TABLE db.t (a UInt64) ENGINE = Log\n"},
+	}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "db", Raws: []RawSpec{
+		{Kind: "table", Name: "t", SQL: "CREATE TABLE db.t (a UInt64, b UInt64) ENGINE = Log\n"},
+	}}}}
+	cs := Diff(from, to)
+	require.Len(t, cs.Databases, 1)
+	require.Len(t, cs.Databases[0].AlterRaws, 1)
+	assert.True(t, cs.Databases[0].AlterRaws[0].IsUnsafe(), "a table recreate destroys data")
+}
+
+func TestDiff_Raw_TrailingNewlineNotADiff(t *testing.T) {
+	from := &Schema{Databases: []DatabaseSpec{{Name: "db", Raws: []RawSpec{
+		{Kind: "view", Name: "v", SQL: "CREATE VIEW db.v AS SELECT 1"},
+	}}}}
+	to := &Schema{Databases: []DatabaseSpec{{Name: "db", Raws: []RawSpec{
+		{Kind: "view", Name: "v", SQL: "CREATE VIEW db.v AS SELECT 1\n\n"},
+	}}}}
+	assert.True(t, Diff(from, to).IsEmpty(), "trailing-newline-only differences are not changes")
+}
+
 func TestDiff_IdenticalSchemasEmpty(t *testing.T) {
 	a := []DatabaseSpec{mkDB("posthog", mkTable("events", EngineMergeTree{}, ColumnSpec{Name: "id", Type: "UUID"}))}
 	b := []DatabaseSpec{mkDB("posthog", mkTable("events", EngineMergeTree{}, ColumnSpec{Name: "id", Type: "UUID"}))}

--- a/internal/loader/hcl/dump.go
+++ b/internal/loader/hcl/dump.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"io"
 	"sort"
+	"strings"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -107,6 +109,41 @@ func writeDatabase(body *hclwrite.Body, db DatabaseSpec) {
 		dBlock := body.AppendNewBlock("dictionary", []string{d.Name})
 		writeDictionary(dBlock.Body(), d)
 	}
+
+	raws := append([]RawSpec(nil), db.Raws...)
+	sort.Slice(raws, func(i, j int) bool { return raws[i].Name < raws[j].Name })
+	for i, r := range raws {
+		if len(tables) > 0 || len(mvs) > 0 || len(views) > 0 || len(dicts) > 0 || i > 0 {
+			body.AppendNewline()
+		}
+		rBlock := body.AppendNewBlock("raw", []string{r.Kind, r.Name})
+		writeRaw(rBlock.Body(), r)
+	}
+}
+
+// writeRaw emits a raw escape-hatch block. The CREATE DDL is rendered as a
+// heredoc when it spans multiple lines (the common case, for readability) and
+// as a quoted string otherwise. Heredoc emission is exact: the re-parsed value
+// equals the stored SQL.
+func writeRaw(body *hclwrite.Body, r RawSpec) {
+	setSQLAttribute(body, "sql", r.SQL)
+}
+
+// setSQLAttribute writes a (normalized, trailing-newline) SQL string. Genuinely
+// multi-line bodies are emitted as a plain heredoc so the DDL stays readable in
+// a dump; the heredoc body is the SQL verbatim and re-parses to the same value.
+// Single-line bodies use a quoted string. Callers must pass normalizeRawSQL'd
+// input so the value always ends in exactly one newline (heredocs always do).
+func setSQLAttribute(body *hclwrite.Body, name, sql string) {
+	if strings.Count(sql, "\n") <= 1 {
+		body.SetAttributeValue(name, cty.StringVal(sql))
+		return
+	}
+	body.SetAttributeRaw(name, hclwrite.Tokens{
+		{Type: hclsyntax.TokenOHeredoc, Bytes: []byte("<<SQL\n")},
+		{Type: hclsyntax.TokenStringLit, Bytes: []byte(sql)},
+		{Type: hclsyntax.TokenCHeredoc, Bytes: []byte("SQL\n")},
+	})
 }
 
 func writeView(body *hclwrite.Body, v ViewSpec) {

--- a/internal/loader/hcl/dump_test.go
+++ b/internal/loader/hcl/dump_test.go
@@ -74,6 +74,10 @@ func TestWrite_RoundTrip_Dictionary(t *testing.T) {
 	roundTrip(t, filepath.Join("testdata", "dictionary.hcl"))
 }
 
+func TestWrite_RoundTrip_RawBlock(t *testing.T) {
+	roundTrip(t, filepath.Join("testdata", "raw_block.hcl"))
+}
+
 func TestWrite_OutputIsStable(t *testing.T) {
 	dbs, err := ParseFile(filepath.Join("testdata", "resolve_basic.hcl"))
 	require.NoError(t, err)

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strconv"
 	"strings"
@@ -32,10 +33,10 @@ type rowScanner interface {
 // default/materialized/ephemeral/alias, comment), indexes, constraints,
 // engine, ORDER BY, PARTITION BY, SAMPLE BY, table TTL, SETTINGS, and
 // table comment.
-func Introspect(ctx context.Context, conn driver.Conn, database string) (*DatabaseSpec, error) {
+func Introspect(ctx context.Context, conn driver.Conn, database string, allowRaw bool) (*DatabaseSpec, error) {
 	db := &DatabaseSpec{Name: database}
 
-	const q = `SELECT name, create_table_query
+	const q = `SELECT name, create_table_query, engine
 		FROM system.tables
 		WHERE database = ? AND NOT is_temporary
 		ORDER BY name`
@@ -45,7 +46,7 @@ func Introspect(ctx context.Context, conn driver.Conn, database string) (*Databa
 	}
 	defer rows.Close()
 
-	if err := processIntrospectRows(db, database, rows); err != nil {
+	if err := processIntrospectRowsOpt(db, database, rows, allowRaw); err != nil {
 		return nil, err
 	}
 	if err := rows.Err(); err != nil {
@@ -54,52 +55,94 @@ func Introspect(ctx context.Context, conn driver.Conn, database string) (*Databa
 	return db, nil
 }
 
+// rawKindForEngine maps a system.tables.engine value to a RawSpec kind. The
+// engine column is populated even when create_table_query cannot be parsed, so
+// it is the reliable source for the kind of a captured raw object.
+func rawKindForEngine(engine string) string {
+	switch engine {
+	case "Dictionary":
+		return "dictionary"
+	case "View":
+		return "view"
+	case "MaterializedView":
+		return "materialized_view"
+	default:
+		return "table"
+	}
+}
+
 // processIntrospectRows fills db with tables and materialized views parsed
 // from rows produced by a system.tables query. Each row must yield (name,
 // create_table_query) via Scan. Plain views (CREATE VIEW) are silently
 // skipped; inner-engine and refreshable MVs return an error.
 func processIntrospectRows(db *DatabaseSpec, database string, rows rowScanner) error {
+	return processIntrospectRowsOpt(db, database, rows, false)
+}
+
+// processIntrospectRowsOpt fills db from rows. When allowRaw is false (the
+// strict default) any object whose CREATE DDL cannot be parsed or expressed in
+// the schema language aborts with an error that names the -allow-raw flag.
+// When allowRaw is true, such an object is instead captured verbatim as a
+// RawSpec (its kind taken from system.tables.engine) and introspection
+// continues, so one unparseable object never breaks the whole dump.
+func processIntrospectRowsOpt(db *DatabaseSpec, database string, rows rowScanner, allowRaw bool) error {
 	for rows.Next() {
-		var name, createSQL string
-		if err := rows.Scan(&name, &createSQL); err != nil {
+		var name, createSQL, engine string
+		if err := rows.Scan(&name, &createSQL, &engine); err != nil {
 			return fmt.Errorf("scan system.tables: %w", err)
 		}
-		stmt, err := parseCreateStatement(createSQL)
+		if err := introspectOneObject(db, database, name, createSQL); err != nil {
+			if !allowRaw {
+				return fmt.Errorf("%w (re-run with -allow-raw to capture this object as a raw SQL block instead of failing)", err)
+			}
+			kind := rawKindForEngine(engine)
+			db.Raws = append(db.Raws, RawSpec{Kind: kind, Name: name, SQL: normalizeRawSQL(createSQL)})
+			slog.Warn("captured object as raw SQL", "object", database+"."+name, "kind", kind, "reason", err)
+		}
+	}
+	return nil
+}
+
+// introspectOneObject parses one create_table_query and appends the resulting
+// typed spec to db. It returns an error when the DDL cannot be parsed or the
+// object uses an engine/form the schema language does not express; callers
+// decide whether that is fatal (strict) or captured as raw.
+func introspectOneObject(db *DatabaseSpec, database, name, createSQL string) error {
+	stmt, err := parseCreateStatement(createSQL)
+	if err != nil {
+		return fmt.Errorf("parse create_table_query for %s.%s: %w", database, name, err)
+	}
+	switch s := stmt.(type) {
+	case *chparser.CreateTable:
+		ts, err := buildTableFromCreateTable(s)
 		if err != nil {
-			return fmt.Errorf("parse create_table_query for %s.%s: %w", database, name, err)
+			return fmt.Errorf("introspect table %s.%s: %w", database, name, err)
 		}
-		switch s := stmt.(type) {
-		case *chparser.CreateTable:
-			ts, err := buildTableFromCreateTable(s)
-			if err != nil {
-				return fmt.Errorf("introspect table %s.%s: %w", database, name, err)
-			}
-			ts.Name = name
-			db.Tables = append(db.Tables, ts)
-		case *chparser.CreateMaterializedView:
-			mv, err := buildMaterializedViewFromCreateMV(s)
-			if err != nil {
-				return fmt.Errorf("introspect materialized view %s.%s: %w", database, name, err)
-			}
-			mv.Name = name
-			db.MaterializedViews = append(db.MaterializedViews, mv)
-		case *chparser.CreateDictionary:
-			d, err := buildDictionaryFromCreateDictionary(s)
-			if err != nil {
-				return fmt.Errorf("introspect dictionary %s.%s: %w", database, name, err)
-			}
-			d.Name = name
-			db.Dictionaries = append(db.Dictionaries, d)
-		case *chparser.CreateView:
-			v, err := buildViewFromCreateView(s)
-			if err != nil {
-				return fmt.Errorf("introspect view %s.%s: %w", database, name, err)
-			}
-			v.Name = name
-			db.Views = append(db.Views, v)
-		default:
-			return fmt.Errorf("introspect %s.%s: unsupported statement type %T", database, name, stmt)
+		ts.Name = name
+		db.Tables = append(db.Tables, ts)
+	case *chparser.CreateMaterializedView:
+		mv, err := buildMaterializedViewFromCreateMV(s)
+		if err != nil {
+			return fmt.Errorf("introspect materialized view %s.%s: %w", database, name, err)
 		}
+		mv.Name = name
+		db.MaterializedViews = append(db.MaterializedViews, mv)
+	case *chparser.CreateDictionary:
+		d, err := buildDictionaryFromCreateDictionary(s)
+		if err != nil {
+			return fmt.Errorf("introspect dictionary %s.%s: %w", database, name, err)
+		}
+		d.Name = name
+		db.Dictionaries = append(db.Dictionaries, d)
+	case *chparser.CreateView:
+		v, err := buildViewFromCreateView(s)
+		if err != nil {
+			return fmt.Errorf("introspect view %s.%s: %w", database, name, err)
+		}
+		v.Name = name
+		db.Views = append(db.Views, v)
+	default:
+		return fmt.Errorf("introspect %s.%s: unsupported statement type %T", database, name, stmt)
 	}
 	return nil
 }

--- a/internal/loader/hcl/introspect_live_test.go
+++ b/internal/loader/hcl/introspect_live_test.go
@@ -51,7 +51,7 @@ func TestCHLive_Introspect(t *testing.T) {
 			require.NoError(t, conn.Exec(ctx, sql), "CREATE TABLE rejected:\n%s", sql)
 
 			// 3. Introspect back.
-			db, err := Introspect(ctx, conn, dbName)
+			db, err := Introspect(ctx, conn, dbName, false)
 			require.NoError(t, err)
 			var got *TableSpec
 			for i := range db.Tables {
@@ -97,7 +97,7 @@ func TestCHLive_IntrospectMaterializedView(t *testing.T) {
 			"AS SELECT team_id, count() AS cnt FROM %s.events GROUP BY team_id",
 		dbName, dbName, dbName)))
 
-	db, err := Introspect(ctx, conn, dbName)
+	db, err := Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err, "introspecting a database with a materialized view must not fail")
 
 	require.Len(t, db.MaterializedViews, 1)
@@ -277,7 +277,7 @@ func TestCHLive_IntrospectDictionary(t *testing.T) {
 			"LAYOUT(HASHED())",
 		dbName, dbName))
 
-	db, err := Introspect(ctx, conn, dbName)
+	db, err := Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 
 	var got *DictionarySpec

--- a/internal/loader/hcl/introspect_test.go
+++ b/internal/loader/hcl/introspect_test.go
@@ -1,6 +1,7 @@
 package hcl
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -290,8 +291,10 @@ func TestBuildMaterializedViewFromCreateSQL_RefreshableUnsupported(t *testing.T)
 
 // fakeRows is a minimal rowScanner backed by a slice of (name, createSQL)
 // pairs, used to test processIntrospectRows without a live ClickHouse.
+type fakeRow struct{ name, sql, engine string }
+
 type fakeRows struct {
-	rows []struct{ name, sql string }
+	rows []fakeRow
 	pos  int
 }
 
@@ -304,6 +307,9 @@ func (r *fakeRows) Scan(dest ...any) error {
 	row := r.rows[r.pos-1]
 	*dest[0].(*string) = row.name
 	*dest[1].(*string) = row.sql
+	if len(dest) > 2 {
+		*dest[2].(*string) = row.engine
+	}
 	return nil
 }
 
@@ -314,7 +320,7 @@ func (r *fakeRows) Err() error { return nil }
 // and a plain CREATE VIEW must all be processed in one call without error, and
 // each must land in the correct collection.
 func TestProcessIntrospectRows_Dispatch(t *testing.T) {
-	rows := &fakeRows{rows: []struct{ name, sql string }{
+	rows := &fakeRows{rows: []fakeRow{
 		{
 			name: "events",
 			sql: `CREATE TABLE db.events (` +
@@ -351,7 +357,7 @@ func TestProcessIntrospectRows_Dispatch(t *testing.T) {
 }
 
 func TestProcessIntrospectRows_PlainView(t *testing.T) {
-	rows := &fakeRows{rows: []struct{ name, sql string }{
+	rows := &fakeRows{rows: []fakeRow{
 		{
 			name: "v_simple",
 			sql:  "CREATE VIEW posthog.v_simple AS SELECT team_id FROM posthog.events",
@@ -368,7 +374,7 @@ func TestProcessIntrospectRows_PlainView(t *testing.T) {
 }
 
 func TestProcessIntrospectRows_ViewWithColumnAliasesAndComment(t *testing.T) {
-	rows := &fakeRows{rows: []struct{ name, sql string }{
+	rows := &fakeRows{rows: []fakeRow{
 		{
 			name: "v_aliased",
 			sql: "CREATE VIEW posthog.v_aliased (team_id, n) " +
@@ -388,7 +394,7 @@ func TestProcessIntrospectRows_ViewWithSQLSecurityDefiner(t *testing.T) {
 	// chparser as of the currently-pinned fork doesn't model DEFINER / SQL
 	// SECURITY on CREATE VIEW; buildViewFromCreateView falls back to a
 	// regex on the input text for those clauses.
-	rows := &fakeRows{rows: []struct{ name, sql string }{
+	rows := &fakeRows{rows: []fakeRow{
 		{
 			name: "v_sec",
 			sql:  "CREATE VIEW posthog.v_sec DEFINER = alice SQL SECURITY DEFINER AS SELECT 1",
@@ -500,7 +506,7 @@ LIFETIME(0)`
 }
 
 func TestProcessIntrospectRows_DispatchesDictionary(t *testing.T) {
-	rows := &fakeRows{rows: []struct{ name, sql string }{
+	rows := &fakeRows{rows: []fakeRow{
 		{name: "events", sql: "CREATE TABLE db.events (`id` UUID) ENGINE = MergeTree ORDER BY id"},
 		{name: "d", sql: "CREATE DICTIONARY db.d (`k` UInt64, `v` String) PRIMARY KEY k SOURCE(NULL()) LAYOUT(HASHED()) LIFETIME(0)"},
 	}}
@@ -513,6 +519,41 @@ func TestProcessIntrospectRows_DispatchesDictionary(t *testing.T) {
 	assert.Equal(t, "null", db.Dictionaries[0].Source.Kind)
 	require.NotNil(t, db.Dictionaries[0].Layout)
 	assert.Equal(t, "hashed", db.Dictionaries[0].Layout.Kind)
+}
+
+func TestRawKindForEngine(t *testing.T) {
+	assert.Equal(t, "dictionary", rawKindForEngine("Dictionary"))
+	assert.Equal(t, "view", rawKindForEngine("View"))
+	assert.Equal(t, "materialized_view", rawKindForEngine("MaterializedView"))
+	assert.Equal(t, "table", rawKindForEngine("MergeTree"))
+	assert.Equal(t, "table", rawKindForEngine(""))
+}
+
+func TestProcessIntrospectRows_RawFallback_AllowRaw(t *testing.T) {
+	rows := &fakeRows{rows: []fakeRow{
+		{name: "events", sql: "CREATE TABLE db.events (`id` UUID) ENGINE = MergeTree ORDER BY id", engine: "MergeTree"},
+		{name: "weird", sql: "this is definitely not valid clickhouse sql", engine: "Dictionary"},
+	}}
+	db := &DatabaseSpec{Name: "db"}
+	require.NoError(t, processIntrospectRowsOpt(db, "db", rows, true))
+
+	require.Len(t, db.Tables, 1, "the parseable table is still introspected normally")
+	require.Len(t, db.Raws, 1)
+	assert.Equal(t, "dictionary", db.Raws[0].Kind, "kind comes from system.tables.engine, not the unparseable SQL")
+	assert.Equal(t, "weird", db.Raws[0].Name)
+	assert.Contains(t, db.Raws[0].SQL, "not valid clickhouse sql")
+	assert.True(t, strings.HasSuffix(db.Raws[0].SQL, "\n"), "captured SQL is normalized to a trailing newline")
+}
+
+func TestProcessIntrospectRows_RawFallback_StrictErrorsWithFlagHint(t *testing.T) {
+	rows := &fakeRows{rows: []fakeRow{
+		{name: "weird", sql: "this is definitely not valid clickhouse sql", engine: "Dictionary"},
+	}}
+	db := &DatabaseSpec{Name: "db"}
+	err := processIntrospectRowsOpt(db, "db", rows, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-allow-raw")
+	assert.Empty(t, db.Raws, "strict mode captures nothing")
 }
 
 func TestParseKafkaEngine_Cases(t *testing.T) {
@@ -603,7 +644,7 @@ func TestIntrospect_TimeSeries_External(t *testing.T) {
 		"`metric_name` LowCardinality(String)) " +
 		"ENGINE = TimeSeries DATA default.m_data TAGS default.m_tags METRICS default.m_metrics"
 	db := &DatabaseSpec{Name: "default"}
-	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []fakeRow{{name: "m", sql: sql}}}))
 	require.Len(t, db.Tables, 1)
 	tbl := db.Tables[0]
 	assert.Equal(t, "m", tbl.Name)
@@ -625,7 +666,7 @@ func TestIntrospect_TimeSeries_Inner(t *testing.T) {
 		"SAMPLES INNER COLUMNS (`id` UUID, `timestamp` DateTime64(3), `value` Float64) " +
 		"SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp)"
 	db := &DatabaseSpec{Name: "default"}
-	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []fakeRow{{name: "m", sql: sql}}}))
 	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
 	assert.Equal(t, "SAMPLES", e.KeywordHint)
 	require.NotNil(t, e.Samples)
@@ -641,7 +682,7 @@ func TestIntrospect_TimeSeries_Inner(t *testing.T) {
 func TestIntrospect_TimeSeries_Bare(t *testing.T) {
 	sql := "CREATE TABLE default.m (`metric_name` LowCardinality(String)) ENGINE = TimeSeries"
 	db := &DatabaseSpec{Name: "default"}
-	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []fakeRow{{name: "m", sql: sql}}}))
 	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
 	assert.Nil(t, e.Samples)
 	assert.Nil(t, e.Tags)
@@ -654,7 +695,7 @@ func TestIntrospect_TimeSeries_TagsToColumns(t *testing.T) {
 		"SETTINGS id_generator = 'sipHash64(metric_name, all_tags)', " +
 		"tags_to_columns = {'instance':'instance','job':'job'}"
 	db := &DatabaseSpec{Name: "default"}
-	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "default", &fakeRows{rows: []fakeRow{{name: "m", sql: sql}}}))
 	e := db.Tables[0].Engine.Decoded.(EngineTimeSeries)
 	assert.Equal(t, "sipHash64(metric_name, all_tags)", e.Settings["id_generator"])
 	assert.Equal(t, map[string]string{"instance": "instance", "job": "job"}, e.TagsToColumns)
@@ -663,7 +704,7 @@ func TestIntrospect_TimeSeries_TagsToColumns(t *testing.T) {
 func TestIntrospect_TimeSeries_ProductionPromMetrics(t *testing.T) {
 	sql := "CREATE TABLE posthog.prom_metrics (`id` UUID DEFAULT reinterpretAsUUID(sipHash128(metric_name, all_tags)), `timestamp` DateTime64(3), `value` Float64, `metric_name` LowCardinality(String), `tags` Map(LowCardinality(String), String), `all_tags` Map(String, String), `min_time` Nullable(DateTime64(3)), `max_time` Nullable(DateTime64(3)), `metric_family_name` String, `type` String, `unit` String, `help` String) ENGINE = TimeSeries DATA posthog.prom_metrics_data TAGS posthog.prom_metrics_tags METRICS posthog.prom_metrics_metrics"
 	db := &DatabaseSpec{Name: "posthog"}
-	require.NoError(t, processIntrospectRows(db, "posthog", &fakeRows{rows: []struct{ name, sql string }{{"prom_metrics", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "posthog", &fakeRows{rows: []fakeRow{{name: "prom_metrics", sql: sql}}}))
 	require.Len(t, db.Tables, 1)
 	assert.Equal(t, "prom_metrics", db.Tables[0].Name)
 	assert.Len(t, db.Tables[0].Columns, 12)
@@ -675,7 +716,7 @@ func TestIntrospect_TimeSeries_ProductionPromMetrics(t *testing.T) {
 func TestIntrospect_Join_SingleKey(t *testing.T) {
 	sql := "CREATE TABLE db.j (`id` UInt64, `value` String) ENGINE = Join(ANY, LEFT, id)"
 	db := &DatabaseSpec{Name: "db"}
-	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"j", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []fakeRow{{name: "j", sql: sql}}}))
 	e := db.Tables[0].Engine.Decoded.(EngineJoin)
 	assert.Equal(t, "ANY", e.Strictness)
 	assert.Equal(t, "LEFT", e.JoinType)
@@ -685,7 +726,7 @@ func TestIntrospect_Join_SingleKey(t *testing.T) {
 func TestIntrospect_Join_MultiKey(t *testing.T) {
 	sql := "CREATE TABLE db.j (`a` UInt64, `b` UInt64, `v` String) ENGINE = Join(ALL, INNER, a, b)"
 	db := &DatabaseSpec{Name: "db"}
-	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"j", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []fakeRow{{name: "j", sql: sql}}}))
 	e := db.Tables[0].Engine.Decoded.(EngineJoin)
 	assert.Equal(t, "ALL", e.Strictness)
 	assert.Equal(t, "INNER", e.JoinType)
@@ -695,7 +736,7 @@ func TestIntrospect_Join_MultiKey(t *testing.T) {
 func TestIntrospect_Join_RejectsTooFewArgs(t *testing.T) {
 	sql := "CREATE TABLE db.j (`id` UInt64) ENGINE = Join(ANY, LEFT)"
 	db := &DatabaseSpec{Name: "db"}
-	err := processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"j", sql}}})
+	err := processIntrospectRows(db, "db", &fakeRows{rows: []fakeRow{{name: "j", sql: sql}}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Join needs")
 }
@@ -703,7 +744,7 @@ func TestIntrospect_Join_RejectsTooFewArgs(t *testing.T) {
 func TestIntrospect_Buffer_FullArgs(t *testing.T) {
 	sql := "CREATE TABLE db.buf (`id` UUID) ENGINE = Buffer('', 'dest_table', 16, 10, 100, 10000, 1000000, 10000000, 100000000)"
 	db := &DatabaseSpec{Name: "db"}
-	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"buf", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []fakeRow{{name: "buf", sql: sql}}}))
 	e := db.Tables[0].Engine.Decoded.(EngineBuffer)
 	assert.Equal(t, "", e.Database)
 	assert.Equal(t, "dest_table", e.Table)
@@ -716,7 +757,7 @@ func TestIntrospect_Buffer_FullArgs(t *testing.T) {
 func TestIntrospect_Buffer_WithFlushTriplet(t *testing.T) {
 	sql := "CREATE TABLE db.buf (`id` UUID) ENGINE = Buffer('default', 'dest', 1, 5, 60, 100, 10000, 1000, 100000, 30, 200, 50000)"
 	db := &DatabaseSpec{Name: "db"}
-	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"buf", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []fakeRow{{name: "buf", sql: sql}}}))
 	e := db.Tables[0].Engine.Decoded.(EngineBuffer)
 	assert.Equal(t, "default", e.Database)
 	require.NotNil(t, e.FlushTime)
@@ -730,7 +771,7 @@ func TestIntrospect_Buffer_WithFlushTriplet(t *testing.T) {
 func TestIntrospect_Merge(t *testing.T) {
 	sql := "CREATE TABLE db.m (`id` UUID) ENGINE = Merge('default', '^shard_.*')"
 	db := &DatabaseSpec{Name: "db"}
-	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"m", sql}}}))
+	require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []fakeRow{{name: "m", sql: sql}}}))
 	e := db.Tables[0].Engine.Decoded.(EngineMerge)
 	assert.Equal(t, "default", e.DBRegex)
 	assert.Equal(t, "^shard_.*", e.TableRegex)
@@ -744,7 +785,7 @@ func TestIntrospect_Null_Memory(t *testing.T) {
 		{"CREATE TABLE db.n (`id` UUID) ENGINE = Memory()", "memory"},
 	} {
 		db := &DatabaseSpec{Name: "db"}
-		require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []struct{ name, sql string }{{"n", c.sql}}}))
+		require.NoError(t, processIntrospectRows(db, "db", &fakeRows{rows: []fakeRow{{name: "n", sql: c.sql}}}))
 		assert.Equal(t, c.kind, db.Tables[0].Engine.Kind)
 	}
 }

--- a/internal/loader/hcl/kafka_namedcollection_live_test.go
+++ b/internal/loader/hcl/kafka_namedcollection_live_test.go
@@ -75,7 +75,7 @@ func TestCHLive_Kafka_WithNamedCollection_E2E(t *testing.T) {
 	}
 	assert.Equal(t, wantValues, gotValues)
 
-	dbIntrospected, err := Introspect(ctx, conn, dbName)
+	dbIntrospected, err := Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 	require.Len(t, dbIntrospected.Tables, 1)
 	got := dbIntrospected.Tables[0]
@@ -135,7 +135,7 @@ func TestCHLive_Kafka_AllSettingsForm(t *testing.T) {
 		require.NoError(t, conn.Exec(ctx, stmt), "exec failed: %s", stmt)
 	}
 
-	dbIntrospected, err := Introspect(ctx, conn, dbName)
+	dbIntrospected, err := Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 	require.Len(t, dbIntrospected.Tables, 1)
 	got := dbIntrospected.Tables[0]

--- a/internal/loader/hcl/parser.go
+++ b/internal/loader/hcl/parser.go
@@ -32,6 +32,13 @@ func ParseFile(path string) (*Schema, error) {
 
 	for di := range spec.Databases {
 		db := &spec.Databases[di]
+		for i := range db.Raws {
+			r := &db.Raws[i]
+			if !rawKinds[r.Kind] {
+				return nil, fmt.Errorf("%s: raw %q has unknown kind %q (want one of table, materialized_view, view, dictionary)", db.Name, r.Name, r.Kind)
+			}
+			r.SQL = normalizeRawSQL(r.SQL)
+		}
 		for ti := range db.Tables {
 			tbl := &db.Tables[ti]
 			if tbl.Engine == nil {

--- a/internal/loader/hcl/parser_test.go
+++ b/internal/loader/hcl/parser_test.go
@@ -173,6 +173,26 @@ func TestParseFile_Dictionary(t *testing.T) {
 	assert.Equal(t, expected, schema.Databases)
 }
 
+func TestParseFile_RawBlock(t *testing.T) {
+	schema, err := ParseFile(filepath.Join("testdata", "raw_block.hcl"))
+	require.NoError(t, err)
+
+	require.Len(t, schema.Databases, 1)
+	require.Len(t, schema.Databases[0].Raws, 1)
+	raw := schema.Databases[0].Raws[0]
+	assert.Equal(t, "dictionary", raw.Kind)
+	assert.Equal(t, "city_postal_ip_trie", raw.Name)
+	assert.Contains(t, raw.SQL, "CREATE DICTIONARY posthog.city_postal_ip_trie")
+	assert.Contains(t, raw.SQL, "LAYOUT(IP_TRIE)")
+}
+
+func TestParseFile_RawBlock_BadKind(t *testing.T) {
+	_, err := ParseFile(filepath.Join("testdata", "raw_block_bad_kind.hcl"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tabel")
+	assert.Contains(t, err.Error(), "kind")
+}
+
 func TestParseFile_NamedCollection(t *testing.T) {
 	schema, err := ParseFile(filepath.Join("testdata", "named_collection.hcl"))
 	require.NoError(t, err)

--- a/internal/loader/hcl/sqlgen.go
+++ b/internal/loader/hcl/sqlgen.go
@@ -78,6 +78,14 @@ func GenerateSQL(cs ChangeSet) GeneratedSQL {
 			out.Statements = append(out.Statements, createDictionarySQL(dc.Database, d))
 		}
 	}
+	// Raw adds last among creates: a raw object (typically a leaf dictionary
+	// or view) may reference tables created above. Its dependencies cannot be
+	// analysed, so no finer ordering is attempted.
+	for _, dc := range cs.Databases {
+		for _, r := range dc.AddRaws {
+			out.Statements = append(out.Statements, createRawSQL(r))
+		}
+	}
 	for _, dc := range cs.Databases {
 		for _, td := range dc.AlterTables {
 			if td.IsUnsafe() {
@@ -128,6 +136,24 @@ func GenerateSQL(cs ChangeSet) GeneratedSQL {
 			})
 		}
 	}
+	// Raw recreates: a raw object is opaque, so the only reconciliation is
+	// DROP + CREATE. For a table this destroys on-disk data, so it is flagged
+	// unsafe and the destructive DDL is NOT auto-emitted (manual review). For
+	// a view/dictionary/materialized_view the recreate is lossless and emitted
+	// as adjacent DROP + CREATE statements.
+	for _, dc := range cs.Databases {
+		for _, rc := range dc.AlterRaws {
+			if rc.IsUnsafe() {
+				out.Unsafe = append(out.Unsafe, UnsafeChange{
+					Database: dc.Database, Table: rc.Name,
+					Reason: "raw table change requires DROP + CREATE, which destroys the table's data",
+				})
+				continue
+			}
+			out.Statements = append(out.Statements, dropRawSQL(rc.Kind, dc.Database, rc.Name))
+			out.Statements = append(out.Statements, createRawSQL(RawSpec{Kind: rc.Kind, Name: rc.Name, SQL: rc.NewSQL}))
+		}
+	}
 
 	// 8. ALTER NAMED COLLECTION (SET then DELETE, only for non-recreate diffs).
 	for _, ncc := range cs.NamedCollections {
@@ -159,6 +185,13 @@ func GenerateSQL(cs ChangeSet) GeneratedSQL {
 		sort.Strings(names)
 		for _, name := range names {
 			out.Statements = append(out.Statements, dropDictionarySQL(dc.Database, name))
+		}
+	}
+	// Raw drops before table drops: a raw object may read from a table (e.g. a
+	// raw materialized view), so it must be removed first.
+	for _, dc := range cs.Databases {
+		for _, r := range dc.DropRaws {
+			out.Statements = append(out.Statements, dropRawSQL(r.Kind, dc.Database, r.Name))
 		}
 	}
 	for _, dt := range orderTablesByDependency(gatherTables(cs, dropTablesOf), true) {
@@ -401,6 +434,27 @@ func constraintClause(c ConstraintSpec) string {
 
 func dropTableSQL(database, table string) string {
 	return fmt.Sprintf("DROP TABLE %s.%s", database, table)
+}
+
+// createRawSQL emits a raw object's stored CREATE DDL verbatim, trimming the
+// canonical trailing newline so it matches the formatting of other generated
+// statements.
+func createRawSQL(r RawSpec) string {
+	return strings.TrimRight(r.SQL, "\n")
+}
+
+// dropRawSQL renders the DROP for a raw object, choosing the statement form
+// from its kind. Dictionaries need DROP DICTIONARY and plain views DROP VIEW;
+// tables and (TO-form) materialized views are dropped with DROP TABLE.
+func dropRawSQL(kind, database, name string) string {
+	form := "TABLE"
+	switch kind {
+	case "dictionary":
+		form = "DICTIONARY"
+	case "view":
+		form = "VIEW"
+	}
+	return fmt.Sprintf("DROP %s IF EXISTS %s.%s", form, database, name)
 }
 
 func alterTableSQL(database string, td TableDiff) string {

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -9,6 +9,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGenerateSQL_Raw_AddAndDrop(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "db",
+		AddRaws: []RawSpec{
+			{Kind: "dictionary", Name: "d", SQL: "CREATE DICTIONARY db.d (k UInt64) LAYOUT(FLAT)\n"},
+		},
+		DropRaws: []RawSpec{
+			{Kind: "view", Name: "v", SQL: "CREATE VIEW db.v AS SELECT 1\n"},
+		},
+	}}}
+	out := GenerateSQL(cs)
+	joined := strings.Join(out.Statements, "\n")
+	assert.Contains(t, joined, "CREATE DICTIONARY db.d")
+	assert.Contains(t, joined, "DROP VIEW IF EXISTS db.v")
+	assert.Empty(t, out.Unsafe)
+}
+
+func TestGenerateSQL_Raw_DictRecreateIsSafe(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "db",
+		AlterRaws: []RawChange{
+			{Kind: "dictionary", Name: "d", OldSQL: "CREATE DICTIONARY db.d LAYOUT(FLAT)\n", NewSQL: "CREATE DICTIONARY db.d LAYOUT(HASHED)\n"},
+		},
+	}}}
+	out := GenerateSQL(cs)
+	joined := strings.Join(out.Statements, "\n")
+	assert.Contains(t, joined, "DROP DICTIONARY IF EXISTS db.d")
+	assert.Contains(t, joined, "LAYOUT(HASHED)")
+	assert.Empty(t, out.Unsafe, "recreating a dictionary loses no data")
+}
+
+func TestGenerateSQL_Raw_TableRecreateIsUnsafeAndNotAutoEmitted(t *testing.T) {
+	cs := ChangeSet{Databases: []DatabaseChange{{
+		Database: "db",
+		AlterRaws: []RawChange{
+			{Kind: "table", Name: "t", OldSQL: "CREATE TABLE db.t (a UInt64) ENGINE = Log\n", NewSQL: "CREATE TABLE db.t (a UInt64, b UInt64) ENGINE = Log\n"},
+		},
+	}}}
+	out := GenerateSQL(cs)
+	require.Len(t, out.Unsafe, 1)
+	assert.Equal(t, "t", out.Unsafe[0].Table)
+	joined := strings.Join(out.Statements, "\n")
+	assert.NotContains(t, joined, "DROP TABLE", "a destructive table recreate is never auto-emitted")
+}
+
 func TestSQLGen_EmptyChangeSet(t *testing.T) {
 	out := GenerateSQL(ChangeSet{})
 	assert.Empty(t, out.Statements)

--- a/internal/loader/hcl/testdata/raw_block.hcl
+++ b/internal/loader/hcl/testdata/raw_block.hcl
@@ -1,0 +1,11 @@
+database "posthog" {
+  raw "dictionary" "city_postal_ip_trie" {
+    sql = <<-SQL
+      CREATE DICTIONARY posthog.city_postal_ip_trie (`prefix` String)
+      PRIMARY KEY prefix
+      SOURCE(CLICKHOUSE(USER 'admin'))
+      LIFETIME(MIN 0 MAX 3600)
+      LAYOUT(IP_TRIE)
+    SQL
+  }
+}

--- a/internal/loader/hcl/testdata/raw_block_bad_kind.hcl
+++ b/internal/loader/hcl/testdata/raw_block_bad_kind.hcl
@@ -1,0 +1,5 @@
+database "posthog" {
+  raw "tabel" "oops" {
+    sql = "CREATE TABLE posthog.oops (id UInt64) ENGINE = MergeTree ORDER BY id"
+  }
+}

--- a/internal/loader/hcl/types.go
+++ b/internal/loader/hcl/types.go
@@ -1,6 +1,10 @@
 package hcl
 
-import "github.com/hashicorp/hcl/v2"
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+)
 
 type DatabaseSpec struct {
 	Name string `hcl:"name,label"`
@@ -28,6 +32,39 @@ type DatabaseSpec struct {
 	// they live as a sibling collection and do not participate in the
 	// table inheritance system.
 	Views []ViewSpec `hcl:"view,block"`
+
+	// Raws are escape-hatch objects whose CREATE DDL could not be parsed
+	// or expressed in this schema language. They are stored verbatim,
+	// round-tripped unchanged, and recreated (DROP+CREATE) on change.
+	Raws []RawSpec `hcl:"raw,block"`
+}
+
+// RawSpec is an opaque object captured as its original CREATE DDL. It is the
+// escape hatch for DDL the parser cannot handle or the HCL model cannot
+// express. The two labels mirror Terraform's `resource "<type>" "<name>"`:
+// Kind drives the DROP form on a recreate, Name is the object name, and SQL
+// is emitted verbatim on apply.
+type RawSpec struct {
+	Kind string `hcl:"kind,label"` // table | materialized_view | view | dictionary
+	Name string `hcl:"name,label"`
+	SQL  string `hcl:"sql"`
+}
+
+// rawKinds is the set of kinds a RawSpec label may take.
+var rawKinds = map[string]bool{
+	"table":             true,
+	"materialized_view": true,
+	"view":              true,
+	"dictionary":        true,
+}
+
+// normalizeRawSQL canonicalizes a raw SQL body to end with exactly one
+// trailing newline. Applied both when capturing during introspection and when
+// decoding from HCL, it makes the stored form independent of authoring style
+// (quoted string vs heredoc) so round-tripping is exact and diffs are stable.
+// Trailing newlines are never semantically significant in a CREATE statement.
+func normalizeRawSQL(s string) string {
+	return strings.TrimRight(s, "\n") + "\n"
 }
 
 // MaterializedViewSpec models a ClickHouse materialized view in its

--- a/internal/loader/hcl/validate.go
+++ b/internal/loader/hcl/validate.go
@@ -459,6 +459,13 @@ func Validate(dbs []DatabaseSpec, skip SkipSet) []ValidationError {
 		for _, v := range db.Views {
 			declared[ObjectRef{Database: db.Name, Name: v.Name}] = true
 		}
+		// Raw objects are opaque (no outgoing dependency checks), but a
+		// declared raw block still registers its name so a real MV's
+		// to_table or a Distributed table's remote_table that points at it
+		// resolves instead of reporting a missing dependency.
+		for _, r := range db.Raws {
+			declared[ObjectRef{Database: db.Name, Name: r.Name}] = true
+		}
 	}
 
 	deps, err := CollectDependencies(dbs)

--- a/internal/loader/hcl/validate_test.go
+++ b/internal/loader/hcl/validate_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidate_RawObjectSatisfiesReference(t *testing.T) {
+	dbs := []DatabaseSpec{{
+		Name: "db",
+		// A Distributed table forwarding to a raw-captured local table.
+		Tables: []TableSpec{mkDistTable("dist", "db", "raw_local")},
+		Raws: []RawSpec{
+			{Kind: "table", Name: "raw_local", SQL: "CREATE TABLE db.raw_local (a UInt64) ENGINE = MergeTree ORDER BY a\n"},
+		},
+	}}
+	errs := Validate(dbs, ParseSkipSet(""))
+	require.Empty(t, errs, "a declared raw block satisfies a Distributed remote_table reference")
+}
+
 // mkDistTable builds a Distributed-engine table forwarding to remoteDB.remoteTable.
 func mkDistTable(name, remoteDB, remoteTable string) TableSpec {
 	return mkTable(name, EngineDistributed{

--- a/test/hcl_introspect_live_test.go
+++ b/test/hcl_introspect_live_test.go
@@ -52,7 +52,7 @@ func TestLive_HCLIntrospect(t *testing.T) {
 		require.NoError(t, conn.Exec(ctx, s), "failed to create test table")
 	}
 
-	got, err := hclload.Introspect(ctx, conn, dbName)
+	got, err := hclload.Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 
 	want := &hclload.DatabaseSpec{
@@ -157,7 +157,7 @@ func TestLive_HCLIntrospect_TimeSeries(t *testing.T) {
 		require.NoError(t, conn.Exec(ctx, s), "create failed: %s", s)
 	}
 
-	got, err := hclload.Introspect(ctx, conn, dbName)
+	got, err := hclload.Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 
 	var external *hclload.TableSpec
@@ -207,7 +207,7 @@ func TestLive_HCLIntrospect_Join(t *testing.T) {
 		require.NoError(t, conn.Exec(ctx, s), "create failed: %s", s)
 	}
 
-	got, err := hclload.Introspect(ctx, conn, dbName)
+	got, err := hclload.Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 
 	byName := map[string]hclload.Engine{}
@@ -256,7 +256,7 @@ func TestLive_HCLIntrospect_CommonEngines(t *testing.T) {
 		require.NoError(t, conn.Exec(ctx, s), "create failed: %s", s)
 	}
 
-	got, err := hclload.Introspect(ctx, conn, dbName)
+	got, err := hclload.Introspect(ctx, conn, dbName, false)
 	require.NoError(t, err)
 
 	byName := map[string]hclload.Engine{}


### PR DESCRIPTION
## What

Adds a `raw "<kind>" "<name>" { sql = ... }` block — an escape hatch for objects whose `CREATE` DDL the SQL parser can't handle, or that use an engine/form the HCL model can't express. The statement is stored verbatim and round-tripped unchanged. Two-label addressing mirrors Terraform's `resource "<type>" "<name>"`.

```hcl
database "posthog" {
  raw "dictionary" "city_postal_ip_trie" {
    sql = <<SQL
CREATE DICTIONARY posthog.city_postal_ip_trie (...) ... LAYOUT(IP_TRIE)
SQL
  }
}
```

## Why

`hclexp introspect` reconstructs HCL by parsing each `create_table_query`. A single object the parser can't handle (a new engine, exotic syntax, an unsupported form) aborted the **entire** database dump. That's brittle for the `dump-cluster` k8s job that feeds drift detection. This gives a way to capture such objects and keep going — while keeping parser gaps loud by default.

## Behavior

- **Strict by default.** An unparseable/unsupported object aborts introspection with an error that names the flag. Pass **`-allow-raw`** (on `introspect` and `dump-cluster`) to capture it as a `raw` block (with a warning) and continue. The object's `kind` comes from `system.tables.engine`, which is populated even when the DDL won't parse. The diff live side stays strict.
- **Opaque diff.** Raw `sql` is compared as text (trailing newlines ignored; all other whitespace is significant). No structural diff.
- **Recreate on change.** A changed `sql` is `DROP` + `CREATE`. View/dictionary/materialized_view recreates are lossless; a **`table`-kind change is flagged `-- UNSAFE`** and its destructive DDL is *not* auto-emitted.
- **Validation.** Raw objects run no outgoing dependency checks, but a declared raw block *satisfies* references to it (an MV `to_table`, a Distributed `remote_table`).

## Implementation (TDD, all layers)

types → decode + `kind` validation → heredoc-aware encode (exact round-trip) → introspect capture → diff (`AddRaws`/`DropRaws`/`AlterRaws`) → sqlgen → dependency validation → CLI `-allow-raw` plumbing → diff summary renderer. Design spec: `docs/superpowers/specs/2026-06-16-raw-sql-escape-hatch-design.md`.

## Tests

Unit tests at every layer (decode, bad-kind error, round-trip, introspect strict-vs-allow-raw + kind mapping, diff add/drop/change + table-unsafe + trailing-newline stability, sqlgen verbatim/kind-mapped-drop/unsafe, validation, renderer). End-to-end verified through the binary (diff summary, `-sql` create + recreate, validate).

```
go build ./...   # ok
go vet ./...      # ok
go test ./...     # all pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)