### PR TITLE
Add sql2hcl: apply SQL DDL edits to an HCL schema

### DIFF
--- a/cmd/hclexp/hclexp.go
+++ b/cmd/hclexp/hclexp.go
@@ -43,6 +43,9 @@ func main() {
 	case "drift":
 		runDrift(os.Args[2:])
 		return
+	case "sql2hcl":
+		runSQL2HCL(os.Args[2:])
+		return
 	case "load":
 		runLoad(os.Args[2:])
 		return
@@ -74,6 +77,7 @@ Commands:
   diff         compare two schemas (HCL or live), optionally emit migration DDL
   validate     check that MV and Distributed dependency references resolve
   drift        detect cross-node schema drift across per-node HCL dumps
+  sql2hcl      apply SQL DDL edits (CREATE/ALTER/DROP/RENAME) to an HCL schema
   load         parse and resolve an HCL config (default when flags are given)
   help         print this help
 

--- a/cmd/hclexp/sql2hcl.go
+++ b/cmd/hclexp/sql2hcl.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
+)
+
+// runSQL2HCL applies SQL DDL edits to an existing HCL schema and emits the
+// updated HCL. Developers express a change as the ClickHouse SQL they already
+// know — CREATE / ALTER TABLE / DROP / RENAME — and it is folded into their
+// declarative schema (the "left side"). The output is the resolved (flat)
+// schema; pair it with `hclexp diff` to preview the migration the edit implies.
+func runSQL2HCL(args []string) {
+	fs := flag.NewFlagSet("hclexp sql2hcl", flag.ExitOnError)
+	leftFlag := fs.String("left", "", "HCL schema to modify: a single file, or comma-separated layer directories")
+	inFlag := fs.String("in", "", "SQL file to apply (default: stdin; \"-\" also means stdin)")
+	outFlag := fs.String("out", "", "where to write updated HCL: empty=stdout, a directory=one <db>.hcl per database, else a single file")
+	dbFlag := fs.String("database", "", "default database for unqualified object names")
+	allowRaw := fs.Bool("allow-raw", false, "capture a CREATE the schema model can't express as a raw{} block instead of failing")
+	_ = fs.Parse(args)
+
+	if *leftFlag == "" {
+		fmt.Fprintln(os.Stderr, "hclexp sql2hcl: -left is required (the HCL schema to modify)")
+		os.Exit(2)
+	}
+
+	schema, err := loadLeft(*leftFlag)
+	if err != nil {
+		slog.Error("failed to load -left schema", "err", err)
+		os.Exit(1)
+	}
+	if err := hclload.Resolve(schema); err != nil {
+		slog.Error("failed to resolve -left schema", "err", err)
+		os.Exit(1)
+	}
+
+	sql, err := readSQL(*inFlag)
+	if err != nil {
+		slog.Error("failed to read SQL input", "err", err)
+		os.Exit(1)
+	}
+
+	applied, err := hclload.ApplySQL(schema, sql, *dbFlag, *allowRaw)
+	if err != nil {
+		slog.Error("failed to apply SQL", "err", err)
+		os.Exit(1)
+	}
+
+	if err := writeIntrospected(*outFlag, schema); err != nil {
+		slog.Error("failed to write updated schema", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("SQL applied", "statements", applied, "databases", len(schema.Databases))
+}
+
+// loadLeft loads the left-side schema. A path naming a directory (or a
+// comma-separated list of directories) is loaded as layers; a single path that
+// is a file is parsed directly.
+func loadLeft(path string) (*hclload.Schema, error) {
+	parts := splitList(path)
+	if len(parts) > 1 {
+		return hclload.LoadLayers(parts)
+	}
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		return hclload.LoadLayers([]string{path})
+	}
+	return hclload.ParseFile(path)
+}
+
+// readSQL reads the SQL to apply from a file, or from stdin when the path is
+// empty or "-".
+func readSQL(path string) (string, error) {
+	if path == "" || path == "-" {
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/docs/README.hcl.md
+++ b/docs/README.hcl.md
@@ -358,6 +358,52 @@ spans ingestion-events / -medium / -small; `data` spans online and offline
 nodes). `-group-by role` uses the deployment role from the node name and
 usually isolates genuine drift.
 
+## SQL → HCL edits — `hclexp sql2hcl`
+
+You already know ClickHouse SQL; `sql2hcl` lets you change a schema with the
+DDL you'd naturally write instead of hand-editing HCL. It loads your existing
+HCL (the **left side**), applies one or more SQL statements to it, and emits the
+updated HCL.
+
+```sh
+# Edit from stdin, preview on stdout
+echo 'ALTER TABLE db.events ADD COLUMN name String AFTER id;' \
+  | hclexp sql2hcl -left ./schema
+
+# Edit from a file, write the updated schema, then preview the migration
+hclexp sql2hcl -left ./schema -in change.sql -out /tmp/updated.hcl
+hclexp diff -left ./schema -right /tmp/updated.hcl -sql
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `-left`       | —      | HCL schema to modify: a single file, or comma-separated layer directories (required) |
+| `-in`         | stdin  | SQL file to apply (`-` also means stdin) |
+| `-out`        | stdout | empty → stdout; a directory → one `<db>.hcl` per database; else a single file |
+| `-database`   | —      | default database for unqualified object names (e.g. `CREATE TABLE foo`, not `db.foo`) |
+| `-allow-raw`  | off    | capture a `CREATE` the model can't express as a [`raw`](#raw) block instead of failing |
+
+**Supported statements** (declarative schema changes):
+
+- `CREATE TABLE | MATERIALIZED VIEW | VIEW | DICTIONARY` — adds the object, or
+  replaces an existing object of the same name.
+- `ALTER TABLE … ADD/DROP/MODIFY/RENAME COLUMN`, `ADD/DROP INDEX`,
+  `MODIFY/REMOVE TTL`, `MODIFY/RESET SETTING` — edits the matching `table` block.
+  `RENAME COLUMN` records [`renamed_from`](#column) so a later diff emits
+  `RENAME COLUMN` rather than drop + add.
+- `ALTER TABLE <mv> MODIFY QUERY …` — replaces a materialized view's `query`.
+- `DROP TABLE | VIEW | DICTIONARY | DATABASE` — removes the object (`IF EXISTS`
+  makes a missing target a no-op).
+- `RENAME TABLE a TO b` — renames, moving across databases when they differ.
+
+**Scope boundary.** `sql2hcl` works on schema *state*, not data: `TRUNCATE`,
+`ALTER … DELETE`, partition operations (attach/detach/drop/freeze/replace), and
+`MATERIALIZE INDEX/PROJECTION` are rejected with a clear error. The output is the
+resolved (flat) schema — `sql2hcl` does **not** rewrite your layered source files
+in place. Review the emitted HCL (or the `diff -sql` it implies) and integrate.
+The default database for an unqualified name comes from `-database`, or, when the
+left side has exactly one database, that database.
+
 ## `view`
 
 A `view` block declares a ClickHouse **plain** (non-materialized) view — a

--- a/internal/loader/hcl/introspect.go
+++ b/internal/loader/hcl/introspect.go
@@ -112,39 +112,92 @@ func introspectOneObject(db *DatabaseSpec, database, name, createSQL string) err
 	if err != nil {
 		return fmt.Errorf("parse create_table_query for %s.%s: %w", database, name, err)
 	}
+	if err := upsertObjectFromStmt(db, name, stmt); err != nil {
+		return fmt.Errorf("introspect %s.%s: %w", database, name, err)
+	}
+	return nil
+}
+
+// upsertObjectFromStmt builds the typed spec for an already-parsed CREATE
+// statement and stores it on db under name. When an object of the same kind
+// already exists with that name it is replaced in place (otherwise appended),
+// so the helper is safe both for introspection — where names are unique — and
+// for the sql2hcl edit path, where a CREATE redefines an existing object.
+func upsertObjectFromStmt(db *DatabaseSpec, name string, stmt chparser.Expr) error {
 	switch s := stmt.(type) {
 	case *chparser.CreateTable:
 		ts, err := buildTableFromCreateTable(s)
 		if err != nil {
-			return fmt.Errorf("introspect table %s.%s: %w", database, name, err)
+			return fmt.Errorf("table %s: %w", name, err)
 		}
 		ts.Name = name
-		db.Tables = append(db.Tables, ts)
+		upsertTable(db, ts)
 	case *chparser.CreateMaterializedView:
 		mv, err := buildMaterializedViewFromCreateMV(s)
 		if err != nil {
-			return fmt.Errorf("introspect materialized view %s.%s: %w", database, name, err)
+			return fmt.Errorf("materialized view %s: %w", name, err)
 		}
 		mv.Name = name
-		db.MaterializedViews = append(db.MaterializedViews, mv)
+		upsertMaterializedView(db, mv)
 	case *chparser.CreateDictionary:
 		d, err := buildDictionaryFromCreateDictionary(s)
 		if err != nil {
-			return fmt.Errorf("introspect dictionary %s.%s: %w", database, name, err)
+			return fmt.Errorf("dictionary %s: %w", name, err)
 		}
 		d.Name = name
-		db.Dictionaries = append(db.Dictionaries, d)
+		upsertDictionary(db, d)
 	case *chparser.CreateView:
 		v, err := buildViewFromCreateView(s)
 		if err != nil {
-			return fmt.Errorf("introspect view %s.%s: %w", database, name, err)
+			return fmt.Errorf("view %s: %w", name, err)
 		}
 		v.Name = name
-		db.Views = append(db.Views, v)
+		upsertView(db, v)
 	default:
-		return fmt.Errorf("introspect %s.%s: unsupported statement type %T", database, name, stmt)
+		return fmt.Errorf("unsupported statement type %T", stmt)
 	}
 	return nil
+}
+
+// upsertTable replaces the table named t.Name in db, or appends it when absent.
+func upsertTable(db *DatabaseSpec, t TableSpec) {
+	for i := range db.Tables {
+		if db.Tables[i].Name == t.Name {
+			db.Tables[i] = t
+			return
+		}
+	}
+	db.Tables = append(db.Tables, t)
+}
+
+func upsertMaterializedView(db *DatabaseSpec, mv MaterializedViewSpec) {
+	for i := range db.MaterializedViews {
+		if db.MaterializedViews[i].Name == mv.Name {
+			db.MaterializedViews[i] = mv
+			return
+		}
+	}
+	db.MaterializedViews = append(db.MaterializedViews, mv)
+}
+
+func upsertDictionary(db *DatabaseSpec, d DictionarySpec) {
+	for i := range db.Dictionaries {
+		if db.Dictionaries[i].Name == d.Name {
+			db.Dictionaries[i] = d
+			return
+		}
+	}
+	db.Dictionaries = append(db.Dictionaries, d)
+}
+
+func upsertView(db *DatabaseSpec, v ViewSpec) {
+	for i := range db.Views {
+		if db.Views[i].Name == v.Name {
+			db.Views[i] = v
+			return
+		}
+	}
+	db.Views = append(db.Views, v)
 }
 
 // parseCreateStatement parses a single DDL statement (the value of

--- a/internal/loader/hcl/sql_edit.go
+++ b/internal/loader/hcl/sql_edit.go
@@ -1,0 +1,540 @@
+package hcl
+
+import (
+	"fmt"
+	"strings"
+
+	chparser "github.com/orian/clickhouse-sql-parser/parser"
+)
+
+// ApplySQL parses ClickHouse DDL and applies each statement, in order, to
+// schema. It is the engine behind `hclexp sql2hcl`: developers express a change
+// as the SQL they already know and it is folded into their declarative HCL.
+//
+// Supported statements (declarative schema changes only):
+//
+//   - CREATE TABLE | MATERIALIZED VIEW | VIEW | DICTIONARY — adds the object, or
+//     replaces an existing object of the same name.
+//   - ALTER TABLE … ADD/DROP/MODIFY/RENAME COLUMN, ADD/DROP INDEX,
+//     MODIFY/REMOVE TTL, MODIFY/RESET SETTING — edits the matching table block.
+//   - ALTER TABLE <mv> MODIFY QUERY … — replaces a materialized view's query.
+//   - DROP TABLE | VIEW | DICTIONARY | DATABASE — removes the object.
+//   - RENAME TABLE a TO b — renames (and moves across databases).
+//
+// Data and partition operations (TRUNCATE, ALTER … DELETE, attach/detach/drop/
+// freeze/replace partition, materialize index/projection) carry no declarative
+// schema meaning and are rejected with a clear error.
+//
+// defaultDatabase supplies the database for unqualified object names. When it is
+// empty and the schema has exactly one database, that database is used.
+//
+// allowRaw mirrors `introspect`: a CREATE the schema model cannot express is
+// captured verbatim as a raw{} block instead of failing. (A statement that does
+// not even parse aborts the whole call — per-statement isolation is impossible
+// once the parser has rejected the input.)
+//
+// It returns the number of statements applied.
+func ApplySQL(schema *Schema, sql, defaultDatabase string, allowRaw bool) (int, error) {
+	p := chparser.NewParser(sql)
+	stmts, err := p.ParseStmts()
+	if err != nil {
+		return 0, fmt.Errorf("parse SQL: %w", err)
+	}
+	applied := 0
+	for _, stmt := range stmts {
+		if err := applyStatement(schema, stmt, defaultDatabase, allowRaw); err != nil {
+			return applied, err
+		}
+		applied++
+	}
+	return applied, nil
+}
+
+// applyStatement dispatches a single parsed statement to the right mutation.
+func applyStatement(schema *Schema, stmt chparser.Expr, defaultDatabase string, allowRaw bool) error {
+	switch s := stmt.(type) {
+	case *chparser.CreateTable, *chparser.CreateMaterializedView,
+		*chparser.CreateView, *chparser.CreateDictionary:
+		return applyCreate(schema, stmt, defaultDatabase, allowRaw)
+	case *chparser.AlterTable:
+		return applyAlter(schema, s, defaultDatabase)
+	case *chparser.DropStmt:
+		return applyDrop(schema, s, defaultDatabase)
+	case *chparser.DropDatabase:
+		return applyDropDatabase(schema, s)
+	case *chparser.RenameStmt:
+		return applyRename(schema, s, defaultDatabase)
+	default:
+		return fmt.Errorf("unsupported statement %T (sql2hcl applies declarative schema DDL: CREATE / ALTER TABLE / DROP / RENAME)", stmt)
+	}
+}
+
+// applyCreate adds or replaces an object from a CREATE statement, honoring the
+// allowRaw escape hatch when the schema model cannot express it.
+func applyCreate(schema *Schema, stmt chparser.Expr, defaultDatabase string, allowRaw bool) error {
+	dbName, name := createTarget(stmt)
+	resolved, err := resolveDatabaseName(schema, dbName, defaultDatabase)
+	if err != nil {
+		return err
+	}
+	db := findOrCreateDatabase(schema, resolved)
+	if err := upsertObjectFromStmt(db, name, stmt); err != nil {
+		if !allowRaw {
+			return fmt.Errorf("%w (re-run with -allow-raw to capture this object as a raw SQL block instead of failing)", err)
+		}
+		kind := rawKindForStmt(stmt)
+		upsertRaw(db, RawSpec{Kind: kind, Name: name, SQL: normalizeRawSQL(formatNode(stmt))})
+	}
+	return nil
+}
+
+// applyAlter applies an ALTER TABLE statement. The target is resolved as a
+// table first, then a materialized view (MODIFY QUERY only).
+func applyAlter(schema *Schema, a *chparser.AlterTable, defaultDatabase string) error {
+	dbName, name := identifierParts(a.TableIdentifier, "")
+	resolved, err := resolveDatabaseName(schema, dbName, defaultDatabase)
+	if err != nil {
+		return err
+	}
+	db := findDatabase(schema, resolved)
+	if db == nil {
+		return fmt.Errorf("ALTER TABLE %s.%s: database %q not found in schema", resolved, name, resolved)
+	}
+
+	if t := findTable(db, name); t != nil {
+		for _, clause := range a.AlterExprs {
+			if err := applyAlterClause(t, clause); err != nil {
+				return fmt.Errorf("ALTER TABLE %s.%s: %w", resolved, name, err)
+			}
+		}
+		return nil
+	}
+
+	if mv := findMaterializedView(db, name); mv != nil {
+		for _, clause := range a.AlterExprs {
+			mq, ok := clause.(*chparser.AlterTableModifyQuery)
+			if !ok {
+				return fmt.Errorf("ALTER TABLE %s.%s: only MODIFY QUERY is supported on a materialized view, got %s", resolved, name, clause.AlterType())
+			}
+			mv.Query = strings.TrimSpace(formatNode(mq.SelectExpr))
+		}
+		return nil
+	}
+
+	return fmt.Errorf("ALTER TABLE %s.%s: no such table or materialized view in schema", resolved, name)
+}
+
+// applyAlterClause applies one ALTER TABLE clause to a table block, reusing the
+// introspection AST converters so column/index decoding stays identical.
+func applyAlterClause(t *TableSpec, clause chparser.AlterTableClause) error {
+	switch c := clause.(type) {
+	case *chparser.AlterTableAddColumn:
+		col := columnFromAST(c.Column)
+		if findColumn(t, col.Name) >= 0 {
+			if c.IfNotExists {
+				return nil
+			}
+			return fmt.Errorf("ADD COLUMN %q: column already exists", col.Name)
+		}
+		after := ""
+		if c.After != nil {
+			after = identName(c.After)
+		}
+		insertColumnAfter(t, col, after)
+	case *chparser.AlterTableModifyColumn:
+		if c.RemovePropertyType != nil {
+			return fmt.Errorf("MODIFY COLUMN %s REMOVE …: not a representable declarative change", identName(c.Column.Name))
+		}
+		col := columnFromAST(c.Column)
+		idx := findColumn(t, col.Name)
+		if idx < 0 {
+			if c.IfExists {
+				return nil
+			}
+			return fmt.Errorf("MODIFY COLUMN %q: no such column", col.Name)
+		}
+		t.Columns[idx] = col
+	case *chparser.AlterTableDropColumn:
+		name := identName(c.ColumnName)
+		idx := findColumn(t, name)
+		if idx < 0 {
+			if c.IfExists {
+				return nil
+			}
+			return fmt.Errorf("DROP COLUMN %q: no such column", name)
+		}
+		t.Columns = append(t.Columns[:idx], t.Columns[idx+1:]...)
+	case *chparser.AlterTableRenameColumn:
+		old := identName(c.OldColumnName)
+		newName := identName(c.NewColumnName)
+		idx := findColumn(t, old)
+		if idx < 0 {
+			if c.IfExists {
+				return nil
+			}
+			return fmt.Errorf("RENAME COLUMN %q: no such column", old)
+		}
+		t.Columns[idx].Name = newName
+		// Record the prior name so the diff engine emits RENAME COLUMN rather
+		// than DROP + ADD when this schema is later compared against a live DB.
+		t.Columns[idx].RenamedFrom = strPtr(old)
+	case *chparser.AlterTableAddIndex:
+		idx := indexFromAST(c.Index)
+		if findIndex(t, idx.Name) >= 0 {
+			if c.IfNotExists {
+				return nil
+			}
+			return fmt.Errorf("ADD INDEX %q: index already exists", idx.Name)
+		}
+		t.Indexes = append(t.Indexes, idx)
+	case *chparser.AlterTableDropIndex:
+		name := identName(c.IndexName)
+		i := findIndex(t, name)
+		if i < 0 {
+			if c.IfExists {
+				return nil
+			}
+			return fmt.Errorf("DROP INDEX %q: no such index", name)
+		}
+		t.Indexes = append(t.Indexes[:i], t.Indexes[i+1:]...)
+	case *chparser.AlterTableModifyTTL:
+		if c.TTL != nil && len(c.TTL.Items) > 0 {
+			t.TTL = strPtr(formatNode(c.TTL.Items[0].Expr))
+		}
+	case *chparser.AlterTableRemoveTTL:
+		t.TTL = nil
+	case *chparser.AlterTableModifySetting:
+		if t.Settings == nil {
+			t.Settings = map[string]string{}
+		}
+		for _, s := range c.Settings {
+			if s.Name == nil {
+				continue
+			}
+			t.Settings[s.Name.Name] = formatNode(s.Expr)
+		}
+	case *chparser.AlterTableResetSetting:
+		for _, s := range c.Settings {
+			delete(t.Settings, s.Name)
+		}
+	default:
+		return fmt.Errorf("unsupported ALTER operation %s (not a declarative schema change)", clause.AlterType())
+	}
+	return nil
+}
+
+// applyDrop removes a table, view, materialized view, or dictionary.
+func applyDrop(schema *Schema, d *chparser.DropStmt, defaultDatabase string) error {
+	dbName, name := identifierParts(d.Name, "")
+	resolved, err := resolveDatabaseName(schema, dbName, defaultDatabase)
+	if err != nil {
+		return err
+	}
+	db := findDatabase(schema, resolved)
+	if db == nil {
+		if d.IfExists {
+			return nil
+		}
+		return fmt.Errorf("DROP %s %s.%s: database %q not found in schema", d.DropTarget, resolved, name, resolved)
+	}
+
+	removed := false
+	switch d.DropTarget {
+	case "DICTIONARY":
+		removed = removeDictionary(db, name)
+	case "VIEW":
+		// A ClickHouse materialized view is also dropped via DROP VIEW.
+		removed = removeView(db, name) || removeMaterializedView(db, name)
+	default: // TABLE
+		removed = removeTable(db, name) || removeMaterializedView(db, name) || removeRaw(db, name)
+	}
+	if !removed && !d.IfExists {
+		return fmt.Errorf("DROP %s %s.%s: no such object in schema", d.DropTarget, resolved, name)
+	}
+	return nil
+}
+
+// applyDropDatabase removes a whole database block.
+func applyDropDatabase(schema *Schema, d *chparser.DropDatabase) error {
+	name := ""
+	if d.Name != nil {
+		name = d.Name.Name
+	}
+	for i := range schema.Databases {
+		if schema.Databases[i].Name == name {
+			schema.Databases = append(schema.Databases[:i], schema.Databases[i+1:]...)
+			return nil
+		}
+	}
+	if d.IfExists {
+		return nil
+	}
+	return fmt.Errorf("DROP DATABASE %q: no such database in schema", name)
+}
+
+// applyRename renames objects (tables, MVs, views, dictionaries), moving them
+// across databases when the rename targets a different database.
+func applyRename(schema *Schema, r *chparser.RenameStmt, defaultDatabase string) error {
+	for _, pair := range r.TargetPairList {
+		oldDBName, oldName := identifierParts(pair.Old, "")
+		newDBName, newName := identifierParts(pair.New, "")
+		oldDB, err := resolveDatabaseName(schema, oldDBName, defaultDatabase)
+		if err != nil {
+			return err
+		}
+		newDB, err := resolveDatabaseName(schema, newDBName, defaultDatabase)
+		if err != nil {
+			return err
+		}
+		if err := renameObject(schema, oldDB, oldName, newDB, newName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renameObject finds the object named oldName in oldDB, renames it to newName,
+// and moves it into newDB when the databases differ.
+func renameObject(schema *Schema, oldDB, oldName, newDB, newName string) error {
+	src := findDatabase(schema, oldDB)
+	if src == nil {
+		return fmt.Errorf("RENAME %s.%s: database %q not found in schema", oldDB, oldName, oldDB)
+	}
+	dst := findOrCreateDatabase(schema, newDB)
+
+	if t := findTable(src, oldName); t != nil {
+		moved := *t
+		moved.Name = newName
+		removeTable(src, oldName)
+		upsertTable(dst, moved)
+		return nil
+	}
+	if mv := findMaterializedView(src, oldName); mv != nil {
+		moved := *mv
+		moved.Name = newName
+		removeMaterializedView(src, oldName)
+		upsertMaterializedView(dst, moved)
+		return nil
+	}
+	if v := findView(src, oldName); v != nil {
+		moved := *v
+		moved.Name = newName
+		removeView(src, oldName)
+		upsertView(dst, moved)
+		return nil
+	}
+	if d := findDictionary(src, oldName); d != nil {
+		moved := *d
+		moved.Name = newName
+		removeDictionary(src, oldName)
+		upsertDictionary(dst, moved)
+		return nil
+	}
+	return fmt.Errorf("RENAME %s.%s: no such object in schema", oldDB, oldName)
+}
+
+// --- target / name extraction helpers ---
+
+// createTarget returns the (database, name) declared by a CREATE statement.
+func createTarget(stmt chparser.Expr) (database, name string) {
+	switch s := stmt.(type) {
+	case *chparser.CreateTable:
+		return identifierParts(s.Name, "")
+	case *chparser.CreateMaterializedView:
+		return identifierParts(s.Name, "")
+	case *chparser.CreateView:
+		return identifierParts(s.Name, "")
+	case *chparser.CreateDictionary:
+		return identifierParts(s.Name, "")
+	}
+	return "", ""
+}
+
+// identifierParts splits a TableIdentifier into (database, name). database falls
+// back to defaultDB when the identifier is unqualified.
+func identifierParts(t *chparser.TableIdentifier, defaultDB string) (database, name string) {
+	if t == nil {
+		return defaultDB, ""
+	}
+	if t.Table != nil {
+		name = t.Table.Name
+	}
+	if t.Database != nil && t.Database.Name != "" {
+		return t.Database.Name, name
+	}
+	return defaultDB, name
+}
+
+// rawKindForStmt maps a parsed CREATE statement to its RawSpec kind.
+func rawKindForStmt(stmt chparser.Expr) string {
+	switch stmt.(type) {
+	case *chparser.CreateMaterializedView:
+		return "materialized_view"
+	case *chparser.CreateView:
+		return "view"
+	case *chparser.CreateDictionary:
+		return "dictionary"
+	default:
+		return "table"
+	}
+}
+
+// resolveDatabaseName picks the database for an object: the explicit name from
+// the SQL, else the -database default, else the sole database in the schema.
+func resolveDatabaseName(schema *Schema, fromSQL, defaultDatabase string) (string, error) {
+	if fromSQL != "" {
+		return fromSQL, nil
+	}
+	if defaultDatabase != "" {
+		return defaultDatabase, nil
+	}
+	if len(schema.Databases) == 1 {
+		return schema.Databases[0].Name, nil
+	}
+	return "", fmt.Errorf("object name is unqualified; pass -database or qualify the name as db.object")
+}
+
+// --- collection lookup / mutation helpers ---
+
+func findDatabase(schema *Schema, name string) *DatabaseSpec {
+	for i := range schema.Databases {
+		if schema.Databases[i].Name == name {
+			return &schema.Databases[i]
+		}
+	}
+	return nil
+}
+
+func findOrCreateDatabase(schema *Schema, name string) *DatabaseSpec {
+	if db := findDatabase(schema, name); db != nil {
+		return db
+	}
+	schema.Databases = append(schema.Databases, DatabaseSpec{Name: name})
+	return &schema.Databases[len(schema.Databases)-1]
+}
+
+func findTable(db *DatabaseSpec, name string) *TableSpec {
+	for i := range db.Tables {
+		if db.Tables[i].Name == name {
+			return &db.Tables[i]
+		}
+	}
+	return nil
+}
+
+func findMaterializedView(db *DatabaseSpec, name string) *MaterializedViewSpec {
+	for i := range db.MaterializedViews {
+		if db.MaterializedViews[i].Name == name {
+			return &db.MaterializedViews[i]
+		}
+	}
+	return nil
+}
+
+func findView(db *DatabaseSpec, name string) *ViewSpec {
+	for i := range db.Views {
+		if db.Views[i].Name == name {
+			return &db.Views[i]
+		}
+	}
+	return nil
+}
+
+func findDictionary(db *DatabaseSpec, name string) *DictionarySpec {
+	for i := range db.Dictionaries {
+		if db.Dictionaries[i].Name == name {
+			return &db.Dictionaries[i]
+		}
+	}
+	return nil
+}
+
+func removeTable(db *DatabaseSpec, name string) bool {
+	for i := range db.Tables {
+		if db.Tables[i].Name == name {
+			db.Tables = append(db.Tables[:i], db.Tables[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func removeMaterializedView(db *DatabaseSpec, name string) bool {
+	for i := range db.MaterializedViews {
+		if db.MaterializedViews[i].Name == name {
+			db.MaterializedViews = append(db.MaterializedViews[:i], db.MaterializedViews[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func removeView(db *DatabaseSpec, name string) bool {
+	for i := range db.Views {
+		if db.Views[i].Name == name {
+			db.Views = append(db.Views[:i], db.Views[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func removeDictionary(db *DatabaseSpec, name string) bool {
+	for i := range db.Dictionaries {
+		if db.Dictionaries[i].Name == name {
+			db.Dictionaries = append(db.Dictionaries[:i], db.Dictionaries[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func removeRaw(db *DatabaseSpec, name string) bool {
+	for i := range db.Raws {
+		if db.Raws[i].Name == name {
+			db.Raws = append(db.Raws[:i], db.Raws[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func upsertRaw(db *DatabaseSpec, r RawSpec) {
+	for i := range db.Raws {
+		if db.Raws[i].Name == r.Name {
+			db.Raws[i] = r
+			return
+		}
+	}
+	db.Raws = append(db.Raws, r)
+}
+
+func findColumn(t *TableSpec, name string) int {
+	for i := range t.Columns {
+		if t.Columns[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func findIndex(t *TableSpec, name string) int {
+	for i := range t.Indexes {
+		if t.Indexes[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// insertColumnAfter inserts col after the column named after; when after is
+// empty or not found, col is appended.
+func insertColumnAfter(t *TableSpec, col ColumnSpec, after string) {
+	if after != "" {
+		if idx := findColumn(t, after); idx >= 0 {
+			t.Columns = append(t.Columns[:idx+1], append([]ColumnSpec{col}, t.Columns[idx+1:]...)...)
+			return
+		}
+	}
+	t.Columns = append(t.Columns, col)
+}

--- a/internal/loader/hcl/sql_edit_test.go
+++ b/internal/loader/hcl/sql_edit_test.go
@@ -1,0 +1,298 @@
+package hcl
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseSchema returns a schema with one database "db" holding a single table
+// "events" used as the left side for ALTER/DROP/RENAME tests.
+func baseSchema() *Schema {
+	return &Schema{
+		Databases: []DatabaseSpec{{
+			Name: "db",
+			Tables: []TableSpec{{
+				Name: "events",
+				Columns: []ColumnSpec{
+					{Name: "id", Type: "UInt64"},
+					{Name: "ts", Type: "DateTime"},
+				},
+				OrderBy:  []string{"id"},
+				Settings: map[string]string{"index_granularity": "8192"},
+				Engine:   &EngineSpec{Kind: "merge_tree", Decoded: EngineMergeTree{}},
+			}},
+		}},
+	}
+}
+
+func colNames(t TableSpec) []string {
+	out := make([]string, len(t.Columns))
+	for i, c := range t.Columns {
+		out[i] = c.Name
+	}
+	return out
+}
+
+func TestApplySQL_CreateTableAddsAndReplaces(t *testing.T) {
+	s := &Schema{}
+	n, err := ApplySQL(s, `CREATE TABLE db.events (id UInt64) ENGINE = MergeTree ORDER BY id`, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	require.Len(t, s.Databases, 1)
+	require.Len(t, s.Databases[0].Tables, 1)
+	assert.Equal(t, "events", s.Databases[0].Tables[0].Name)
+	assert.Equal(t, []string{"id"}, colNames(s.Databases[0].Tables[0]))
+
+	// A second CREATE with the same name replaces the object, not appends.
+	_, err = ApplySQL(s, `CREATE TABLE db.events (id UInt64, name String) ENGINE = MergeTree ORDER BY id`, "", false)
+	require.NoError(t, err)
+	require.Len(t, s.Databases[0].Tables, 1)
+	assert.Equal(t, []string{"id", "name"}, colNames(s.Databases[0].Tables[0]))
+}
+
+func TestApplySQL_UnqualifiedUsesDefaultDatabase(t *testing.T) {
+	s := &Schema{}
+	_, err := ApplySQL(s, `CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id`, "analytics", false)
+	require.NoError(t, err)
+	require.Len(t, s.Databases, 1)
+	assert.Equal(t, "analytics", s.Databases[0].Name)
+}
+
+func TestApplySQL_UnqualifiedNoDefaultMultiDBErrors(t *testing.T) {
+	s := &Schema{Databases: []DatabaseSpec{{Name: "a"}, {Name: "b"}}}
+	_, err := ApplySQL(s, `CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id`, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unqualified")
+}
+
+func TestApplySQL_AlterAddColumn(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events ADD COLUMN name String`, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id", "ts", "name"}, colNames(s.Databases[0].Tables[0]))
+}
+
+func TestApplySQL_AlterAddColumnAfter(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events ADD COLUMN name String AFTER id`, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id", "name", "ts"}, colNames(s.Databases[0].Tables[0]))
+}
+
+func TestApplySQL_AlterAddColumnDuplicateErrors(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events ADD COLUMN id UInt64`, "", false)
+	require.Error(t, err)
+
+	// IF NOT EXISTS makes the duplicate a no-op.
+	s = baseSchema()
+	_, err = ApplySQL(s, `ALTER TABLE db.events ADD COLUMN IF NOT EXISTS id UInt64`, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id", "ts"}, colNames(s.Databases[0].Tables[0]))
+}
+
+func TestApplySQL_AlterModifyColumn(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events MODIFY COLUMN ts DateTime64(3)`, "", false)
+	require.NoError(t, err)
+	cols := s.Databases[0].Tables[0].Columns
+	assert.Equal(t, "DateTime64(3)", cols[1].Type)
+}
+
+func TestApplySQL_AlterDropColumn(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events DROP COLUMN ts`, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, colNames(s.Databases[0].Tables[0]))
+
+	_, err = ApplySQL(s, `ALTER TABLE db.events DROP COLUMN nope`, "", false)
+	require.Error(t, err)
+}
+
+func TestApplySQL_AlterRenameColumnRecordsRenamedFrom(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events RENAME COLUMN ts TO event_time`, "", false)
+	require.NoError(t, err)
+	cols := s.Databases[0].Tables[0].Columns
+	assert.Equal(t, "event_time", cols[1].Name)
+	require.NotNil(t, cols[1].RenamedFrom)
+	assert.Equal(t, "ts", *cols[1].RenamedFrom)
+}
+
+func TestApplySQL_AlterIndex(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events ADD INDEX idx_ts ts TYPE minmax GRANULARITY 4`, "", false)
+	require.NoError(t, err)
+	require.Len(t, s.Databases[0].Tables[0].Indexes, 1)
+	assert.Equal(t, "idx_ts", s.Databases[0].Tables[0].Indexes[0].Name)
+
+	_, err = ApplySQL(s, `ALTER TABLE db.events DROP INDEX idx_ts`, "", false)
+	require.NoError(t, err)
+	assert.Empty(t, s.Databases[0].Tables[0].Indexes)
+}
+
+func TestApplySQL_AlterSettings(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events MODIFY SETTING index_granularity = 4096`, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, "4096", s.Databases[0].Tables[0].Settings["index_granularity"])
+
+	_, err = ApplySQL(s, `ALTER TABLE db.events RESET SETTING index_granularity`, "", false)
+	require.NoError(t, err)
+	_, ok := s.Databases[0].Tables[0].Settings["index_granularity"]
+	assert.False(t, ok)
+}
+
+func TestApplySQL_AlterTTL(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.events MODIFY TTL ts + INTERVAL 30 DAY`, "", false)
+	require.NoError(t, err)
+	require.NotNil(t, s.Databases[0].Tables[0].TTL)
+
+	_, err = ApplySQL(s, `ALTER TABLE db.events REMOVE TTL`, "", false)
+	require.NoError(t, err)
+	assert.Nil(t, s.Databases[0].Tables[0].TTL)
+}
+
+func TestApplySQL_AlterMaterializedViewModifyQuery(t *testing.T) {
+	s := &Schema{Databases: []DatabaseSpec{{
+		Name: "db",
+		MaterializedViews: []MaterializedViewSpec{{
+			Name:    "mv",
+			ToTable: "db.dest",
+			Query:   "SELECT id FROM db.events",
+		}},
+	}}}
+	_, err := ApplySQL(s, `ALTER TABLE db.mv MODIFY QUERY SELECT id, ts FROM db.events`, "", false)
+	require.NoError(t, err)
+	assert.Contains(t, s.Databases[0].MaterializedViews[0].Query, "ts")
+}
+
+func TestApplySQL_AlterMissingTableErrors(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `ALTER TABLE db.missing ADD COLUMN x String`, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such table")
+}
+
+func TestApplySQL_DropTable(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `DROP TABLE db.events`, "", false)
+	require.NoError(t, err)
+	assert.Empty(t, s.Databases[0].Tables)
+
+	// Dropping a missing table errors unless IF EXISTS.
+	_, err = ApplySQL(s, `DROP TABLE db.events`, "", false)
+	require.Error(t, err)
+	_, err = ApplySQL(s, `DROP TABLE IF EXISTS db.events`, "", false)
+	require.NoError(t, err)
+}
+
+func TestApplySQL_RenameTable(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `RENAME TABLE db.events TO db.events_v2`, "", false)
+	require.NoError(t, err)
+	require.Len(t, s.Databases[0].Tables, 1)
+	assert.Equal(t, "events_v2", s.Databases[0].Tables[0].Name)
+}
+
+func TestApplySQL_MultipleStatementsInOrder(t *testing.T) {
+	s := baseSchema()
+	sql := `
+		ALTER TABLE db.events ADD COLUMN name String;
+		ALTER TABLE db.events ADD COLUMN city String AFTER name;
+		ALTER TABLE db.events DROP COLUMN ts;
+	`
+	n, err := ApplySQL(s, sql, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, []string{"id", "name", "city"}, colNames(s.Databases[0].Tables[0]))
+}
+
+func TestApplySQL_RejectsDataOperations(t *testing.T) {
+	for _, sql := range []string{
+		`TRUNCATE TABLE db.events`,
+		`ALTER TABLE db.events DELETE WHERE id = 1`,
+		`ALTER TABLE db.events DROP PARTITION '2024-01-01'`,
+	} {
+		s := baseSchema()
+		_, err := ApplySQL(s, sql, "", false)
+		require.Error(t, err, "expected rejection for %q", sql)
+	}
+}
+
+func TestApplySQL_AllowRawCapturesUnexpressibleCreate(t *testing.T) {
+	// An inner-engine (non-TO-form) materialized view is parseable but not
+	// expressible in the typed model. Strict mode fails; allow-raw captures it.
+	sql := `CREATE MATERIALIZED VIEW db.mv ENGINE = MergeTree ORDER BY id AS SELECT id FROM db.events`
+
+	s := &Schema{}
+	_, err := ApplySQL(s, sql, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-allow-raw")
+
+	s = &Schema{}
+	_, err = ApplySQL(s, sql, "", true)
+	require.NoError(t, err)
+	require.Len(t, s.Databases, 1)
+	require.Len(t, s.Databases[0].Raws, 1)
+	assert.Equal(t, "materialized_view", s.Databases[0].Raws[0].Kind)
+	assert.Equal(t, "mv", s.Databases[0].Raws[0].Name)
+}
+
+func TestApplySQL_ParseErrorAborts(t *testing.T) {
+	s := baseSchema()
+	_, err := ApplySQL(s, `this is not valid sql`, "", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse SQL")
+}
+
+// TestApplySQL_RoundTripThroughHCL exercises the real sql2hcl path: parse HCL
+// from disk, resolve, apply SQL edits, emit HCL, and re-parse the emitted HCL —
+// confirming the edit survives a full load/edit/emit/reload round-trip.
+func TestApplySQL_RoundTripThroughHCL(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "schema.hcl")
+	require.NoError(t, os.WriteFile(src, []byte(`
+database "db" {
+  table "events" {
+    order_by = ["id"]
+    column "id" { type = "UInt64" }
+    column "ts" { type = "DateTime" }
+    engine "merge_tree" {}
+  }
+}
+`), 0o644))
+
+	schema, err := ParseFile(src)
+	require.NoError(t, err)
+	require.NoError(t, Resolve(schema))
+
+	_, err = ApplySQL(schema, `
+		ALTER TABLE db.events ADD COLUMN name String AFTER id;
+		CREATE TABLE db.users (uid UInt64) ENGINE = MergeTree ORDER BY uid;
+	`, "", false)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, Write(&buf, schema))
+
+	out := filepath.Join(dir, "out.hcl")
+	require.NoError(t, os.WriteFile(out, buf.Bytes(), 0o644))
+	reparsed, err := ParseFile(out)
+	require.NoError(t, err)
+
+	require.Len(t, reparsed.Databases, 1)
+	db := reparsed.Databases[0]
+	require.Len(t, db.Tables, 2)
+
+	events := db.Tables[0]
+	require.Equal(t, "events", events.Name)
+	assert.Equal(t, []string{"id", "name", "ts"}, colNames(events))
+	assert.Equal(t, "users", db.Tables[1].Name)
+}


### PR DESCRIPTION
## What

A new `hclexp sql2hcl` subcommand. Developers already know ClickHouse SQL — this lets them change a schema with the DDL they'd naturally write instead of hand-editing HCL. It loads the existing HCL (the **left side**), applies SQL statements to it, and emits the updated HCL.

```sh
echo 'ALTER TABLE db.events ADD COLUMN name String AFTER id;' | hclexp sql2hcl -left ./schema

hclexp sql2hcl -left ./schema -in change.sql -out /tmp/updated.hcl
hclexp diff -left ./schema -right /tmp/updated.hcl -sql   # preview the migration
```

## How

The SQL→spec→HCL machinery already existed and is decoupled from any live ClickHouse connection — introspection only uses the DB to *fetch* `create_table_query` strings. This reuses it rather than adding a new parser/emitter:

- The CREATE-routing switch in `introspectOneObject` is extracted into a shared `upsertObjectFromStmt` (add-or-replace by name). Introspection behavior is unchanged.
- New `ApplySQL` engine (`internal/loader/hcl/sql_edit.go`) routes `ALTER` clauses through the same `columnFromAST`/`indexFromAST` converters.

### Supported statements
- `CREATE TABLE / MATERIALIZED VIEW / VIEW / DICTIONARY` — add or replace by name
- `ALTER TABLE …` — add/drop/modify/rename column (records `renamed_from`), add/drop index, modify/remove TTL, modify/reset setting
- `ALTER TABLE <mv> MODIFY QUERY …`
- `DROP TABLE/VIEW/DICTIONARY/DATABASE` (`IF EXISTS` → no-op)
- `RENAME TABLE a TO b` (cross-database moves)

### Flags
`-left` (file or layer dirs), `-in` (file/stdin), `-out` (stdout/file/dir), `-database` (default DB for unqualified names), `-allow-raw` (capture unexpressible CREATE as a `raw{}` block, like `introspect`).

## Scope boundary
- **Schema state only** — `TRUNCATE`, `ALTER … DELETE`, partition ops, and `MATERIALIZE …` are rejected with a clear error.
- Output is the **resolved (flat) schema**; it does not rewrite layered source files in place. Review the emitted HCL / `diff -sql` and integrate.

## Tests
21 tests in `sql_edit_test.go` covering CREATE add/replace, every ALTER op, MV modify-query, DROP, RENAME, multi-statement ordering, default-database resolution, rejected ops, `-allow-raw`, and a full `ParseFile → ApplySQL → Write → re-parse` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)