### PR TITLE
Fix invalid CREATE VIEW for views with a column list + SELECT * (#41)

### DIFF
--- a/internal/loader/hcl/sqlgen.go
+++ b/internal/loader/hcl/sqlgen.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	chparser "github.com/orian/clickhouse-sql-parser/parser"
 )
 
 // GeneratedSQL holds the result of GenerateSQL: the safe DDL statements ready
@@ -341,13 +343,66 @@ func dropViewSQL(database, name string) string {
 //
 //	CREATE VIEW [ON CLUSTER c] db.name [(aliases)] [DEFINER = u]
 //	  [SQL SECURITY ...] AS <query> [COMMENT '...']
+//
+// viewQueryProjectsStar reports whether the view's top-level output projection
+// (the outer SELECT and any UNION/EXCEPT branch) includes a star (`*` or a
+// qualified `x.*`). It deliberately does not descend into FROM subqueries or
+// expression subqueries — stars there do not determine the view's own output
+// columns. When the query can't be parsed it returns false, leaving alias
+// emission unchanged.
+func viewQueryProjectsStar(query string) bool {
+	stmts, err := chparser.NewParser(query).ParseStmts()
+	if err != nil || len(stmts) == 0 {
+		return false
+	}
+	head, ok := stmts[0].(*chparser.SelectQuery)
+	if !ok {
+		// Fall back to the outermost SelectQuery the walker reports first.
+		for _, n := range chparser.FindAll(stmts[0], isSelectQuery) {
+			head = n.(*chparser.SelectQuery)
+			break
+		}
+	}
+	for sq := head; sq != nil; sq = nextUnionBranch(sq) {
+		for _, item := range sq.SelectItems {
+			if item == nil || item.Expr == nil {
+				continue
+			}
+			expr := strings.TrimSpace(formatNode(item.Expr))
+			if expr == "*" || strings.HasSuffix(expr, ".*") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// nextUnionBranch returns the next branch in a UNION ALL / UNION DISTINCT /
+// EXCEPT chain, or nil at the end.
+func nextUnionBranch(sq *chparser.SelectQuery) *chparser.SelectQuery {
+	switch {
+	case sq.UnionAll != nil:
+		return sq.UnionAll
+	case sq.UnionDistinct != nil:
+		return sq.UnionDistinct
+	case sq.Except != nil:
+		return sq.Except
+	}
+	return nil
+}
+
 func createViewSQL(database string, v ViewSpec) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "CREATE VIEW %s.%s", database, v.Name)
 	if v.Cluster != nil {
 		fmt.Fprintf(&b, " ON CLUSTER %s", *v.Cluster)
 	}
-	if len(v.ColumnAliases) > 0 {
+	// A view whose output projection includes a star can't carry an explicit
+	// column-alias list — ClickHouse rejects `CREATE VIEW v (a, b) AS SELECT *`
+	// because the column count isn't statically known. The list captured at
+	// introspection is ClickHouse-inferred, so omit it and let ClickHouse
+	// re-infer the columns (issue #41).
+	if len(v.ColumnAliases) > 0 && !viewQueryProjectsStar(v.Query) {
 		fmt.Fprintf(&b, " (%s)", strings.Join(v.ColumnAliases, ", "))
 	}
 	if v.Definer != nil {

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -708,6 +708,71 @@ func TestSQLGen_CreateView_FullForm(t *testing.T) {
 		got.Statements[0])
 }
 
+// A view whose body projects a star cannot carry an explicit column-alias list:
+// ClickHouse rejects `CREATE VIEW v (a, b) AS SELECT * ...` because the column
+// count isn't statically known. The generator must omit the inferred alias list
+// for such views. See issue #41.
+func TestSQLGen_CreateView_OmitsAliasesWhenBodyHasStar(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		keepAliases bool
+	}{
+		{
+			name:        "plain select star",
+			query:       "SELECT * FROM custom_metrics_test",
+			keepAliases: false,
+		},
+		{
+			name:        "select star with REPLACE and UNION ALL (repro)",
+			query:       "SELECT * REPLACE(toFloat64(value) AS value) FROM custom_metrics_test UNION ALL SELECT 'X' AS name, map('instance', hostname()) AS labels, toFloat64(count()) AS value, 'h' AS help, 'gauge' AS type FROM system.part_log",
+			keepAliases: false,
+		},
+		{
+			name:        "qualified star",
+			query:       "SELECT t.* FROM custom_metrics_test AS t",
+			keepAliases: false,
+		},
+		{
+			name:        "star only in a non-first union branch",
+			query:       "SELECT 'a' AS name FROM x UNION ALL SELECT * FROM y",
+			keepAliases: false,
+		},
+		{
+			name:        "static projection keeps aliases",
+			query:       "SELECT team_id, count() AS n FROM events GROUP BY team_id",
+			keepAliases: true,
+		},
+		{
+			name:        "count star is not a projection star",
+			query:       "SELECT count(*) AS n FROM events",
+			keepAliases: true,
+		},
+		{
+			name:        "multiplication is not a projection star",
+			query:       "SELECT a * b AS p FROM events",
+			keepAliases: true,
+		},
+		{
+			name:        "star only inside a from-subquery keeps aliases",
+			query:       "SELECT a AS x FROM (SELECT * FROM t)",
+			keepAliases: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := ViewSpec{Name: "v", Query: tc.query, ColumnAliases: []string{"name", "labels", "value", "help", "type"}}
+			got := createViewSQL("posthog", v)
+			if tc.keepAliases {
+				assert.Contains(t, got, "(name, labels, value, help, type)", "expected alias list to be kept")
+			} else {
+				assert.NotContains(t, got, "(name, labels, value, help, type)", "expected alias list to be omitted")
+				assert.Contains(t, got, tc.query, "query body must still be present")
+			}
+		})
+	}
+}
+
 func TestSQLGen_DropPlainView(t *testing.T) {
 	cs := ChangeSet{Databases: []DatabaseChange{{
 		Database:  "posthog",

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	chparser "github.com/orian/clickhouse-sql-parser/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -771,6 +772,31 @@ func TestSQLGen_CreateView_OmitsAliasesWhenBodyHasStar(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSQLGen_CreateView_StarReplace_Reappliable mirrors what introspect captures
+// for the issue #41 view: ClickHouse stores its own inferred column list in
+// create_table_query, so the ViewSpec carries ColumnAliases alongside a starred
+// body. The regenerated DDL must equal the form ClickHouse actually accepts (no
+// column list) and must itself parse as a valid CREATE VIEW.
+func TestSQLGen_CreateView_StarReplace_Reappliable(t *testing.T) {
+	v := ViewSpec{
+		Name:          "custom_metrics",
+		Query:         "SELECT * REPLACE(toFloat64(value) AS value) FROM posthog.custom_metrics_test",
+		ColumnAliases: []string{"name", "labels", "value", "help", "type"},
+	}
+	got := createViewSQL("posthog", v)
+
+	assert.Equal(t,
+		"CREATE VIEW posthog.custom_metrics AS SELECT * REPLACE(toFloat64(value) AS value) FROM posthog.custom_metrics_test",
+		got)
+
+	// The regenerated statement must be syntactically valid CREATE VIEW.
+	stmts, err := chparser.NewParser(got).ParseStmts()
+	require.NoError(t, err, "regenerated CREATE VIEW must parse")
+	require.Len(t, stmts, 1)
+	_, ok := stmts[0].(*chparser.CreateView)
+	assert.True(t, ok, "regenerated statement must be a CREATE VIEW")
 }
 
 func TestSQLGen_DropPlainView(t *testing.T) {

--- a/test/hcl_introspect_live_test.go
+++ b/test/hcl_introspect_live_test.go
@@ -280,3 +280,50 @@ func TestLive_HCLIntrospect_CommonEngines(t *testing.T) {
 	require.Equal(t, dbName, merge.DBRegex)
 	require.Equal(t, "^shard_", merge.TableRegex)
 }
+
+// TestLive_ViewRoundTrip_StarReplace verifies the issue #41 fix end-to-end. A
+// view created the only way ClickHouse accepts — a starred body with no explicit
+// column list — must, after introspect -> GenerateSQL, regenerate a CREATE VIEW
+// that ClickHouse can apply again. Before the fix the regenerated DDL carried
+// ClickHouse's inferred column list and was rejected with BAD_ARGUMENTS.
+func TestLive_ViewRoundTrip_StarReplace(t *testing.T) {
+	if !*clickhouse {
+		t.SkipNow()
+	}
+	conn := testhelpers.RequireClickHouse(t)
+	dbName := testhelpers.CreateTestDatabase(t, conn)
+	ctx := context.Background()
+
+	require.NoError(t, conn.Exec(ctx, `CREATE TABLE `+dbName+`.custom_metrics_test (
+		name String,
+		labels Map(String, String),
+		value String,
+		help String,
+		type String
+	) ENGINE = MergeTree ORDER BY name`))
+
+	require.NoError(t, conn.Exec(ctx, `CREATE VIEW `+dbName+`.custom_metrics AS
+		SELECT * REPLACE(toFloat64(value) AS value) FROM `+dbName+`.custom_metrics_test`))
+
+	got, err := hclload.Introspect(ctx, conn, dbName, false)
+	require.NoError(t, err)
+	require.Len(t, got.Views, 1)
+	view := got.Views[0]
+	require.Equal(t, "custom_metrics", view.Name)
+
+	// Regenerate just the CREATE VIEW via the same path as `diff -sql`.
+	cs := hclload.ChangeSet{Databases: []hclload.DatabaseChange{{
+		Database: dbName,
+		AddViews: []hclload.ViewSpec{view},
+	}}}
+	gen := hclload.GenerateSQL(cs)
+	require.Len(t, gen.Statements, 1)
+	ddl := gen.Statements[0]
+	require.NotContains(t, ddl, "(name, labels",
+		"the inferred column list must be omitted for a starred view")
+
+	// Drop and re-create from the regenerated DDL: the assertion that the fix
+	// produces an applyable view.
+	require.NoError(t, conn.Exec(ctx, `DROP VIEW `+dbName+`.custom_metrics`))
+	require.NoError(t, conn.Exec(ctx, ddl), "regenerated CREATE VIEW must be applyable: %s", ddl)
+}


### PR DESCRIPTION
Fixes #41.

## Problem

For a view whose body projects a star (commonly `SELECT * REPLACE(...)` with `UNION ALL`), ClickHouse's stored `create_table_query` carries an **inferred** column-name list. `introspect` captures it into `ViewSpec.ColumnAliases`, and `diff -sql` then regenerates:

```sql
CREATE VIEW custom_metrics (name, labels, value, help, type) AS SELECT * REPLACE(...) FROM ... UNION ALL ...
```

which ClickHouse **rejects**:

```
Code: 36. DB::Exception: Number of aliases does not match number of expressions in SELECT list. (BAD_ARGUMENTS)
```

The column count isn't statically known when the projection contains a star, so such a view can never validly carry an explicit column list — the captured list is ClickHouse-inferred, not author-specified. This broke the introspect → `diff -sql` → apply round-trip.

## Fix

`createViewSQL` now omits the alias list when the view's **top-level** output projection (the outer `SELECT` and any `UNION`/`EXCEPT` branch) includes a star, letting ClickHouse re-infer the columns — reproducing how the view was originally created.

Detection parses the query and inspects only the top-level projection, so it does **not** false-positive on:
- stars inside `FROM`/expression subqueries (they don't determine the view's output columns),
- `count(*)`, or
- multiplication (`a * b`).

## Testing

`TestSQLGen_CreateView_OmitsAliasesWhenBodyHasStar` is table-driven over the repro and edge cases (plain `*`, `* REPLACE` + `UNION ALL`, qualified `t.*`, star in a non-first union branch → omit; static projection, `count(*)`, `a * b`, from-subquery star → keep). Full `internal/...`, `cmd/hclexp`, and `test` suites pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)