### PR TITLE
web: surface dataflow validation problems in the schema browser

### DIFF
--- a/cmd/hclexp/flows.go
+++ b/cmd/hclexp/flows.go
@@ -19,17 +19,20 @@ type flowStage struct {
 	Href      string // detail-page link; "" when the object isn't declared
 	Declared  bool
 	EdgeLabel string // label on the arrow leading into this stage (empty for the first)
+	Problems  []problemView
 }
 
 // A flow is a single linear ingestion chain from a source to a terminal table.
 type flow struct {
-	Anchor string
-	Stages []flowStage
+	Anchor      string
+	Stages      []flowStage
+	HasProblems bool
 }
 
 type flowsData struct {
-	Title string
-	Flows []flow
+	Title          string
+	Flows          []flow
+	GlobalProblems []problemView
 }
 
 // flowBuilder holds the indexes used to reconstruct flows from the dependency
@@ -234,7 +237,7 @@ func (s *webServer) handleFlows(w http.ResponseWriter, r *http.Request) {
 		s.notFound(w)
 		return
 	}
-	s.render(w, s.tmplFlows, flowsData{Title: "Data flows", Flows: s.flows})
+	s.render(w, s.tmplFlows, flowsData{Title: "Data flows", Flows: s.flows, GlobalProblems: s.globalProblems})
 }
 
 // refOfKey reverses indexKey for the root lookup.

--- a/cmd/hclexp/web.go
+++ b/cmd/hclexp/web.go
@@ -63,14 +63,26 @@ func runWeb(args []string) {
 // webServer holds the resolved schema, parsed templates, and the precomputed
 // dependency graph + object kind index used for cross-linking.
 type webServer struct {
-	schema      *hclload.Schema
-	tmplIndex   *template.Template
-	tmplObject  *template.Template
-	tmplFlows   *template.Template
-	deps        []hclload.Dependency
-	kindIndex   map[string]string // "db\x00name" -> object kind
-	flows       []flow
-	flowAnchors map[string]string // "db\x00name" -> anchor of the first flow it appears in
+	schema         *hclload.Schema
+	tmplIndex      *template.Template
+	tmplObject     *template.Template
+	tmplFlows      *template.Template
+	deps           []hclload.Dependency
+	kindIndex      map[string]string // "db\x00name" -> object kind
+	flows          []flow
+	flowAnchors    map[string]string        // "db\x00name" -> anchor of the first flow it appears in
+	problems       map[string][]problemView // "db\x00name" -> validation problems for that object
+	globalProblems []problemView            // problems not attributable to a specific object
+}
+
+// problemView is a single validation issue rendered in the UI (e.g. a
+// materialized view referencing a column its source table does not provide, or
+// a dependency target that is not declared).
+type problemView struct {
+	Kind        string // friendly category, e.g. "undefined column", "missing target"
+	Reason      string // full human-readable explanation from the validator
+	Missing     string // the offending reference ("db.name" / "db.column")
+	MissingHref string // link to the missing object when it is itself declared
 }
 
 func newWebServer(schema *hclload.Schema) (*webServer, error) {
@@ -123,7 +135,56 @@ func newWebServer(schema *hclload.Schema) (*webServer, error) {
 		}
 	}
 	s.flows, s.flowAnchors = buildFlows(schema, s.deps, s.kindIndex)
+	s.buildProblems()
 	return s, nil
+}
+
+// buildProblems runs the schema validator and indexes each issue by the object
+// it is attributed to, then tags the flow stages whose object has problems.
+func (s *webServer) buildProblems() {
+	s.problems = map[string][]problemView{}
+	for _, e := range hclload.Validate(s.schema.Databases, hclload.ParseSkipSet("")) {
+		pv := problemView{
+			Kind:    problemKind(e.Kind),
+			Reason:  e.Reason,
+			Missing: e.Missing.String(),
+		}
+		if k := s.kindIndex[indexKey(e.Missing.Database, e.Missing.Name)]; k != "" {
+			pv.MissingHref = objectHref(e.Missing.Database, k, e.Missing.Name)
+		}
+		if e.Object.Database == "" && e.Object.Name == "" {
+			s.globalProblems = append(s.globalProblems, pv)
+			continue
+		}
+		key := indexKey(e.Object.Database, e.Object.Name)
+		s.problems[key] = append(s.problems[key], pv)
+	}
+
+	for fi := range s.flows {
+		for si := range s.flows[fi].Stages {
+			st := &s.flows[fi].Stages[si]
+			if p := s.problems[indexKey(st.Database, st.Name)]; len(p) > 0 {
+				st.Problems = p
+				s.flows[fi].HasProblems = true
+			}
+		}
+	}
+}
+
+// problemKind maps a validator dependency kind to a short UI label.
+func problemKind(kind string) string {
+	switch kind {
+	case hclload.KindMVColumn:
+		return "undefined column"
+	case hclload.DepMVSource, hclload.DepViewSource:
+		return "missing source"
+	case hclload.DepMVDest, hclload.DepBufferDestination, hclload.DepTimeSeriesTarget:
+		return "missing target"
+	case hclload.DepDistributedRemote:
+		return "missing remote table"
+	default:
+		return "problem"
+	}
 }
 
 func indexKey(db, name string) string { return db + "\x00" + name }
@@ -196,6 +257,7 @@ type objectData struct {
 	RawSQL     string
 	Code       string // rendered DDL or HCL for those views
 	FlowAnchor string // anchor on /flows when this object participates in a flow
+	Problems   []problemView
 	DependsOn  []objLink
 	DependedBy []objLink
 }
@@ -302,6 +364,7 @@ func (s *webServer) handleObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data.FlowAnchor = s.flowAnchors[indexKey(database, name)]
+	data.Problems = s.problems[indexKey(database, name)]
 	s.buildDeps(&data, database, name)
 	s.render(w, s.tmplObject, data)
 }

--- a/cmd/hclexp/web/flows.html
+++ b/cmd/hclexp/web/flows.html
@@ -1,19 +1,32 @@
 {{define "content"}}
 <h1>Data flows</h1>
 <p class="muted">Ingestion chains reconstructed from materialized-view sources, targets, and Distributed remotes.</p>
+{{if .GlobalProblems}}
+<div class="problems">
+  <h2 class="problems-title">⚠ Schema problems</h2>
+  <ul class="problem-list">
+    {{range .GlobalProblems}}<li><span class="problem-kind">{{.Kind}}</span> {{.Reason}}</li>{{end}}
+  </ul>
+</div>
+{{end}}
+
 {{if not .Flows}}<p class="muted">No materialized-view ingestion chains found in this schema.</p>{{end}}
 
 {{range .Flows}}
-<section class="flow" id="{{.Anchor}}">
+<section class="flow{{if .HasProblems}} flow-problem{{end}}" id="{{.Anchor}}">
+  {{if .HasProblems}}<div class="flow-badge">⚠ this flow has problems</div>{{end}}
   <div class="chain">
     {{range $i, $st := .Stages}}
     {{if $i}}<div class="arrow"><span class="arrow-label">{{$st.EdgeLabel}}</span><span class="arrow-glyph">▼</span></div>{{end}}
-    <div class="stage stage-{{$st.Kind}}{{if not $st.Declared}} undeclared{{end}}">
-      <div class="stage-kind">{{$st.KindLabel}}{{if $st.Engine}} · {{$st.Engine}}{{end}}</div>
+    <div class="stage stage-{{$st.Kind}}{{if not $st.Declared}} undeclared{{end}}{{if $st.Problems}} stage-problem{{end}}">
+      <div class="stage-kind">{{$st.KindLabel}}{{if $st.Engine}} · {{$st.Engine}}{{end}}{{if $st.Problems}} <span class="stage-warn">⚠</span>{{end}}</div>
       <div class="stage-name">
         {{if $st.Href}}<a href="{{$st.Href}}">{{$st.Name}}</a>{{else}}{{$st.Name}}{{end}}
       </div>
       <div class="stage-meta">{{$st.Database}}{{if $st.Detail}} · {{$st.Detail}}{{end}}{{if not $st.Declared}} · not declared{{end}}</div>
+      {{range $st.Problems}}
+      <div class="stage-problem-msg"><span class="problem-kind">{{.Kind}}</span> {{.Reason}}</div>
+      {{end}}
     </div>
     {{end}}
   </div>

--- a/cmd/hclexp/web/object.html
+++ b/cmd/hclexp/web/object.html
@@ -8,6 +8,17 @@
   <a href="{{.HCLHref}}" class="{{if eq .View "hcl"}}active{{end}}">HCL</a>
 </div>
 
+{{if .Problems}}
+<div class="problems">
+  <h2 class="problems-title">⚠ Problems</h2>
+  <ul class="problem-list">
+    {{range .Problems}}
+    <li><span class="problem-kind">{{.Kind}}</span> {{.Reason}}</li>
+    {{end}}
+  </ul>
+</div>
+{{end}}
+
 {{if eq .View "html"}}
   {{if .Props}}
   <table class="props">

--- a/cmd/hclexp/web/static/style.css
+++ b/cmd/hclexp/web/static/style.css
@@ -153,6 +153,43 @@ pre.code {
 
 .flowlink { margin: 4px 0 12px; }
 
+/* validation problems */
+:root { --warn: #e0a33e; --warn-bg: #2a2113; --warn-border: #5a4520; }
+
+.problems {
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  border-radius: 8px;
+  padding: 12px 18px;
+  margin: 12px 0 16px;
+}
+.problems-title { color: var(--warn); border: none; margin: 0 0 6px; font-size: 15px; }
+.problem-list { margin: 0; padding-left: 18px; }
+.problem-list li { margin: 2px 0; }
+.problem-kind {
+  display: inline-block;
+  background: var(--warn-border);
+  color: var(--warn);
+  border-radius: 4px;
+  padding: 0 6px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-right: 6px;
+}
+
+.flow.flow-problem { border-color: var(--warn-border); }
+.flow-badge { color: var(--warn); font-size: 13px; margin-bottom: 10px; }
+.stage.stage-problem { border-left-color: var(--warn); }
+.stage-warn { color: var(--warn); }
+.stage-problem-msg {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  color: var(--warn);
+  font-size: 12px;
+}
+
 .flow {
   background: var(--panel);
   border: 1px solid var(--border);

--- a/cmd/hclexp/web_test.go
+++ b/cmd/hclexp/web_test.go
@@ -232,6 +232,83 @@ func TestWeb_NoFlowBacklinkWhenNotInFlow(t *testing.T) {
 	assert.NotContains(t, body, "Appears in a data flow")
 }
 
+func TestWeb_FlowProblems(t *testing.T) {
+	// An MV that references a virtual column its source doesn't provide, plus a
+	// second MV whose target table isn't declared.
+	schema := &hclload.Schema{Databases: []hclload.DatabaseSpec{{
+		Name: "posthog",
+		Tables: []hclload.TableSpec{
+			{
+				Name:    "src",
+				OrderBy: []string{"id"},
+				Columns: []hclload.ColumnSpec{{Name: "id", Type: "UInt64"}},
+				Engine:  &hclload.EngineSpec{Kind: "merge_tree", Decoded: hclload.EngineMergeTree{}},
+			},
+			{
+				Name:    "dst",
+				OrderBy: []string{"id"},
+				Columns: []hclload.ColumnSpec{{Name: "id", Type: "UInt64"}},
+				Engine:  &hclload.EngineSpec{Kind: "merge_tree", Decoded: hclload.EngineMergeTree{}},
+			},
+		},
+		MaterializedViews: []hclload.MaterializedViewSpec{
+			{
+				Name:    "bad_columns_mv",
+				ToTable: "posthog.dst",
+				Query:   "SELECT id, _bogus FROM posthog.src",
+			},
+			{
+				Name:    "missing_target_mv",
+				ToTable: "posthog.nope",
+				Query:   "SELECT id FROM posthog.src",
+			},
+		},
+	}}}
+	srv, err := newWebServer(schema)
+	require.NoError(t, err)
+
+	// The undefined-column problem is attributed to the MV.
+	colProblems := srv.problems[indexKey("posthog", "bad_columns_mv")]
+	require.NotEmpty(t, colProblems)
+	assert.Equal(t, "undefined column", colProblems[0].Kind)
+
+	// The missing-target problem is attributed to the other MV.
+	tgtProblems := srv.problems[indexKey("posthog", "missing_target_mv")]
+	require.NotEmpty(t, tgtProblems)
+	assert.Equal(t, "missing target", tgtProblems[0].Kind)
+
+	// At least one reconstructed flow is flagged as having problems.
+	flagged := false
+	for _, f := range srv.flows {
+		if f.HasProblems {
+			flagged = true
+		}
+	}
+	assert.True(t, flagged, "a flow touching a broken MV should be flagged")
+
+	code, body := getBody(t, srv, "/flows")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, body, "this flow has problems")
+	assert.Contains(t, body, "undefined column")
+
+	// The MV's own page surfaces the problem too.
+	code, page := getBody(t, srv, "/db/posthog/materialized_view/bad_columns_mv?view=html")
+	require.Equal(t, http.StatusOK, code)
+	assert.Contains(t, page, "Problems")
+	assert.Contains(t, page, "_bogus")
+}
+
+func TestWeb_NoProblemsWhenSchemaIsClean(t *testing.T) {
+	srv, err := newWebServer(kafkaFlowSchema())
+	require.NoError(t, err)
+	for ref, p := range srv.problems {
+		assert.Emptyf(t, p, "unexpected problems for %s", ref)
+	}
+	code, body := getBody(t, srv, "/flows")
+	require.Equal(t, http.StatusOK, code)
+	assert.NotContains(t, body, "this flow has problems")
+}
+
 func TestWeb_NotFound(t *testing.T) {
 	srv, err := newWebServer(webTestSchema())
 	require.NoError(t, err)

--- a/docs/plans/web-flows-view.md
+++ b/docs/plans/web-flows-view.md
@@ -29,6 +29,15 @@ reconstructs and renders these chains.
   participates in a flow.
 - **CSS**: horizontal card chain with labeled arrows.
 
+### Dataflow problems
+
+- Run `hclload.Validate` once in `newWebServer`; index each `ValidationError` by
+  its offending object (`Object`). This surfaces MVs that reference columns their
+  source doesn't provide (`mv_column`), undeclared MV/Distributed targets, etc.
+- `/flows` badges any stage whose object has problems (with the reason) and marks
+  the containing flow; object overview pages gain a "Problems" section.
+- Errors not tied to a specific object become page-level "Schema problems".
+
 ## Files
 
 - `cmd/hclexp/flows.go` — new: flow model, `buildFlows`, `handleFlows`.


### PR DESCRIPTION
Follow-up to #40.

## Summary

Surfaces schema-validation problems in the `hclexp web` UI so a broken dataflow is visible while browsing — most notably **a materialized view that references a column its source table does not provide** (the `mv_column` check), plus undeclared MV/Distributed targets and other dependency gaps.

- Runs `hclload.Validate` once at server start and indexes each `ValidationError` by the object it's attributed to.
- **`/flows`** badges any stage whose object has problems (showing the reason) and marks the containing flow with a "⚠ this flow has problems" banner.
- **Object overview** pages gain a "Problems" section.
- Issues not tied to a specific object render as page-level "Schema problems".

No new analysis logic — it reuses the existing validator, so the web view stays consistent with `hclexp validate`.

## Testing

- `cmd/hclexp/web_test.go` — `TestWeb_FlowProblems` (undefined-column + missing-target attributed to the right MVs, flow flagged, `/flows` and the MV page render the warnings) and `TestWeb_NoProblemsWhenSchemaIsClean`.
- `go test ./cmd/hclexp ./internal/... ./test` pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)