### PR TITLE
Add hclexp web: read-only schema browser with data-flow view

### DIFF
--- a/cmd/hclexp/flows.go
+++ b/cmd/hclexp/flows.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
+)
+
+// A flowStage is one node in a data-flow chain (a table or materialized view).
+type flowStage struct {
+	Kind      string // object kind: table | materialized_view | raw
+	KindLabel string
+	Engine    string // engine kind for tables (kafka, distributed, ...); "" for MVs
+	Database  string
+	Name      string
+	Detail    string // optional subtitle (topic=…, cluster=…)
+	Href      string // detail-page link; "" when the object isn't declared
+	Declared  bool
+	EdgeLabel string // label on the arrow leading into this stage (empty for the first)
+}
+
+// A flow is a single linear ingestion chain from a source to a terminal table.
+type flow struct {
+	Anchor string
+	Stages []flowStage
+}
+
+type flowsData struct {
+	Title string
+	Flows []flow
+}
+
+// flowBuilder holds the indexes used to reconstruct flows from the dependency
+// graph and the resolved schema.
+type flowBuilder struct {
+	kindIndex  map[string]string              // ref -> object kind
+	engineKind map[string]string              // ref -> engine kind (tables only)
+	detail     map[string]string              // ref -> stage subtitle
+	readBy     map[string][]hclload.ObjectRef // source table ref -> MVs reading it
+	mvDest     map[string]hclload.ObjectRef   // MV ref -> its target
+	distRemote map[string]hclload.ObjectRef   // Distributed ref -> its storage table
+	produced   map[string]bool                // refs that are an MV/Distributed target
+}
+
+// buildFlows reconstructs every MV ingestion chain in the schema and returns the
+// flows plus a map from each participating object ref to its (first) flow anchor.
+func buildFlows(schema *hclload.Schema, deps []hclload.Dependency, kindIndex map[string]string) ([]flow, map[string]string) {
+	b := &flowBuilder{
+		kindIndex:  kindIndex,
+		engineKind: map[string]string{},
+		detail:     map[string]string{},
+		readBy:     map[string][]hclload.ObjectRef{},
+		mvDest:     map[string]hclload.ObjectRef{},
+		distRemote: map[string]hclload.ObjectRef{},
+		produced:   map[string]bool{},
+	}
+
+	for i := range schema.Databases {
+		db := &schema.Databases[i]
+		for j := range db.Tables {
+			t := &db.Tables[j]
+			ref := indexKey(db.Name, t.Name)
+			if t.Engine != nil {
+				b.engineKind[ref] = t.Engine.Kind
+				b.detail[ref] = engineDetail(t.Engine)
+			}
+		}
+	}
+
+	for _, d := range deps {
+		switch d.Kind {
+		case hclload.DepMVSource:
+			to := indexKey(d.To.Database, d.To.Name)
+			b.readBy[to] = append(b.readBy[to], d.From)
+		case hclload.DepMVDest:
+			b.mvDest[indexKey(d.From.Database, d.From.Name)] = d.To
+			b.produced[indexKey(d.To.Database, d.To.Name)] = true
+		case hclload.DepDistributedRemote:
+			b.distRemote[indexKey(d.From.Database, d.From.Name)] = d.To
+			b.produced[indexKey(d.To.Database, d.To.Name)] = true
+		}
+	}
+
+	// Roots: source tables read by an MV that are not themselves produced by one.
+	var roots []hclload.ObjectRef
+	for ref, mvs := range b.readBy {
+		if len(mvs) == 0 || b.produced[ref] {
+			continue
+		}
+		// Recover an ObjectRef from any reading MV's edge target.
+		roots = append(roots, refOfKey(ref))
+	}
+	sort.Slice(roots, func(i, j int) bool { return roots[i].String() < roots[j].String() })
+
+	var flows []flow
+	for _, root := range roots {
+		b.walk(root, []flowStage{b.tableStage(root, "")}, map[string]bool{indexKey(root.Database, root.Name): true}, &flows)
+	}
+
+	anchorByRef := map[string]string{}
+	for i := range flows {
+		flows[i].Anchor = fmt.Sprintf("flow-%d", i+1)
+		for _, st := range flows[i].Stages {
+			ref := indexKey(st.Database, st.Name)
+			if _, seen := anchorByRef[ref]; !seen {
+				anchorByRef[ref] = flows[i].Anchor
+			}
+		}
+	}
+	return flows, anchorByRef
+}
+
+// walk extends the current chain (whose last stage is the table tableRef) through
+// every MV that reads it, appending completed root→leaf paths to out.
+func (b *flowBuilder) walk(tableRef hclload.ObjectRef, stages []flowStage, visited map[string]bool, out *[]flow) {
+	consumers := b.readBy[indexKey(tableRef.Database, tableRef.Name)]
+	if len(consumers) == 0 {
+		*out = append(*out, flow{Stages: stages})
+		return
+	}
+	sort.Slice(consumers, func(i, j int) bool { return consumers[i].String() < consumers[j].String() })
+
+	for _, mv := range consumers {
+		mvKey := indexKey(mv.Database, mv.Name)
+		if visited[mvKey] {
+			continue // cycle guard
+		}
+		dest, ok := b.mvDest[mvKey]
+		if !ok {
+			// MV with no recorded destination; end the chain at the MV.
+			*out = append(*out, flow{Stages: append(clone(stages), b.mvStage(mv, "reads"))})
+			continue
+		}
+		stagesA := append(clone(stages), b.mvStage(mv, "reads"))
+		destKey := indexKey(dest.Database, dest.Name)
+
+		if b.engineKind[destKey] == "distributed" {
+			stagesB := append(stagesA, b.tableStage(dest, "writes to"))
+			remote, hasRemote := b.distRemote[destKey]
+			if !hasRemote {
+				*out = append(*out, flow{Stages: stagesB})
+				continue
+			}
+			stagesC := append(stagesB, b.tableStage(remote, "forwards to"))
+			b.descend(remote, stagesC, visited, mvKey, out)
+			continue
+		}
+
+		stagesB := append(stagesA, b.tableStage(dest, "writes to"))
+		b.descend(dest, stagesB, visited, mvKey, out)
+	}
+}
+
+// descend continues a chain from the next storage table, carrying a fresh visited
+// set (with the just-used MV added) so sibling branches stay independent.
+func (b *flowBuilder) descend(next hclload.ObjectRef, stages []flowStage, visited map[string]bool, usedMV string, out *[]flow) {
+	nextKey := indexKey(next.Database, next.Name)
+	if visited[nextKey] {
+		*out = append(*out, flow{Stages: stages})
+		return
+	}
+	v := cloneSet(visited)
+	v[usedMV] = true
+	v[nextKey] = true
+	b.walk(next, stages, v, out)
+}
+
+func (b *flowBuilder) tableStage(ref hclload.ObjectRef, edge string) flowStage {
+	key := indexKey(ref.Database, ref.Name)
+	kind := b.kindIndex[key]
+	declared := kind != ""
+	if kind == "" {
+		kind = hclload.KindTable
+	}
+	st := flowStage{
+		Kind:      kind,
+		KindLabel: kindLabel(kind),
+		Engine:    b.engineKind[key],
+		Database:  ref.Database,
+		Name:      ref.Name,
+		Detail:    b.detail[key],
+		Declared:  declared,
+		EdgeLabel: edge,
+	}
+	if declared {
+		st.Href = objectHref(ref.Database, kind, ref.Name)
+	}
+	return st
+}
+
+func (b *flowBuilder) mvStage(ref hclload.ObjectRef, edge string) flowStage {
+	key := indexKey(ref.Database, ref.Name)
+	declared := b.kindIndex[key] != ""
+	st := flowStage{
+		Kind:      hclload.KindMaterializedView,
+		KindLabel: kindLabel(hclload.KindMaterializedView),
+		Database:  ref.Database,
+		Name:      ref.Name,
+		Declared:  declared,
+		EdgeLabel: edge,
+	}
+	if declared {
+		st.Href = objectHref(ref.Database, hclload.KindMaterializedView, ref.Name)
+	}
+	return st
+}
+
+// engineDetail returns a short subtitle for a table's engine, surfacing the
+// fields most useful when reading an ingestion chain.
+func engineDetail(spec *hclload.EngineSpec) string {
+	if spec == nil || spec.Decoded == nil {
+		return ""
+	}
+	switch e := spec.Decoded.(type) {
+	case hclload.EngineKafka:
+		if e.Collection != nil && *e.Collection != "" {
+			return "collection=" + *e.Collection
+		}
+		if e.TopicList != nil && *e.TopicList != "" {
+			return "topic=" + *e.TopicList
+		}
+	case hclload.EngineDistributed:
+		if e.ClusterName != "" {
+			return "cluster=" + e.ClusterName
+		}
+	}
+	return ""
+}
+
+func (s *webServer) handleFlows(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/flows" {
+		s.notFound(w)
+		return
+	}
+	s.render(w, s.tmplFlows, flowsData{Title: "Data flows", Flows: s.flows})
+}
+
+// refOfKey reverses indexKey for the root lookup.
+func refOfKey(key string) hclload.ObjectRef {
+	for i := 0; i < len(key); i++ {
+		if key[i] == '\x00' {
+			return hclload.ObjectRef{Database: key[:i], Name: key[i+1:]}
+		}
+	}
+	return hclload.ObjectRef{Name: key}
+}
+
+func clone(s []flowStage) []flowStage {
+	out := make([]flowStage, len(s))
+	copy(out, s)
+	return out
+}
+
+func cloneSet(m map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/cmd/hclexp/hclexp.go
+++ b/cmd/hclexp/hclexp.go
@@ -49,6 +49,9 @@ func main() {
 	case "load":
 		runLoad(os.Args[2:])
 		return
+	case "web":
+		runWeb(os.Args[2:])
+		return
 	}
 
 	// A flag as the first argument (e.g. -config, -layer) is the
@@ -79,6 +82,7 @@ Commands:
   drift        detect cross-node schema drift across per-node HCL dumps
   sql2hcl      apply SQL DDL edits (CREATE/ALTER/DROP/RENAME) to an HCL schema
   load         parse and resolve an HCL config (default when flags are given)
+  web          serve a read-only web UI to browse the resolved schema
   help         print this help
 
 Run "hclexp <command> -h" for command-specific flags.

--- a/cmd/hclexp/web.go
+++ b/cmd/hclexp/web.go
@@ -1,0 +1,729 @@
+package main
+
+import (
+	"embed"
+	"flag"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
+)
+
+//go:embed web/layout.html web/index.html web/object.html web/flows.html web/static/*
+var webFS embed.FS
+
+// runWeb loads an HCL config (single file or layers), resolves it, and serves a
+// read-only web UI for browsing databases and their objects. It mirrors the
+// load/resolve flow of the other subcommands; no ClickHouse connection is made.
+func runWeb(args []string) {
+	flags := flag.NewFlagSet("hclexp web", flag.ExitOnError)
+	configFlag := flags.String("config", "./cmd/hclexp/node.conf", "path to a single HCL config file (mutually exclusive with -layer)")
+	layersFlag := flags.String("layer", "", "comma-separated list of layer directories (loaded in order)")
+	addrFlag := flags.String("addr", ":8080", "address to listen on (host:port)")
+	_ = flags.Parse(args)
+
+	schema, err := load(*configFlag, *layersFlag)
+	if err != nil {
+		slog.Error("failed to load config", "err", err)
+		os.Exit(1)
+	}
+	if err := hclload.Resolve(schema); err != nil {
+		slog.Error("failed to resolve schema", "err", err)
+		os.Exit(1)
+	}
+
+	srv, err := newWebServer(schema)
+	if err != nil {
+		slog.Error("failed to build web server", "err", err)
+		os.Exit(1)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", srv.handleIndex)
+	mux.HandleFunc("/flows", srv.handleFlows)
+	mux.HandleFunc("/db/", srv.handleObject)
+	staticSub, _ := fs.Sub(webFS, "web/static")
+	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))
+
+	slog.Info("serving schema browser", "addr", *addrFlag, "url", "http://localhost"+*addrFlag+"/")
+	if err := http.ListenAndServe(*addrFlag, mux); err != nil {
+		slog.Error("web server stopped", "err", err)
+		os.Exit(1)
+	}
+}
+
+// webServer holds the resolved schema, parsed templates, and the precomputed
+// dependency graph + object kind index used for cross-linking.
+type webServer struct {
+	schema      *hclload.Schema
+	tmplIndex   *template.Template
+	tmplObject  *template.Template
+	tmplFlows   *template.Template
+	deps        []hclload.Dependency
+	kindIndex   map[string]string // "db\x00name" -> object kind
+	flows       []flow
+	flowAnchors map[string]string // "db\x00name" -> anchor of the first flow it appears in
+}
+
+func newWebServer(schema *hclload.Schema) (*webServer, error) {
+	funcs := template.FuncMap{"dict": templateDict}
+	tmplIndex, err := template.New("layout").Funcs(funcs).ParseFS(webFS, "web/layout.html", "web/index.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse index template: %w", err)
+	}
+	tmplObject, err := template.New("layout").Funcs(funcs).ParseFS(webFS, "web/layout.html", "web/object.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse object template: %w", err)
+	}
+	tmplFlows, err := template.New("layout").Funcs(funcs).ParseFS(webFS, "web/layout.html", "web/flows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse flows template: %w", err)
+	}
+
+	deps, err := hclload.CollectDependencies(schema.Databases)
+	if err != nil {
+		// A query that won't parse shouldn't take the whole UI down; browsing
+		// still works without cross-links.
+		slog.Warn("dependency graph unavailable; object cross-links disabled", "err", err)
+		deps = nil
+	}
+
+	s := &webServer{
+		schema:     schema,
+		tmplIndex:  tmplIndex,
+		tmplObject: tmplObject,
+		tmplFlows:  tmplFlows,
+		deps:       deps,
+		kindIndex:  map[string]string{},
+	}
+	for i := range schema.Databases {
+		db := &schema.Databases[i]
+		for _, t := range db.Tables {
+			s.kindIndex[indexKey(db.Name, t.Name)] = hclload.KindTable
+		}
+		for _, mv := range db.MaterializedViews {
+			s.kindIndex[indexKey(db.Name, mv.Name)] = hclload.KindMaterializedView
+		}
+		for _, v := range db.Views {
+			s.kindIndex[indexKey(db.Name, v.Name)] = hclload.KindView
+		}
+		for _, d := range db.Dictionaries {
+			s.kindIndex[indexKey(db.Name, d.Name)] = hclload.KindDictionary
+		}
+		for _, r := range db.Raws {
+			s.kindIndex[indexKey(db.Name, r.Name)] = hclload.KindRaw
+		}
+	}
+	s.flows, s.flowAnchors = buildFlows(schema, s.deps, s.kindIndex)
+	return s, nil
+}
+
+func indexKey(db, name string) string { return db + "\x00" + name }
+
+// templateDict builds a map from alternating key/value args, letting templates
+// pass multiple named values to a sub-template (used by the "objgroup" block).
+func templateDict(pairs ...any) (map[string]any, error) {
+	if len(pairs)%2 != 0 {
+		return nil, fmt.Errorf("dict: odd number of arguments")
+	}
+	m := make(map[string]any, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		k, ok := pairs[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("dict: key %d is not a string", i)
+		}
+		m[k] = pairs[i+1]
+	}
+	return m, nil
+}
+
+// ---- view models ----
+
+type kv struct{ K, V string }
+
+type tableSection struct {
+	Title       string
+	Headers     []string
+	Rows        [][]string
+	Collapsible bool // long column lists can be collapsed to the first 10 rows
+}
+
+type objLink struct {
+	Kind  string
+	Name  string
+	Label string // human label (e.g. "db.name" for deps)
+	Href  string
+}
+
+type dbView struct {
+	Name              string
+	Cluster           string
+	Tables            []objLink
+	MaterializedViews []objLink
+	Views             []objLink
+	Dictionaries      []objLink
+	Raws              []objLink
+}
+
+type indexData struct {
+	Title            string
+	Databases        []dbView
+	NamedCollections []string
+	Nodes            []string
+}
+
+type objectData struct {
+	Title      string
+	Database   string
+	Kind       string
+	KindLabel  string
+	Name       string
+	View       string // "html" | "ddl" | "hcl"
+	HTMLHref   string
+	DDLHref    string
+	HCLHref    string
+	Props      []kv
+	Tables     []tableSection
+	Query      string
+	RawSQL     string
+	Code       string // rendered DDL or HCL for those views
+	FlowAnchor string // anchor on /flows when this object participates in a flow
+	DependsOn  []objLink
+	DependedBy []objLink
+}
+
+// columnCollapseLimit is the row count above which a collapsible column list is
+// folded by default; it must match the LIMIT constant in web/static/app.js.
+const columnCollapseLimit = 10
+
+// ---- handlers ----
+
+func (s *webServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		s.notFound(w)
+		return
+	}
+	data := indexData{Title: "Schema"}
+	for i := range s.schema.Databases {
+		db := &s.schema.Databases[i]
+		dv := dbView{Name: db.Name}
+		if db.Cluster != nil {
+			dv.Cluster = *db.Cluster
+		}
+		for _, t := range db.Tables {
+			dv.Tables = append(dv.Tables, s.objLink(db.Name, hclload.KindTable, t.Name))
+		}
+		for _, mv := range db.MaterializedViews {
+			dv.MaterializedViews = append(dv.MaterializedViews, s.objLink(db.Name, hclload.KindMaterializedView, mv.Name))
+		}
+		for _, v := range db.Views {
+			dv.Views = append(dv.Views, s.objLink(db.Name, hclload.KindView, v.Name))
+		}
+		for _, d := range db.Dictionaries {
+			dv.Dictionaries = append(dv.Dictionaries, s.objLink(db.Name, hclload.KindDictionary, d.Name))
+		}
+		for _, raw := range db.Raws {
+			dv.Raws = append(dv.Raws, s.objLink(db.Name, hclload.KindRaw, raw.Name))
+		}
+		data.Databases = append(data.Databases, dv)
+	}
+	for _, nc := range s.schema.NamedCollections {
+		data.NamedCollections = append(data.NamedCollections, nc.Name)
+	}
+	for _, n := range s.schema.Nodes {
+		data.Nodes = append(data.Nodes, n.Name)
+	}
+	s.render(w, s.tmplIndex, data)
+}
+
+func (s *webServer) handleObject(w http.ResponseWriter, r *http.Request) {
+	// Path: /db/{database}/{kind}/{name}
+	rest := strings.TrimPrefix(r.URL.Path, "/db/")
+	parts := strings.SplitN(rest, "/", 3)
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		s.notFound(w)
+		return
+	}
+	database := unescape(parts[0])
+	kind := unescape(parts[1])
+	name := unescape(parts[2])
+
+	db := s.findDatabase(database)
+	if db == nil {
+		s.notFound(w)
+		return
+	}
+
+	view := r.URL.Query().Get("view")
+	if view != "ddl" && view != "hcl" {
+		view = "html"
+	}
+
+	data := objectData{
+		Title:     name,
+		Database:  database,
+		Kind:      kind,
+		KindLabel: kindLabel(kind),
+		Name:      name,
+		View:      view,
+		HTMLHref:  objectHref(database, kind, name) + "?view=html",
+		DDLHref:   objectHref(database, kind, name) + "?view=ddl",
+		HCLHref:   objectHref(database, kind, name) + "?view=hcl",
+	}
+
+	switch view {
+	case "ddl":
+		code, err := hclload.RenderObjectSQL(database, kind, name, db)
+		if err != nil {
+			s.notFound(w)
+			return
+		}
+		data.Code = code
+	case "hcl":
+		code, err := hclload.RenderObjectHCL(database, kind, name, db)
+		if err != nil {
+			s.notFound(w)
+			return
+		}
+		data.Code = code
+	default:
+		if !s.buildHTMLView(&data, db, kind, name) {
+			s.notFound(w)
+			return
+		}
+	}
+
+	data.FlowAnchor = s.flowAnchors[indexKey(database, name)]
+	s.buildDeps(&data, database, name)
+	s.render(w, s.tmplObject, data)
+}
+
+// buildHTMLView fills the structured (simplified) view for an object. It returns
+// false if no object of that kind/name exists.
+func (s *webServer) buildHTMLView(data *objectData, db *hclload.DatabaseSpec, kind, name string) bool {
+	switch kind {
+	case hclload.KindTable:
+		t := findTable(db, name)
+		if t == nil {
+			return false
+		}
+		data.Props = tableProps(*t)
+		data.Tables = append(data.Tables, columnsSection(t.Columns))
+		if sec, ok := indexesSection(t.Indexes); ok {
+			data.Tables = append(data.Tables, sec)
+		}
+		if sec, ok := constraintsSection(t.Constraints); ok {
+			data.Tables = append(data.Tables, sec)
+		}
+	case hclload.KindMaterializedView:
+		mv := findMaterializedView(db, name)
+		if mv == nil {
+			return false
+		}
+		data.Props = mvProps(*mv)
+		if len(mv.Columns) > 0 {
+			data.Tables = append(data.Tables, columnsSection(mv.Columns))
+		}
+		data.Query = mv.Query
+	case hclload.KindView:
+		v := findView(db, name)
+		if v == nil {
+			return false
+		}
+		data.Props = viewProps(*v)
+		data.Query = v.Query
+	case hclload.KindDictionary:
+		d := findDictionary(db, name)
+		if d == nil {
+			return false
+		}
+		data.Props = dictProps(*d)
+		data.Tables = append(data.Tables, dictAttributesSection(d.Attributes))
+	case hclload.KindRaw:
+		r := findRaw(db, name)
+		if r == nil {
+			return false
+		}
+		data.Props = []kv{{"kind", r.Kind}}
+		data.RawSQL = r.SQL
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *webServer) buildDeps(data *objectData, database, name string) {
+	self := hclload.ObjectRef{Database: database, Name: name}
+	seenOut := map[string]bool{}
+	seenIn := map[string]bool{}
+	for _, d := range s.deps {
+		if d.From == self {
+			ref := d.To
+			key := ref.String() + "|" + d.Kind
+			if !seenOut[key] {
+				seenOut[key] = true
+				data.DependsOn = append(data.DependsOn, s.depLink(ref, d.Kind))
+			}
+		}
+		if d.To == self {
+			ref := d.From
+			key := ref.String() + "|" + d.Kind
+			if !seenIn[key] {
+				seenIn[key] = true
+				data.DependedBy = append(data.DependedBy, s.depLink(ref, d.Kind))
+			}
+		}
+	}
+}
+
+func (s *webServer) depLink(ref hclload.ObjectRef, depKind string) objLink {
+	kind := s.kindIndex[indexKey(ref.Database, ref.Name)]
+	if kind == "" {
+		kind = hclload.KindTable
+	}
+	return objLink{
+		Kind:  kind,
+		Name:  ref.Name,
+		Label: ref.String() + " (" + depKind + ")",
+		Href:  objectHref(ref.Database, kind, ref.Name),
+	}
+}
+
+func (s *webServer) objLink(database, kind, name string) objLink {
+	return objLink{Kind: kind, Name: name, Label: name, Href: objectHref(database, kind, name)}
+}
+
+func (s *webServer) findDatabase(name string) *hclload.DatabaseSpec {
+	for i := range s.schema.Databases {
+		if s.schema.Databases[i].Name == name {
+			return &s.schema.Databases[i]
+		}
+	}
+	return nil
+}
+
+func (s *webServer) render(w http.ResponseWriter, t *template.Template, data any) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := t.ExecuteTemplate(w, "layout", data); err != nil {
+		slog.Error("template execution failed", "err", err)
+	}
+}
+
+func (s *webServer) notFound(w http.ResponseWriter) {
+	http.Error(w, "not found", http.StatusNotFound)
+}
+
+// ---- property/section builders ----
+
+func tableProps(t hclload.TableSpec) []kv {
+	props := engineProps(t.Engine)
+	props = appendList(props, "primary_key", t.PrimaryKey)
+	props = appendList(props, "order_by", t.OrderBy)
+	props = appendPtr(props, "partition_by", t.PartitionBy)
+	props = appendPtr(props, "sample_by", t.SampleBy)
+	props = appendPtr(props, "ttl", t.TTL)
+	props = appendPtr(props, "cluster", t.Cluster)
+	props = appendPtr(props, "comment", t.Comment)
+	props = appendMap(props, t.Settings)
+	return props
+}
+
+func mvProps(mv hclload.MaterializedViewSpec) []kv {
+	var props []kv
+	if mv.ToTable != "" {
+		props = append(props, kv{"to_table", mv.ToTable})
+	}
+	props = appendPtr(props, "cluster", mv.Cluster)
+	props = appendPtr(props, "comment", mv.Comment)
+	return props
+}
+
+func viewProps(v hclload.ViewSpec) []kv {
+	var props []kv
+	props = appendList(props, "column_aliases", v.ColumnAliases)
+	props = appendPtr(props, "sql_security", v.SQLSecurity)
+	props = appendPtr(props, "definer", v.Definer)
+	props = appendPtr(props, "cluster", v.Cluster)
+	props = appendPtr(props, "comment", v.Comment)
+	return props
+}
+
+func dictProps(d hclload.DictionarySpec) []kv {
+	var props []kv
+	props = appendList(props, "primary_key", d.PrimaryKey)
+	if d.Source != nil {
+		props = append(props, kv{"source", d.Source.Kind})
+	}
+	if d.Layout != nil {
+		props = append(props, kv{"layout", d.Layout.Kind})
+	}
+	props = appendPtr(props, "cluster", d.Cluster)
+	props = appendPtr(props, "comment", d.Comment)
+	props = appendMap(props, d.Settings)
+	return props
+}
+
+func columnsSection(cols []hclload.ColumnSpec) tableSection {
+	sec := tableSection{
+		Title:       "Columns",
+		Headers:     []string{"name", "type", "nullable", "default", "codec", "ttl", "comment"},
+		Collapsible: len(cols) > columnCollapseLimit,
+	}
+	for _, c := range cols {
+		def := ""
+		switch {
+		case c.Default != nil:
+			def = "DEFAULT " + *c.Default
+		case c.Materialized != nil:
+			def = "MATERIALIZED " + *c.Materialized
+		case c.Ephemeral != nil:
+			def = "EPHEMERAL " + *c.Ephemeral
+		case c.Alias != nil:
+			def = "ALIAS " + *c.Alias
+		}
+		nullable := ""
+		if c.Nullable {
+			nullable = "yes"
+		}
+		sec.Rows = append(sec.Rows, []string{
+			c.Name, c.Type, nullable, def, deref(c.Codec), deref(c.TTL), deref(c.Comment),
+		})
+	}
+	return sec
+}
+
+func indexesSection(idx []hclload.IndexSpec) (tableSection, bool) {
+	if len(idx) == 0 {
+		return tableSection{}, false
+	}
+	sec := tableSection{Title: "Indexes", Headers: []string{"name", "expr", "type", "granularity"}}
+	for _, i := range idx {
+		gran := ""
+		if i.Granularity != 0 {
+			gran = fmt.Sprintf("%d", i.Granularity)
+		}
+		sec.Rows = append(sec.Rows, []string{i.Name, i.Expr, i.Type, gran})
+	}
+	return sec, true
+}
+
+func constraintsSection(cs []hclload.ConstraintSpec) (tableSection, bool) {
+	if len(cs) == 0 {
+		return tableSection{}, false
+	}
+	sec := tableSection{Title: "Constraints", Headers: []string{"name", "kind", "expr"}}
+	for _, c := range cs {
+		kind, expr := "check", deref(c.Check)
+		if c.Assume != nil {
+			kind, expr = "assume", *c.Assume
+		}
+		sec.Rows = append(sec.Rows, []string{c.Name, kind, expr})
+	}
+	return sec, true
+}
+
+func dictAttributesSection(attrs []hclload.DictionaryAttribute) tableSection {
+	sec := tableSection{Title: "Attributes", Headers: []string{"name", "type", "default", "expression"}}
+	for _, a := range attrs {
+		sec.Rows = append(sec.Rows, []string{a.Name, a.Type, deref(a.Default), deref(a.Expression)})
+	}
+	return sec
+}
+
+// engineProps renders an engine spec as Kind plus its decoded struct's non-zero
+// exported fields, via reflection, so every engine type is covered uniformly.
+func engineProps(spec *hclload.EngineSpec) []kv {
+	if spec == nil {
+		return nil
+	}
+	out := []kv{{"engine", spec.Kind}}
+	if spec.Decoded == nil {
+		return out
+	}
+	v := reflect.ValueOf(spec.Decoded)
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return out
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return out
+	}
+	t := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		fv := v.Field(i)
+		if fv.IsZero() {
+			continue
+		}
+		s := formatValue(fv)
+		if s == "" {
+			continue
+		}
+		out = append(out, kv{toSnake(f.Name), s})
+	}
+	return out
+}
+
+func formatValue(v reflect.Value) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.String:
+		return v.String()
+	case reflect.Slice:
+		var parts []string
+		for i := 0; i < v.Len(); i++ {
+			parts = append(parts, formatValue(v.Index(i)))
+		}
+		return strings.Join(parts, ", ")
+	case reflect.Map:
+		var parts []string
+		for _, k := range v.MapKeys() {
+			parts = append(parts, fmt.Sprintf("%v=%v", k.Interface(), v.MapIndex(k).Interface()))
+		}
+		sort.Strings(parts)
+		return strings.Join(parts, ", ")
+	default:
+		return fmt.Sprintf("%v", v.Interface())
+	}
+}
+
+func appendPtr(props []kv, key string, p *string) []kv {
+	if p != nil && *p != "" {
+		return append(props, kv{key, *p})
+	}
+	return props
+}
+
+func appendList(props []kv, key string, list []string) []kv {
+	if len(list) > 0 {
+		return append(props, kv{key, strings.Join(list, ", ")})
+	}
+	return props
+}
+
+func appendMap(props []kv, m map[string]string) []kv {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		props = append(props, kv{k, m[k]})
+	}
+	return props
+}
+
+// ---- small helpers ----
+
+func findTable(db *hclload.DatabaseSpec, name string) *hclload.TableSpec {
+	for i := range db.Tables {
+		if db.Tables[i].Name == name {
+			return &db.Tables[i]
+		}
+	}
+	return nil
+}
+
+func findMaterializedView(db *hclload.DatabaseSpec, name string) *hclload.MaterializedViewSpec {
+	for i := range db.MaterializedViews {
+		if db.MaterializedViews[i].Name == name {
+			return &db.MaterializedViews[i]
+		}
+	}
+	return nil
+}
+
+func findView(db *hclload.DatabaseSpec, name string) *hclload.ViewSpec {
+	for i := range db.Views {
+		if db.Views[i].Name == name {
+			return &db.Views[i]
+		}
+	}
+	return nil
+}
+
+func findDictionary(db *hclload.DatabaseSpec, name string) *hclload.DictionarySpec {
+	for i := range db.Dictionaries {
+		if db.Dictionaries[i].Name == name {
+			return &db.Dictionaries[i]
+		}
+	}
+	return nil
+}
+
+func findRaw(db *hclload.DatabaseSpec, name string) *hclload.RawSpec {
+	for i := range db.Raws {
+		if db.Raws[i].Name == name {
+			return &db.Raws[i]
+		}
+	}
+	return nil
+}
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func objectHref(database, kind, name string) string {
+	return "/db/" + url.PathEscape(database) + "/" + url.PathEscape(kind) + "/" + url.PathEscape(name)
+}
+
+func unescape(s string) string {
+	if u, err := url.PathUnescape(s); err == nil {
+		return u
+	}
+	return s
+}
+
+func kindLabel(kind string) string {
+	switch kind {
+	case hclload.KindTable:
+		return "Table"
+	case hclload.KindMaterializedView:
+		return "Materialized View"
+	case hclload.KindView:
+		return "View"
+	case hclload.KindDictionary:
+		return "Dictionary"
+	case hclload.KindRaw:
+		return "Raw"
+	default:
+		return kind
+	}
+}
+
+func toSnake(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r - 'A' + 'a')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/cmd/hclexp/web/flows.html
+++ b/cmd/hclexp/web/flows.html
@@ -1,0 +1,22 @@
+{{define "content"}}
+<h1>Data flows</h1>
+<p class="muted">Ingestion chains reconstructed from materialized-view sources, targets, and Distributed remotes.</p>
+{{if not .Flows}}<p class="muted">No materialized-view ingestion chains found in this schema.</p>{{end}}
+
+{{range .Flows}}
+<section class="flow" id="{{.Anchor}}">
+  <div class="chain">
+    {{range $i, $st := .Stages}}
+    {{if $i}}<div class="arrow"><span class="arrow-label">{{$st.EdgeLabel}}</span><span class="arrow-glyph">▼</span></div>{{end}}
+    <div class="stage stage-{{$st.Kind}}{{if not $st.Declared}} undeclared{{end}}">
+      <div class="stage-kind">{{$st.KindLabel}}{{if $st.Engine}} · {{$st.Engine}}{{end}}</div>
+      <div class="stage-name">
+        {{if $st.Href}}<a href="{{$st.Href}}">{{$st.Name}}</a>{{else}}{{$st.Name}}{{end}}
+      </div>
+      <div class="stage-meta">{{$st.Database}}{{if $st.Detail}} · {{$st.Detail}}{{end}}{{if not $st.Declared}} · not declared{{end}}</div>
+    </div>
+    {{end}}
+  </div>
+</section>
+{{end}}
+{{end}}

--- a/cmd/hclexp/web/index.html
+++ b/cmd/hclexp/web/index.html
@@ -1,0 +1,43 @@
+{{define "content"}}
+<h1>Databases</h1>
+{{if not .Databases}}<p class="muted">No databases in this schema.</p>{{end}}
+{{range .Databases}}
+<section class="db">
+  <h2>{{.Name}}{{if .Cluster}} <span class="muted">ON CLUSTER {{.Cluster}}</span>{{end}}</h2>
+  {{template "objgroup" dict "Title" "Tables" "Items" .Tables}}
+  {{template "objgroup" dict "Title" "Materialized Views" "Items" .MaterializedViews}}
+  {{template "objgroup" dict "Title" "Views" "Items" .Views}}
+  {{template "objgroup" dict "Title" "Dictionaries" "Items" .Dictionaries}}
+  {{template "objgroup" dict "Title" "Raw" "Items" .Raws}}
+</section>
+{{end}}
+
+{{if .NamedCollections}}
+<section class="db">
+  <h2>Named Collections</h2>
+  <ul class="objlist">
+    {{range .NamedCollections}}<li>{{.}}</li>{{end}}
+  </ul>
+</section>
+{{end}}
+
+{{if .Nodes}}
+<section class="db">
+  <h2>Nodes</h2>
+  <ul class="objlist">
+    {{range .Nodes}}<li>{{.}}</li>{{end}}
+  </ul>
+</section>
+{{end}}
+{{end}}
+
+{{define "objgroup"}}
+{{if .Items}}
+<div class="group">
+  <h3>{{.Title}} <span class="count">{{len .Items}}</span></h3>
+  <ul class="objlist">
+    {{range .Items}}<li><a href="{{.Href}}">{{.Name}}</a></li>{{end}}
+  </ul>
+</div>
+{{end}}
+{{end}}

--- a/cmd/hclexp/web/layout.html
+++ b/cmd/hclexp/web/layout.html
@@ -1,0 +1,20 @@
+{{define "layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{.Title}} — hclexp</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="/static/app.js" defer></script>
+</head>
+<body>
+  <header>
+    <a class="brand" href="/">hclexp</a>
+    <span class="crumb">schema browser</span>
+    <a class="navlink" href="/flows">data flows</a>
+  </header>
+  <main>
+    {{template "content" .}}
+  </main>
+</body>
+</html>{{end}}

--- a/cmd/hclexp/web/object.html
+++ b/cmd/hclexp/web/object.html
@@ -1,0 +1,59 @@
+{{define "content"}}
+<nav class="path"><a href="/">databases</a> / {{.Database}} / <span class="muted">{{.KindLabel}}</span></nav>
+<h1>{{.Name}}</h1>
+
+<div class="viewtabs">
+  <a href="{{.HTMLHref}}" class="{{if eq .View "html"}}active{{end}}">Overview</a>
+  <a href="{{.DDLHref}}" class="{{if eq .View "ddl"}}active{{end}}">DDL</a>
+  <a href="{{.HCLHref}}" class="{{if eq .View "hcl"}}active{{end}}">HCL</a>
+</div>
+
+{{if eq .View "html"}}
+  {{if .Props}}
+  <table class="props">
+    <tbody>
+      {{range .Props}}<tr><th>{{.K}}</th><td>{{.V}}</td></tr>{{end}}
+    </tbody>
+  </table>
+  {{end}}
+
+  {{range .Tables}}
+  <h2>{{.Title}}{{if .Collapsible}} <span class="count">{{len .Rows}}</span>{{end}}</h2>
+  {{if .Collapsible}}
+  <label class="toggle"><input type="checkbox" class="collapse-toggle"> Hide rows beyond 10</label>
+  {{end}}
+  <table class="grid{{if .Collapsible}} collapsible{{end}}">
+    <thead><tr>{{range .Headers}}<th>{{.}}</th>{{end}}</tr></thead>
+    <tbody>
+      {{range .Rows}}<tr>{{range .}}<td>{{.}}</td>{{end}}</tr>{{end}}
+    </tbody>
+  </table>
+  {{end}}
+
+  {{if .Query}}<h2>Query</h2><pre class="code">{{.Query}}</pre>{{end}}
+  {{if .RawSQL}}<h2>SQL</h2><pre class="code">{{.RawSQL}}</pre>{{end}}
+{{else}}
+  <pre class="code">{{.Code}}</pre>
+{{end}}
+
+{{if or .DependsOn .DependedBy .FlowAnchor}}
+<h2>Dependencies</h2>
+{{if .FlowAnchor}}<p class="flowlink"><a href="/flows#{{.FlowAnchor}}">→ Appears in a data flow</a></p>{{end}}
+{{if .DependsOn}}
+<div class="group">
+  <h3>Depends on</h3>
+  <ul class="objlist">
+    {{range .DependsOn}}<li><a href="{{.Href}}">{{.Label}}</a></li>{{end}}
+  </ul>
+</div>
+{{end}}
+{{if .DependedBy}}
+<div class="group">
+  <h3>Depended on by</h3>
+  <ul class="objlist">
+    {{range .DependedBy}}<li><a href="{{.Href}}">{{.Label}}</a></li>{{end}}
+  </ul>
+</div>
+{{end}}
+{{end}}
+{{end}}

--- a/cmd/hclexp/web/static/app.js
+++ b/cmd/hclexp/web/static/app.js
@@ -1,0 +1,64 @@
+// Collapse long column lists to the first LIMIT rows. The preference is shared
+// across objects and persisted in localStorage. LIMIT must match
+// columnCollapseLimit in web.go.
+(function () {
+  "use strict";
+  var KEY = "hclexp:collapseColumns";
+  var LIMIT = 10;
+
+  function isCollapsed() {
+    var v = localStorage.getItem(KEY);
+    return v === null ? true : v === "1"; // default: collapsed
+  }
+
+  function setCollapsed(on) {
+    localStorage.setItem(KEY, on ? "1" : "0");
+  }
+
+  function apply() {
+    var on = isCollapsed();
+
+    var toggles = document.querySelectorAll("input.collapse-toggle");
+    toggles.forEach(function (t) { t.checked = on; });
+
+    document.querySelectorAll("table.grid.collapsible").forEach(function (tbl) {
+      var body = tbl.tBodies[0];
+      if (!body) return;
+      var rows = Array.prototype.slice.call(body.rows).filter(function (r) {
+        return !r.classList.contains("more-row");
+      });
+      if (rows.length <= LIMIT) return;
+
+      rows.forEach(function (r, i) {
+        r.style.display = on && i >= LIMIT ? "none" : "";
+      });
+
+      var moreRow = body.querySelector("tr.more-row");
+      if (on) {
+        if (!moreRow) {
+          moreRow = document.createElement("tr");
+          moreRow.className = "more-row";
+          var td = document.createElement("td");
+          td.colSpan = rows[0].cells.length;
+          moreRow.appendChild(td);
+          body.appendChild(moreRow);
+        }
+        moreRow.style.display = "";
+        moreRow.cells[0].textContent =
+          "… " + (rows.length - LIMIT) + " more hidden — toggle to show";
+      } else if (moreRow) {
+        moreRow.style.display = "none";
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll("input.collapse-toggle").forEach(function (t) {
+      t.addEventListener("change", function () {
+        setCollapsed(t.checked);
+        apply();
+      });
+    });
+    apply();
+  });
+})();

--- a/cmd/hclexp/web/static/style.css
+++ b/cmd/hclexp/web/static/style.css
@@ -1,0 +1,193 @@
+:root {
+  --bg: #0f1115;
+  --panel: #171a21;
+  --border: #272c37;
+  --text: #d7dce5;
+  --muted: #8a93a3;
+  --accent: #6ea8fe;
+  --accent-dim: #2b3a55;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 12px 24px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+header .brand {
+  font-weight: 700;
+  font-size: 16px;
+  color: var(--text);
+  text-decoration: none;
+}
+
+header .crumb { color: var(--muted); }
+header .navlink { margin-left: auto; }
+
+main { padding: 24px; max-width: 1100px; margin: 0 auto; }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1 { font-size: 22px; margin: 0 0 16px; }
+h2 { font-size: 16px; margin: 24px 0 8px; border-bottom: 1px solid var(--border); padding-bottom: 4px; }
+h3 { font-size: 13px; margin: 12px 0 6px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+
+.muted { color: var(--muted); font-weight: 400; }
+
+.db {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+}
+
+.db h2 { border: none; margin-top: 0; }
+
+.group { margin: 8px 0; }
+
+.count {
+  display: inline-block;
+  background: var(--accent-dim);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 0 8px;
+  font-size: 11px;
+}
+
+.objlist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+}
+
+.objlist li { white-space: nowrap; }
+
+.path { color: var(--muted); margin-bottom: 8px; }
+
+.viewtabs { display: flex; gap: 4px; margin-bottom: 16px; }
+.viewtabs a {
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--muted);
+  background: var(--panel);
+}
+.viewtabs a.active { color: var(--text); border-color: var(--accent); background: var(--accent-dim); }
+
+table.props, table.grid {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 8px 0;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+table.props th {
+  text-align: left;
+  width: 180px;
+  color: var(--muted);
+  font-weight: 500;
+  vertical-align: top;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+}
+table.props td { padding: 6px 12px; border-bottom: 1px solid var(--border); font-family: ui-monospace, Menlo, monospace; }
+
+table.grid th, table.grid td {
+  text-align: left;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+}
+table.grid th { color: var(--muted); font-weight: 500; }
+table.grid td { font-family: ui-monospace, Menlo, monospace; }
+table.grid tr:last-child td { border-bottom: none; }
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 13px;
+  margin: 4px 0 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+table.grid tr.more-row td {
+  color: var(--muted);
+  font-style: italic;
+  font-family: inherit;
+  text-align: center;
+}
+
+pre.code {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 16px;
+  overflow-x: auto;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 13px;
+}
+
+.flowlink { margin: 4px 0 12px; }
+
+.flow {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+}
+
+.chain {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0;
+}
+
+.stage {
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  padding: 8px 14px;
+  min-width: 280px;
+  background: var(--bg);
+}
+
+.stage.undeclared { border-left-color: var(--muted); opacity: 0.75; }
+.stage-kind { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+.stage-name { font-size: 15px; font-family: ui-monospace, Menlo, monospace; }
+.stage-meta { color: var(--muted); font-size: 12px; }
+
+.arrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0 4px 16px;
+  color: var(--muted);
+}
+.arrow-glyph { color: var(--accent); }
+.arrow-label { font-size: 12px; }

--- a/cmd/hclexp/web_test.go
+++ b/cmd/hclexp/web_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	hclload "github.com/posthog/chschema/internal/loader/hcl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// webTestSchema builds a small resolved schema: one table and one materialized
+// view that writes into it, so dependency cross-links have something to point at.
+func webTestSchema() *hclload.Schema {
+	return &hclload.Schema{Databases: []hclload.DatabaseSpec{{
+		Name: "posthog",
+		Tables: []hclload.TableSpec{{
+			Name:    "events",
+			OrderBy: []string{"id"},
+			Columns: []hclload.ColumnSpec{{Name: "id", Type: "UInt64"}},
+			Engine:  &hclload.EngineSpec{Kind: "merge_tree", Decoded: hclload.EngineMergeTree{}},
+		}},
+		MaterializedViews: []hclload.MaterializedViewSpec{{
+			Name:    "events_mv",
+			ToTable: "posthog.events",
+			Query:   "SELECT id FROM posthog.src",
+		}},
+	}}}
+}
+
+func getBody(t *testing.T, srv *webServer, target string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", srv.handleIndex)
+	mux.HandleFunc("/flows", srv.handleFlows)
+	mux.HandleFunc("/db/", srv.handleObject)
+	staticSub, _ := fs.Sub(webFS, "web/static")
+	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))
+	mux.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+// wideTable builds a table with n columns, for exercising the collapse toggle.
+func wideTable(n int) hclload.TableSpec {
+	cols := make([]hclload.ColumnSpec, n)
+	for i := range cols {
+		cols[i] = hclload.ColumnSpec{Name: "c" + strconv.Itoa(i), Type: "UInt64"}
+	}
+	return hclload.TableSpec{
+		Name:    "wide",
+		OrderBy: []string{"c0"},
+		Columns: cols,
+		Engine:  &hclload.EngineSpec{Kind: "merge_tree", Decoded: hclload.EngineMergeTree{}},
+	}
+}
+
+func TestWeb_Index(t *testing.T) {
+	srv, err := newWebServer(webTestSchema())
+	require.NoError(t, err)
+
+	code, body := getBody(t, srv, "/")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, body, "posthog")
+	assert.Contains(t, body, "events")
+	assert.Contains(t, body, "/db/posthog/table/events")
+}
+
+func TestWeb_TableViews(t *testing.T) {
+	srv, err := newWebServer(webTestSchema())
+	require.NoError(t, err)
+
+	code, html := getBody(t, srv, "/db/posthog/table/events?view=html")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, html, "id")         // column name
+	assert.Contains(t, html, "merge_tree") // engine prop
+
+	code, ddl := getBody(t, srv, "/db/posthog/table/events?view=ddl")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, ddl, "CREATE TABLE posthog.events")
+
+	code, hcl := getBody(t, srv, "/db/posthog/table/events?view=hcl")
+	require.Equal(t, http.StatusOK, code)
+	// HCL is HTML-escaped in the page, so the quotes appear as entities.
+	assert.Contains(t, hcl, "table")
+	assert.Contains(t, hcl, "events")
+}
+
+func TestWeb_MaterializedViewDependencyLink(t *testing.T) {
+	srv, err := newWebServer(webTestSchema())
+	require.NoError(t, err)
+
+	code, body := getBody(t, srv, "/db/posthog/materialized_view/events_mv?view=html")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, body, "Dependencies")
+	// MV writes into posthog.events — a link back to that table object.
+	assert.Contains(t, body, "/db/posthog/table/events")
+	assert.Contains(t, body, "mv_dest")
+}
+
+func TestWeb_ColumnCollapseToggle(t *testing.T) {
+	schema := &hclload.Schema{Databases: []hclload.DatabaseSpec{{
+		Name:   "posthog",
+		Tables: []hclload.TableSpec{wideTable(15)},
+	}}}
+	srv, err := newWebServer(schema)
+	require.NoError(t, err)
+
+	code, body := getBody(t, srv, "/db/posthog/table/wide?view=html")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, body, `class="collapse-toggle"`)
+	assert.Contains(t, body, "grid collapsible")
+
+	// app.js (which reads/writes localStorage) is served.
+	code, js := getBody(t, srv, "/static/app.js")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, js, "localStorage")
+}
+
+func TestWeb_NoToggleForShortColumnList(t *testing.T) {
+	// The default webTestSchema table has a single column — no toggle.
+	srv, err := newWebServer(webTestSchema())
+	require.NoError(t, err)
+
+	code, body := getBody(t, srv, "/db/posthog/table/events?view=html")
+	require.Equal(t, http.StatusOK, code)
+	assert.NotContains(t, body, "collapse-toggle")
+	assert.NotContains(t, body, "grid collapsible")
+}
+
+// kafkaFlowSchema builds the canonical ingestion chain:
+// Kafka table -> MV -> Distributed -> ReplicatedMergeTree.
+func kafkaFlowSchema() *hclload.Schema {
+	topic := "events"
+	return &hclload.Schema{Databases: []hclload.DatabaseSpec{{
+		Name: "posthog",
+		Tables: []hclload.TableSpec{
+			{
+				Name:    "kafka_events",
+				Columns: []hclload.ColumnSpec{{Name: "team_id", Type: "UInt64"}},
+				Engine:  &hclload.EngineSpec{Kind: "kafka", Decoded: hclload.EngineKafka{TopicList: &topic}},
+			},
+			{
+				Name:    "sharded_events",
+				Columns: []hclload.ColumnSpec{{Name: "team_id", Type: "UInt64"}},
+				Engine: &hclload.EngineSpec{Kind: "distributed", Decoded: hclload.EngineDistributed{
+					ClusterName: "posthog", RemoteDatabase: "posthog", RemoteTable: "events_local",
+				}},
+			},
+			{
+				Name:    "events_local",
+				OrderBy: []string{"team_id"},
+				Columns: []hclload.ColumnSpec{{Name: "team_id", Type: "UInt64"}},
+				Engine:  &hclload.EngineSpec{Kind: "replicated_merge_tree", Decoded: hclload.EngineReplicatedMergeTree{ZooPath: "/c/{shard}/e", ReplicaName: "{replica}"}},
+			},
+		},
+		MaterializedViews: []hclload.MaterializedViewSpec{{
+			Name:    "events_mv",
+			ToTable: "posthog.sharded_events",
+			Query:   "SELECT team_id FROM posthog.kafka_events",
+		}},
+	}}}
+}
+
+func TestWeb_FlowsFullChain(t *testing.T) {
+	srv, err := newWebServer(kafkaFlowSchema())
+	require.NoError(t, err)
+
+	require.Len(t, srv.flows, 1)
+	stages := srv.flows[0].Stages
+	require.Len(t, stages, 4)
+	assert.Equal(t, []string{"kafka_events", "events_mv", "sharded_events", "events_local"},
+		[]string{stages[0].Name, stages[1].Name, stages[2].Name, stages[3].Name})
+	assert.Equal(t, []string{"", "reads", "writes to", "forwards to"},
+		[]string{stages[0].EdgeLabel, stages[1].EdgeLabel, stages[2].EdgeLabel, stages[3].EdgeLabel})
+	assert.Equal(t, "topic=events", stages[0].Detail)
+	assert.Equal(t, "cluster=posthog", stages[2].Detail)
+
+	code, body := getBody(t, srv, "/flows")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, body, "/db/posthog/table/kafka_events")
+	assert.Contains(t, body, "/db/posthog/materialized_view/events_mv")
+	assert.Contains(t, body, "forwards to")
+}
+
+func TestWeb_FlowFanOut(t *testing.T) {
+	// One Kafka source feeding two MVs → two distinct chains.
+	schema := kafkaFlowSchema()
+	db := &schema.Databases[0]
+	db.MaterializedViews = append(db.MaterializedViews, hclload.MaterializedViewSpec{
+		Name:    "events_mv2",
+		ToTable: "posthog.events_local",
+		Query:   "SELECT team_id FROM posthog.kafka_events",
+	})
+	srv, err := newWebServer(schema)
+	require.NoError(t, err)
+	assert.Len(t, srv.flows, 2)
+}
+
+func TestWeb_ObjectFlowBacklink(t *testing.T) {
+	srv, err := newWebServer(kafkaFlowSchema())
+	require.NoError(t, err)
+
+	code, body := getBody(t, srv, "/db/posthog/table/kafka_events?view=html")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, body, "/flows#flow-1")
+	assert.Contains(t, body, "Appears in a data flow")
+}
+
+func TestWeb_NoFlowBacklinkWhenNotInFlow(t *testing.T) {
+	// webTestSchema's MV writes to a table that nothing reads further; the
+	// standalone "events" table here is the MV target, so it is in a flow. Use a
+	// schema with an isolated table instead.
+	schema := &hclload.Schema{Databases: []hclload.DatabaseSpec{{
+		Name: "posthog",
+		Tables: []hclload.TableSpec{{
+			Name:    "lonely",
+			OrderBy: []string{"id"},
+			Columns: []hclload.ColumnSpec{{Name: "id", Type: "UInt64"}},
+			Engine:  &hclload.EngineSpec{Kind: "merge_tree", Decoded: hclload.EngineMergeTree{}},
+		}},
+	}}}
+	srv, err := newWebServer(schema)
+	require.NoError(t, err)
+
+	code, body := getBody(t, srv, "/db/posthog/table/lonely?view=html")
+	require.Equal(t, http.StatusOK, code)
+	assert.NotContains(t, body, "Appears in a data flow")
+}
+
+func TestWeb_NotFound(t *testing.T) {
+	srv, err := newWebServer(webTestSchema())
+	require.NoError(t, err)
+
+	code, _ := getBody(t, srv, "/db/posthog/table/missing")
+	assert.Equal(t, http.StatusNotFound, code)
+
+	code, _ = getBody(t, srv, "/db/nosuchdb/table/events")
+	assert.Equal(t, http.StatusNotFound, code)
+}

--- a/docs/plans/web-flows-view.md
+++ b/docs/plans/web-flows-view.md
@@ -1,0 +1,45 @@
+# Plan: `hclexp web` data-flow view
+
+## Context
+
+The web browser shows objects in isolation. ClickHouse ingestion is a chain —
+Kafka table → materialized view → (writable Distributed) → ReplicatedMergeTree —
+and following it by hand across object pages is tedious. Add a `/flows` view that
+reconstructs and renders these chains.
+
+## Approach
+
+- **Detection** (`cmd/hclexp/flows.go`): build flows from the existing
+  `CollectDependencies` edges + per-table engine kind.
+  - `mv_source` → table read by MV; `mv_dest` → MV's target; `distributed_remote`
+    → Distributed's storage table.
+  - Roots = tables read by some MV but never produced by one (Kafka tables, plain
+    sources). DFS forward, enumerating each root→leaf path as one flow; the
+    Distributed hop is detected by engine kind and its remote followed; cascading
+    MVs continue naturally. Cycle-guarded with a per-path visited set.
+  - Each stage: object name, kind, engine, optional subtitle (Kafka
+    `topic=`/`collection=`, Distributed `cluster=`), link to detail page (or a
+    non-linked "not declared" card for external targets). Arrow labels: `reads`,
+    `writes to`, `forwards to`.
+- **Caching**: compute flows once in `newWebServer`; store `flows` + a
+  `flowAnchorByRef` map (ref → first containing flow's anchor) on `webServer`.
+- **Routes/templates**: `GET /flows` (`handleFlows` + `web/flows.html`); a
+  `flows` link in the shared header; on each object overview, a link to
+  `/flows#<anchor>` rendered next to the Dependencies section when the object
+  participates in a flow.
+- **CSS**: horizontal card chain with labeled arrows.
+
+## Files
+
+- `cmd/hclexp/flows.go` — new: flow model, `buildFlows`, `handleFlows`.
+- `cmd/hclexp/web.go` — wire flows into `webServer`/`newWebServer`/`runWeb`; set
+  object-page flow anchor.
+- `cmd/hclexp/web/flows.html` — new template; `layout.html` header link;
+  `object.html` flow link near Dependencies; `static/style.css` chain styling.
+
+## Verification
+
+- `web_test.go`: Kafka→MV→Distributed→Replicated fixture renders four stages with
+  links/labels; fan-out (one source, two MVs → two chains); object overview shows
+  the `/flows#` back-link when in a flow and omits it otherwise.
+- `go build`, `go test ./cmd/hclexp ./internal/... ./test`, manual smoke test.

--- a/internal/loader/hcl/render.go
+++ b/internal/loader/hcl/render.go
@@ -1,0 +1,107 @@
+package hcl
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Object kinds accepted by RenderObjectSQL and RenderObjectHCL. They match the
+// segment used in the web UI's object routes.
+const (
+	KindTable            = "table"
+	KindMaterializedView = "materialized_view"
+	KindView             = "view"
+	KindDictionary       = "dictionary"
+	KindRaw              = "raw"
+)
+
+// RenderObjectSQL returns the ClickHouse CREATE DDL for a single object named
+// name of the given kind within db. It reuses the same generators that
+// GenerateSQL drives, so the output matches what a fresh `diff -sql` would emit.
+// It returns an error if the kind is unknown or no such object exists.
+func RenderObjectSQL(database, kind, name string, db *DatabaseSpec) (string, error) {
+	switch kind {
+	case KindTable:
+		if t := findTable(db, name); t != nil {
+			return createTableSQL(database, *t), nil
+		}
+	case KindMaterializedView:
+		if mv := findMaterializedView(db, name); mv != nil {
+			return createMaterializedViewSQL(database, *mv), nil
+		}
+	case KindView:
+		if v := findView(db, name); v != nil {
+			return createViewSQL(database, *v), nil
+		}
+	case KindDictionary:
+		if d := findDictionary(db, name); d != nil {
+			return createDictionarySQL(database, *d), nil
+		}
+	case KindRaw:
+		if r := findRaw(db, name); r != nil {
+			return createRawSQL(*r), nil
+		}
+	default:
+		return "", fmt.Errorf("render: unknown object kind %q", kind)
+	}
+	return "", notFound(kind, name)
+}
+
+// RenderObjectHCL returns the canonical HCL for a single object named name of
+// the given kind within db, using the same writers as the schema dumper. It
+// returns an error if the kind is unknown or no such object exists.
+func RenderObjectHCL(database, kind, name string, db *DatabaseSpec) (string, error) {
+	f := hclwrite.NewEmptyFile()
+	body := f.Body()
+	switch kind {
+	case KindTable:
+		t := findTable(db, name)
+		if t == nil {
+			return "", notFound(kind, name)
+		}
+		writeTable(body.AppendNewBlock("table", []string{t.Name}).Body(), *t)
+	case KindMaterializedView:
+		mv := findMaterializedView(db, name)
+		if mv == nil {
+			return "", notFound(kind, name)
+		}
+		writeMaterializedView(body.AppendNewBlock("materialized_view", []string{mv.Name}).Body(), *mv)
+	case KindView:
+		v := findView(db, name)
+		if v == nil {
+			return "", notFound(kind, name)
+		}
+		writeView(body.AppendNewBlock("view", []string{v.Name}).Body(), *v)
+	case KindDictionary:
+		d := findDictionary(db, name)
+		if d == nil {
+			return "", notFound(kind, name)
+		}
+		writeDictionary(body.AppendNewBlock("dictionary", []string{d.Name}).Body(), *d)
+	case KindRaw:
+		r := findRaw(db, name)
+		if r == nil {
+			return "", notFound(kind, name)
+		}
+		writeRaw(body.AppendNewBlock("raw", []string{r.Kind, r.Name}).Body(), *r)
+	default:
+		return "", fmt.Errorf("render: unknown object kind %q", kind)
+	}
+	return string(f.Bytes()), nil
+}
+
+func notFound(kind, name string) error {
+	return fmt.Errorf("render: no %s named %q", kind, name)
+}
+
+// findRaw returns the raw object named name in db, or nil. The other find*
+// helpers live in sql_edit.go; raw blocks aren't edited there so it's added here.
+func findRaw(db *DatabaseSpec, name string) *RawSpec {
+	for i := range db.Raws {
+		if db.Raws[i].Name == name {
+			return &db.Raws[i]
+		}
+	}
+	return nil
+}

--- a/internal/loader/hcl/render_test.go
+++ b/internal/loader/hcl/render_test.go
@@ -1,0 +1,55 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderObjectSQL_Table(t *testing.T) {
+	db := mkDB("posthog",
+		mkTable("events", EngineMergeTree{}, ColumnSpec{Name: "id", Type: "UInt64"}),
+	)
+	db.Tables[0].OrderBy = []string{"id"}
+
+	sql, err := RenderObjectSQL("posthog", KindTable, "events", &db)
+	require.NoError(t, err)
+	assert.Contains(t, sql, "CREATE TABLE posthog.events")
+	assert.Contains(t, sql, "ORDER BY (id)")
+}
+
+func TestRenderObjectHCL_Table(t *testing.T) {
+	db := mkDB("posthog",
+		mkTable("events", EngineMergeTree{}, ColumnSpec{Name: "id", Type: "UInt64"}),
+	)
+	db.Tables[0].OrderBy = []string{"id"}
+
+	out, err := RenderObjectHCL("posthog", KindTable, "events", &db)
+	require.NoError(t, err)
+	assert.Contains(t, out, `table "events"`)
+	assert.Contains(t, out, `column "id"`)
+}
+
+func TestRenderObjectSQL_MaterializedView(t *testing.T) {
+	db := DatabaseSpec{
+		Name: "posthog",
+		MaterializedViews: []MaterializedViewSpec{
+			mkMV("metrics_mv", "posthog.metrics", "SELECT a FROM posthog.src"),
+		},
+	}
+	sql, err := RenderObjectSQL("posthog", KindMaterializedView, "metrics_mv", &db)
+	require.NoError(t, err)
+	assert.Contains(t, sql, "CREATE MATERIALIZED VIEW posthog.metrics_mv")
+	assert.Contains(t, sql, "TO posthog.metrics")
+}
+
+func TestRenderObject_UnknownNameAndKind(t *testing.T) {
+	db := mkDB("posthog", mkTable("events", EngineMergeTree{}))
+
+	_, err := RenderObjectSQL("posthog", KindTable, "missing", &db)
+	require.Error(t, err)
+
+	_, err = RenderObjectHCL("posthog", "bogus", "events", &db)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Adds a `hclexp web` subcommand that loads and resolves an HCL schema (single file or `-layer` dirs, like the other commands) and serves a server-side-rendered, **read-only** UI for browsing it. No ClickHouse connection.

- **Index** — databases and their tables, materialized views, views, dictionaries, raw blocks, plus named collections and nodes.
- **Object detail** — toggle between a structured **Overview**, generated **DDL**, and canonical **HCL**, with dependency cross-links. Long column lists collapse to the first 10 rows, persisted in `localStorage`.
- **`/flows`** — reconstructs MV ingestion chains (Kafka → MV → writable Distributed → ReplicatedMergeTree) from the dependency graph and renders each as a linked card chain (`reads` → `writes to` → `forwards to`). Participating objects link back to their flow from the Dependencies section.

## Implementation notes

- Per-object DDL/HCL rendering reuses the existing `sqlgen`/`dump` generators via new exported `RenderObjectSQL` / `RenderObjectHCL` wrappers (`internal/loader/hcl/render.go`) — no duplicated generation logic.
- Flow reconstruction reuses `CollectDependencies`; detection lives in `cmd/hclexp/flows.go` to keep `web.go` focused.
- Templates/assets are embedded via `go:embed`; no JS build step.

## Testing

- `cmd/hclexp/web_test.go` — handlers (index, all three object views, 404s), the column-collapse toggle, full Kafka→MV→Distributed→Replicated flow, fan-out, and the object→flow back-link.
- `internal/loader/hcl/render_test.go` — per-object SQL/HCL rendering.
- `go test ./cmd/hclexp ./internal/... ./test` pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)