### PR TITLE
Order generated CREATE statements by the full dependency graph

### DIFF
--- a/docs/plans/2026-06-16-sqlgen-dependency-ordering.md
+++ b/docs/plans/2026-06-16-sqlgen-dependency-ordering.md
@@ -1,0 +1,56 @@
+# Plan: dependency-ordered CREATE generation
+
+## Context
+
+`GenerateSQL` emits CREATE statements in coarse phases (tables → MVs → views →
+dictionaries → raws) and only topologically sorts *within* the table phase, using
+a single edge type: Distributed → remote table (`orderTablesByDependency`). The
+richer dependency graph that `CollectDependencies` already computes
+(`mv_source`, `mv_dest`, `buffer_dest`, `ts_target`, `view_source`) is ignored,
+so several real cases emit in the wrong order and fail to apply:
+
+- **view → view** (a view selecting from another new view) — emitted in slice order.
+- **Buffer → destination table**, **TimeSeries → target table** — same phase, unsorted.
+- **dictionary → source table / dictionary** — emitted by name only.
+- cross-kind (e.g. an MV whose source is a view) — fixed phase order violates the dependency.
+
+## Approach (unified topological order for CREATEs)
+
+Replace the table-only sort + per-kind create loops with one dependency-respecting
+order across **all** added objects (tables, MVs, views, dictionaries):
+
+1. Gather every added object into a node list in the historical stable order
+   (tables, then MVs, then views per change-set order, then dictionaries by name),
+   pairing each with its CREATE DDL (`createTableSQL`/`createMaterializedViewSQL`/
+   `createViewSQL`/`createDictionarySQL`).
+2. Build edges:
+   - reuse `CollectDependencies` over a synthetic schema of the *added* objects
+     (covers tables incl. Distributed/Buffer/TimeSeries, MVs, views), and
+   - derive dictionary→source edges from the typed `DictionarySpec.Source`
+     (`SourceClickHouse.Table` / `.Query`) — `CollectDependencies` doesn't cover
+     dictionaries, and adding them there would change `validate` behaviour.
+   Only edges whose both endpoints are in the add-set constrain ordering.
+3. Topologically sort (Kahn's, **stable** by input index; a cycle falls back to
+   input order) so a dependency is always emitted before its dependent. Raw
+   objects stay last (opaque; unchanged).
+
+Stable ordering means objects without a dependency relationship keep their
+previous relative order, so existing snapshots are unaffected except where a real
+dependency now reorders them.
+
+### Drops
+Left as-is for now: dropped views/MVs/dictionaries arrive as names only (no specs
+to parse), so they can't be topologically sorted. The existing reverse-by-kind
+order (MVs/views/dicts before tables; tables reverse-Distributed) already drops
+dependents before dependencies. Documented as a known limitation.
+
+## Files
+- `internal/loader/hcl/sqlgen.go` — new `orderedCreates`, `createDependencyEdges`,
+  `addedSchema`, `dictionarySourceRefs`, `topoSortNodes`; replace the four create
+  loops in `GenerateSQL`; drop the now-unused `addTablesOf`.
+- `internal/loader/hcl/sqlgen_test.go` — view→view, Buffer→dest, dict→table,
+  dict→dict, cross-kind, and a cycle (no panic); keep existing ordering tests green.
+
+## Verification
+- New + existing `internal/...` ordering tests; `cmd/hclexp`; `test` (snapshots).
+- `go vet`, gofmt. Update snapshots only if a reorder is verified correct.

--- a/internal/loader/hcl/sqlgen.go
+++ b/internal/loader/hcl/sqlgen.go
@@ -62,24 +62,13 @@ func GenerateSQL(cs ChangeSet) GeneratedSQL {
 		}
 	}
 
-	for _, dt := range orderTablesByDependency(gatherTables(cs, addTablesOf), false) {
-		out.Statements = append(out.Statements, createTableSQL(dt.Database, dt.Table))
-	}
-	for _, dc := range cs.Databases {
-		for _, mv := range dc.AddMaterializedViews {
-			out.Statements = append(out.Statements, createMaterializedViewSQL(dc.Database, mv))
-		}
-	}
-	for _, dc := range cs.Databases {
-		for _, v := range dc.AddViews {
-			out.Statements = append(out.Statements, createViewSQL(dc.Database, v))
-		}
-	}
-	for _, dc := range cs.Databases {
-		for _, d := range dictionariesByName(dc.AddDictionaries) {
-			out.Statements = append(out.Statements, createDictionarySQL(dc.Database, d))
-		}
-	}
+	// Tables, materialized views, views, and dictionaries are emitted in one
+	// dependency-respecting order so a referenced object is always created
+	// before the object that references it (Distributed→remote, MV→source/
+	// to_table, view→source view, Buffer→destination, dictionary→source table,
+	// etc.). Objects without a dependency relationship keep their historical
+	// relative order.
+	out.Statements = append(out.Statements, orderedCreates(cs)...)
 	// Raw adds last among creates: a raw object (typically a leaf dictionary
 	// or view) may reference tables created above. Its dependencies cannot be
 	// analysed, so no finer ordering is attempted.
@@ -216,8 +205,180 @@ type dbTable struct {
 	Table    TableSpec
 }
 
-func addTablesOf(dc DatabaseChange) []TableSpec  { return dc.AddTables }
 func dropTablesOf(dc DatabaseChange) []TableSpec { return dc.DropTables }
+
+// createNode is one object to be created, carrying its dependency identity and
+// the DDL that creates it.
+type createNode struct {
+	ref ObjectRef
+	sql string
+}
+
+// orderedCreates returns the CREATE statements for every added table,
+// materialized view, view, and dictionary in a single dependency-respecting
+// order: an object is emitted only after every object it references that is also
+// being created in this change set. Objects without a dependency relationship
+// keep their historical relative order (tables, then materialized views, then
+// views, then dictionaries by name). Raw objects are handled by the caller.
+func orderedCreates(cs ChangeSet) []string {
+	var nodes []createNode
+	add := func(db, name, sql string) {
+		nodes = append(nodes, createNode{ref: ObjectRef{Database: db, Name: name}, sql: sql})
+	}
+	for _, dc := range cs.Databases {
+		for _, t := range dc.AddTables {
+			add(dc.Database, t.Name, createTableSQL(dc.Database, t))
+		}
+	}
+	for _, dc := range cs.Databases {
+		for _, mv := range dc.AddMaterializedViews {
+			add(dc.Database, mv.Name, createMaterializedViewSQL(dc.Database, mv))
+		}
+	}
+	for _, dc := range cs.Databases {
+		for _, v := range dc.AddViews {
+			add(dc.Database, v.Name, createViewSQL(dc.Database, v))
+		}
+	}
+	for _, dc := range cs.Databases {
+		for _, d := range dictionariesByName(dc.AddDictionaries) {
+			add(dc.Database, d.Name, createDictionarySQL(dc.Database, d))
+		}
+	}
+
+	order := topoSortNodes(nodes, createDependencyEdges(cs))
+	out := make([]string, 0, len(order))
+	for _, n := range order {
+		out = append(out, n.sql)
+	}
+	return out
+}
+
+// createDependencyEdges returns {from, to} edges among the added objects: from
+// references to (so to must be created first). It reuses CollectDependencies for
+// tables/materialized views/views and derives dictionary→source edges from the
+// typed dictionary spec, which CollectDependencies does not cover.
+func createDependencyEdges(cs ChangeSet) [][2]ObjectRef {
+	var edges [][2]ObjectRef
+	if deps, err := CollectDependencies(addedSchema(cs)); err == nil {
+		for _, d := range deps {
+			edges = append(edges, [2]ObjectRef{d.From, d.To})
+		}
+	}
+	for _, dc := range cs.Databases {
+		for _, d := range dc.AddDictionaries {
+			from := ObjectRef{Database: dc.Database, Name: d.Name}
+			for _, to := range dictionarySourceRefs(dc.Database, d) {
+				edges = append(edges, [2]ObjectRef{from, to})
+			}
+		}
+	}
+	return edges
+}
+
+// addedSchema projects the change set's added objects into a []DatabaseSpec so
+// the shared dependency collector can analyse them.
+func addedSchema(cs ChangeSet) []DatabaseSpec {
+	dbs := make([]DatabaseSpec, 0, len(cs.Databases))
+	for _, dc := range cs.Databases {
+		dbs = append(dbs, DatabaseSpec{
+			Name:              dc.Database,
+			Tables:            dc.AddTables,
+			MaterializedViews: dc.AddMaterializedViews,
+			Views:             dc.AddViews,
+			Dictionaries:      dc.AddDictionaries,
+		})
+	}
+	return dbs
+}
+
+// dictionarySourceRefs returns the table(s) a dictionary reads from via a
+// ClickHouse source (TABLE or QUERY). Other source kinds (HTTP, file, ...) have
+// no in-schema dependency. An unqualified name defaults to the dictionary's
+// database.
+func dictionarySourceRefs(db string, d DictionarySpec) []ObjectRef {
+	if d.Source == nil {
+		return nil
+	}
+	ch, ok := d.Source.Decoded.(SourceClickHouse)
+	if !ok {
+		return nil
+	}
+	if ch.Table != nil && *ch.Table != "" {
+		ref := ObjectRef{Database: db, Name: *ch.Table}
+		if ch.DB != nil && *ch.DB != "" {
+			ref.Database = *ch.DB
+		}
+		return []ObjectRef{ref}
+	}
+	if ch.Query != nil && *ch.Query != "" {
+		refs, err := extractSourceTables(*ch.Query)
+		if err != nil {
+			return nil
+		}
+		for i := range refs {
+			if refs[i].Database == "" {
+				refs[i].Database = db
+			}
+		}
+		return refs
+	}
+	return nil
+}
+
+// topoSortNodes returns nodes in dependency order: for every edge {from, to}
+// where both endpoints are nodes, to is emitted before from. Independent nodes
+// keep their input order; a dependency cycle is broken by emitting the remaining
+// nodes in input order. Mirrors orderTablesByDependency's Kahn's algorithm,
+// generalised across object kinds.
+func topoSortNodes(nodes []createNode, edges [][2]ObjectRef) []createNode {
+	if len(nodes) < 2 {
+		return nodes
+	}
+	index := make(map[ObjectRef]int, len(nodes))
+	for i, n := range nodes {
+		index[n.ref] = i
+	}
+	indegree := make([]int, len(nodes))
+	dependents := make([][]int, len(nodes))
+	seen := make(map[[2]int]bool)
+	for _, e := range edges {
+		from, okF := index[e[0]]
+		to, okT := index[e[1]]
+		if !okF || !okT || from == to || seen[[2]int{from, to}] {
+			continue
+		}
+		seen[[2]int{from, to}] = true
+		indegree[from]++
+		dependents[to] = append(dependents[to], from)
+	}
+
+	done := make([]bool, len(nodes))
+	order := make([]createNode, 0, len(nodes))
+	for len(order) < len(nodes) {
+		progressed := false
+		for i := range nodes {
+			if done[i] || indegree[i] != 0 {
+				continue
+			}
+			order = append(order, nodes[i])
+			done[i] = true
+			progressed = true
+			for _, d := range dependents[i] {
+				indegree[d]--
+			}
+		}
+		if !progressed { // dependency cycle: emit the rest in input order
+			for i := range nodes {
+				if !done[i] {
+					order = append(order, nodes[i])
+					done[i] = true
+				}
+			}
+		}
+	}
+	return order
+}
 
 // gatherTables flattens one table collection (adds or drops) across every
 // database in the ChangeSet into a single ordered slice.

--- a/internal/loader/hcl/sqlgen_test.go
+++ b/internal/loader/hcl/sqlgen_test.go
@@ -457,6 +457,107 @@ func TestSQLGen_DropOrdersDistributedBeforeRemote(t *testing.T) {
 	assert.Less(t, dist, local, "Distributed table must be dropped before its remote table")
 }
 
+func TestSQLGen_CreateOrder_ViewDependsOnView(t *testing.T) {
+	// v_outer reads from v_inner; both are created in this change set. v_inner
+	// must be emitted first even though it is declared second.
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddViews: []ViewSpec{
+			{Name: "v_outer", Query: "SELECT * FROM posthog.v_inner"},
+			{Name: "v_inner", Query: "SELECT id FROM posthog.base"},
+		},
+	}}})
+	inner := stmtIndex(out.Statements, "CREATE VIEW posthog.v_inner")
+	outer := stmtIndex(out.Statements, "CREATE VIEW posthog.v_outer")
+	require.NotEqual(t, -1, inner)
+	require.NotEqual(t, -1, outer)
+	assert.Less(t, inner, outer, "v_inner must be created before v_outer")
+}
+
+func TestSQLGen_CreateOrder_BufferAfterDestination(t *testing.T) {
+	buf := TableSpec{
+		Name:    "buf",
+		Columns: []ColumnSpec{{Name: "id", Type: "UInt64"}},
+		Engine: &EngineSpec{Kind: "buffer", Decoded: EngineBuffer{
+			Database: "posthog", Table: "dest", NumLayers: 1,
+			MinTime: 1, MaxTime: 10, MinRows: 1, MaxRows: 10, MinBytes: 1, MaxBytes: 10,
+		}},
+	}
+	dest := mkTable("dest", EngineMergeTree{}, ColumnSpec{Name: "id", Type: "UInt64"})
+	dest.OrderBy = []string{"id"}
+	// Buffer declared first; it must still be emitted after its destination.
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog", AddTables: []TableSpec{buf, dest},
+	}}})
+	d := stmtIndex(out.Statements, "CREATE TABLE posthog.dest")
+	b := stmtIndex(out.Statements, "CREATE TABLE posthog.buf")
+	require.NotEqual(t, -1, d)
+	require.NotEqual(t, -1, b)
+	assert.Less(t, d, b, "destination table must be created before the Buffer")
+}
+
+func TestSQLGen_CreateOrder_DictionaryAfterSourceTable(t *testing.T) {
+	dict := mkDict("d", SourceClickHouse{Table: ptr("src")}, LayoutFlat{},
+		DictionaryAttribute{Name: "v", Type: "String"})
+	src := mkTable("src", EngineMergeTree{}, ColumnSpec{Name: "k", Type: "UInt64"})
+	src.OrderBy = []string{"k"}
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog", AddTables: []TableSpec{src}, AddDictionaries: []DictionarySpec{dict},
+	}}})
+	s := stmtIndex(out.Statements, "posthog.src")
+	d := stmtIndex(out.Statements, "DICTIONARY posthog.d")
+	require.NotEqual(t, -1, s)
+	require.NotEqual(t, -1, d)
+	assert.Less(t, s, d, "source table must be created before the dictionary")
+}
+
+func TestSQLGen_CreateOrder_DictionaryDependsOnDictionary(t *testing.T) {
+	// Dictionary 'a' sources from dictionary 'b'. By name they sort a, b; the
+	// dependency must still emit b before a.
+	a := mkDict("a", SourceClickHouse{Table: ptr("b")}, LayoutFlat{}, DictionaryAttribute{Name: "v", Type: "String"})
+	b := mkDict("b", SourceClickHouse{Table: ptr("base")}, LayoutFlat{}, DictionaryAttribute{Name: "v", Type: "String"})
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog", AddDictionaries: []DictionarySpec{a, b},
+	}}})
+	ib := stmtIndex(out.Statements, "DICTIONARY posthog.b")
+	ia := stmtIndex(out.Statements, "DICTIONARY posthog.a")
+	require.NotEqual(t, -1, ib)
+	require.NotEqual(t, -1, ia)
+	assert.Less(t, ib, ia, "dict b must be created before dict a which sources from it")
+}
+
+func TestSQLGen_CreateOrder_CrossKind_MVSourceIsView(t *testing.T) {
+	// A materialized view reads from a plain view; the view must be created
+	// before the MV even though MVs are emitted before views by default.
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddMaterializedViews: []MaterializedViewSpec{
+			{Name: "mv", ToTable: "posthog.dest", Query: "SELECT id FROM posthog.src_view"},
+		},
+		AddViews: []ViewSpec{
+			{Name: "src_view", Query: "SELECT id FROM posthog.base"},
+		},
+	}}})
+	v := stmtIndex(out.Statements, "CREATE VIEW posthog.src_view")
+	mv := stmtIndex(out.Statements, "posthog.mv")
+	require.NotEqual(t, -1, v)
+	require.NotEqual(t, -1, mv)
+	assert.Less(t, v, mv, "the source view must be created before the materialized view that reads it")
+}
+
+func TestSQLGen_CreateOrder_CycleDoesNotHang(t *testing.T) {
+	// Two views reference each other. The generator must not hang or drop a
+	// statement; it breaks the cycle by falling back to input order.
+	out := GenerateSQL(ChangeSet{Databases: []DatabaseChange{{
+		Database: "posthog",
+		AddViews: []ViewSpec{
+			{Name: "v1", Query: "SELECT * FROM posthog.v2"},
+			{Name: "v2", Query: "SELECT * FROM posthog.v1"},
+		},
+	}}})
+	assert.Len(t, out.Statements, 2)
+}
+
 func TestSQLGen_OrderingAcrossDatabases(t *testing.T) {
 	// A Distributed table can forward to a table in another database; the
 	// ordering must hold across the whole ChangeSet, not just per-database.


### PR DESCRIPTION
## Problem

`GenerateSQL` emitted CREATEs in coarse phases (tables → MVs → views → dictionaries) and only topologically sorted *within* the table phase, using a single edge type: **Distributed → remote table**. The richer graph `CollectDependencies` already computes (`mv_source`, `mv_dest`, `buffer_dest`, `ts_target`, `view_source`) was ignored, so valid schemas could emit in an order ClickHouse can't apply:

- a **view selecting from another new view** (emitted in slice order),
- a **Buffer table before its destination**, **TimeSeries before its target**,
- a **dictionary before its source table / source dictionary**,
- **cross-kind** cases (an MV whose source is a view).

## Change

Tables, materialized views, views, and dictionaries are now emitted in **one dependency-respecting topological order**:

- edges come from `CollectDependencies` (tables incl. Distributed/Buffer/TimeSeries, MVs, views), plus dictionary→source edges derived from the typed `DictionarySpec.Source` (`CollectDependencies` doesn't cover dictionaries, and adding them there would change `validate` behaviour);
- the sort is **stable** (Kahn's, ties broken by input index), so objects without a dependency relationship keep their previous relative order — existing output and snapshots are unaffected except where a real dependency now reorders them;
- **cycles** fall back to input order (no hang/drop);
- raw objects remain last (opaque).

**Drops are unchanged** — dropped views/MVs/dictionaries arrive as names only, so they can't be reparsed for ordering; the existing reverse-by-kind order already drops dependents before dependencies. (Noted in the plan doc as a known limitation.)

## Testing

New table-driven ordering tests in `sqlgen_test.go`: view→view, Buffer→destination, dictionary→source table, dictionary→dictionary, cross-kind (MV source is a view), and a cycle (no hang, all statements still emitted). Existing Distributed-ordering and cross-database tests stay green. Full `internal/...`, `cmd/hclexp`, and `test` (snapshot) suites pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)